### PR TITLE
[iOS] Embed iOS provisioning profiles

### DIFF
--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -36,7 +36,7 @@ enum Generator {
     /// @note this version is written into the `XCHAMMER_DEPS_HASH` build setting
     /// the version can be extracted with a simple search: i.e.
     /// grep -m 1 XCHAMMER_DEPS_HASH $PROJ | sed 's,.*version:\(.*\):.*,\1,g'
-    public static let BinaryVersion = "0.1.3"
+    public static let BinaryVersion = "0.1.4"
 
     /// Used to store the `depsHash` into the project
     static let DepsHashSettingName = "XCHAMMER_DEPS_HASH"

--- a/XCHammerAssets/codesigner.sh
+++ b/XCHammerAssets/codesigner.sh
@@ -29,6 +29,8 @@ fi
 
 echo "Signing.."
 
+ditto $PROFILE $WORK_DIR/embedded.mobileprovision
+
 ls $WORK_DIR/Frameworks/* >& /dev/null && /usr/bin/codesign --force --sign $VERIFIED_ID --entitlements $ENTITLEMENTS $WORK_DIR/Frameworks/*
 
 /usr/bin/codesign --force --sign $VERIFIED_ID --entitlements $ENTITLEMENTS $WORK_DIR


### PR DESCRIPTION
Running on device requires a embedded.mobileprovision

This is iOS specific but it should be fine given XCHammer's overall
use cases.

Fixes #9 