### PR TITLE
Remove Xcode's codesign check for Bazel targets

### DIFF
--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -36,7 +36,7 @@ enum Generator {
     /// @note this version is written into the `XCHAMMER_DEPS_HASH` build setting
     /// the version can be extracted with a simple search: i.e.
     /// grep -m 1 XCHAMMER_DEPS_HASH $PROJ | sed 's,.*version:\(.*\):.*,\1,g'
-    public static let BinaryVersion = "0.1.6"
+    public static let BinaryVersion = "0.1.7"
 
     /// Used to store the `depsHash` into the project
     static let DepsHashSettingName = "XCHAMMER_DEPS_HASH"

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -963,13 +963,16 @@ public class XcodeTarget: Hashable, Equatable {
                     with: buildInvocation)
         }
 
+        // Minimal settings for this build
+        var settings = XCBuildSettings()
+        settings.codeSigningRequired <>= First("NO")
         let bazelScript = XCGBuildScript(path: nil, script: getScriptContent(),
                 name: "Bazel build")
         return XCGTarget(
             name: xcTargetName + "-Bazel",
             type: PBXProductType(rawValue: productType.rawValue)!,
             platform: Platform(rawValue: platform)!,
-            settings: makeXcodeGenSettings(from: XCBuildSettings()),
+            settings: makeXcodeGenSettings(from: settings),
             configFiles: [String: String](),
             sources: [],
             dependencies: [],


### PR DESCRIPTION
We codesign within Bazel.