### PR TITLE
CC test case, usage, and fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ build-release: SWIFTBFLAGS = --configuration $(CONFIG) -Xswiftc -static-stdlib
 build-release: build-impl
 
 build-impl:
-	swift build $(SWIFTBFLAGS)
+	swift build $(SWIFTBFLAGS) | tee .build/last_build.log
 	# Install bundle resources
 	ditto $(ASPECTDIR) .build/$(CONFIG)/$(ASPECTDIR)
 	ditto $(ASSETDIR) .build/$(CONFIG)/$(ASSETDIR)

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tadija/AEXML.git",
         "state": {
           "branch": null,
-          "revision": "09f27784d9e328670ef0a181c832cce497117131",
-          "version": "4.2.2"
+          "revision": "6eea665515d079c338690147082a8084a36484b0",
+          "version": "4.3.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/Carthage/Commandant.git",
         "state": {
           "branch": null,
-          "revision": "c281992c31c3f41c48b5036c5a38185eaec32626",
-          "version": "0.12.0"
+          "revision": "7f29606ec3a2054a601f0e72f562a104dbc1a11a",
+          "version": "0.13.0"
         }
       },
       {
@@ -38,12 +38,30 @@
         }
       },
       {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "state": {
+          "branch": null,
+          "revision": "8023e3980d91b470ad073d6da843b73f2eeb1844",
+          "version": "7.1.2"
+        }
+      },
+      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
           "branch": null,
-          "revision": "404d60fd725d1ba7dbf55cb95a3046285a066169",
-          "version": "0.9.0"
+          "revision": "fa81fa9e3a9f59645159c4ea45c0c46ee6558f71",
+          "version": "0.9.1"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/Quick/Quick.git",
+        "state": {
+          "branch": null,
+          "revision": "3e3023569c8d4c4a0d000f58db765df53041117f",
+          "version": "1.3.0"
         }
       },
       {
@@ -51,8 +69,8 @@
         "repositoryURL": "https://github.com/onevcat/Rainbow.git",
         "state": {
           "branch": null,
-          "revision": "f69961599ad524251d677fbec9e4bac57385d6fc",
-          "version": "3.1.1"
+          "revision": "797a68d0a642609424b08f11eb56974a54d5f6e2",
+          "version": "3.1.4"
         }
       },
       {
@@ -75,11 +93,11 @@
       },
       {
         "package": "Spectre",
-        "repositoryURL": "https://github.com/kylef/Spectre.git",
+        "repositoryURL": "https://github.com/yonaskolb/Spectre.git",
         "state": {
           "branch": null,
-          "revision": "e34d5687e1e9d865e3527dd58bc2f7464ef6d936",
-          "version": "0.8.0"
+          "revision": "2b520ec417fc515c70e7093ae3ee321c3237e215",
+          "version": "0.8.1"
         }
       },
       {
@@ -96,7 +114,7 @@
         "repositoryURL": "https://github.com/yonaskolb/XcodeGen.git",
         "state": {
           "branch": null,
-          "revision": "e1b9bc29f7c4538757fc9481d73948b1ccd76ad6",
+          "revision": "2ebfc9a9dc23ce029b81da8408d8991a9fc77a58",
           "version": null
         }
       },
@@ -104,9 +122,9 @@
         "package": "xcproj",
         "repositoryURL": "https://github.com/xcodeswift/xcproj.git",
         "state": {
-          "branch": "8fb1284",
-          "revision": "8fb12846996875c2dacbe8845be141c7c5e56d28",
-          "version": null
+          "branch": null,
+          "revision": "e787c68092e28fe2b34205fc1b62de431922c243",
+          "version": "4.3.0"
         }
       },
       {
@@ -114,8 +132,8 @@
         "repositoryURL": "https://github.com/jpsim/Yams.git",
         "state": {
           "branch": null,
-          "revision": "95f45caf07472ec78223ebada45255086a85b01a",
-          "version": "0.5.0"
+          "revision": "6652aa7b793d3c8a075db0614acb575fcaecf457",
+          "version": "0.7.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,13 +12,20 @@ let package = Package(
           targets: ["XCHammer"]),
     ],
     dependencies: [
-        // xchammer branches
-        .package(url: "https://github.com/yonaskolb/XcodeGen.git", .revision("e1b9bc29f7c4538757fc9481d73948b1ccd76ad6")),
-        .package(url: "https://github.com/pinterest/Tulsi.git", .revision("6ebee5d7d8b98b834515012f01c455fb54c2e78a")),
-        // other deps
-        .package(url: "https://github.com/jpsim/Yams.git", from: "0.3.6"),
-        .package(url: "https://github.com/JohnSundell/ShellOut.git", from: "2.0.0"),
-        .package(url: "https://github.com/Carthage/Commandant.git", from: "0.12.0"),
+        .package(url: "https://github.com/yonaskolb/XcodeGen.git",
+            .revision("2ebfc9a9dc23ce029b81da8408d8991a9fc77a58")),
+
+        // Changes reside in the xchammer branch
+        .package(url: "https://github.com/pinterest/Tulsi.git",
+            .revision("6ebee5d7d8b98b834515012f01c455fb54c2e78a")),
+
+        // Note: XcodeGen now transitively depends on this one, so the versions
+        // must match!
+        .package(url: "https://github.com/JohnSundell/ShellOut.git", from:
+            "2.1.0"),
+
+        .package(url: "https://github.com/Carthage/Commandant.git", from:
+            "0.12.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -418,7 +418,7 @@ enum Generator {
         let clearSourceMapTarget = makeClearSourceMapTarget(labels: targetsToBuild,
                 genOptions: genOptions)
 
-        let options = ProjectSpec.Options(
+        let options = XCGOptions(
                 carthageBuildPath: nil,
                 createIntermediateGroups: true,
                 indentWidth: 4,

--- a/Sources/XCHammer/ProjectWriter.swift
+++ b/Sources/XCHammer/ProjectWriter.swift
@@ -42,8 +42,8 @@ enum ProjectWriter {
         }
 
         // generate the project from the spec
-        let generator = ProjectGenerator(spec: xcodeGenSpec)
-        let xcproj = try generator.generateProject()
+        let generator = ProjectGenerator(project: xcodeGenSpec)
+        let xcproj = try generator.generateXcodeProject()
         try xcproj.write(path: xcodeProjPath)
 
 

--- a/Sources/XCHammer/XcodeGenProjectSpecExtensions.swift
+++ b/Sources/XCHammer/XcodeGenProjectSpecExtensions.swift
@@ -15,13 +15,13 @@ import ProjectSpec
 /// We should fix this in XcodeGen, so we can use ProjectSpec.__TYPE__
 /// TODO: (jerry) Fix this when realted PR's land
 
-public typealias XCGProject = ProjectSpec
+public typealias XCGProject = ProjectSpec.Project
 public typealias XCGTargetSource = TargetSource
 public typealias XCGSettings = Settings
 public typealias XCGDependency = Dependency
 public typealias XCGTarget = Target
 public typealias XCGBuildScript = BuildScript
-public typealias XCGOptions = ProjectSpec.Options
+public typealias XCGOptions = SpecOptions
 public typealias XCGLegacyTarget = LegacyTarget
 
 extension XCGDependency : Hashable {

--- a/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/updateXcodeProj.sh
+++ b/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/updateXcodeProj.sh
@@ -1,7 +1,7 @@
 # This file is governed by XCHammer
 set -e
 
-if [[ "0.1.6" != "/Users/jerry/Projects/xchammer-github/.build/debug/XCHammer --version" ]]; then 
+if [[ "0.1.7" != "/Users/jerry/Projects/xchammer-github/.build/debug/XCHammer --version" ]]; then 
     echo "warning: XCHammer version mismatch"
 fi
 

--- a/sample/UrlGet/UrlGet.xcodeproj/project.pbxproj
+++ b/sample/UrlGet/UrlGet.xcodeproj/project.pbxproj
@@ -8,1081 +8,442 @@
 
 /* Begin PBXBuildFile section */
 		BF_101090596531 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_319111102880-1" /* NSBundle+Stripe_AppName.m */; };
-		BF_101198465298 = {isa = PBXBuildFile; fileRef = FR_808039309519 /* STPSourceRedirect+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_101644373501 = {isa = PBXBuildFile; fileRef = FR_118015691316 /* STPFormTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_101852689553 /* STPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_729837640388 /* STPAPIClient.m */; };
-		BF_102365075497 = {isa = PBXBuildFile; fileRef = FR_564276906433 /* STPPaymentCardTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_103019698139 /* stp_card_applepay@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_866423752002 /* stp_card_applepay@3x.png */; };
-		BF_103099083488 = {isa = PBXBuildFile; fileRef = FR_303363389556 /* NSError+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_103512291321 = {isa = PBXBuildFile; fileRef = FR_986136575822 /* STPInternalAPIResponseDecodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_103647375732 /* STPEphemeralKey.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_118429332705 /* STPEphemeralKey.m */; };
-		BF_103743542999 = {isa = PBXBuildFile; fileRef = FR_650044337253 /* STPAddressViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_105633822527 = {isa = PBXBuildFile; fileRef = FR_159129633610 /* STPCardValidationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_105768087992 = {isa = PBXBuildFile; fileRef = FR_183987345262 /* UpdateXcodeProject */; };
 		BF_106143354257 /* NSDecimalNumber+Stripe_Currency.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_485300186977 /* NSDecimalNumber+Stripe_Currency.m */; };
-		BF_106561429697 = {isa = PBXBuildFile; fileRef = FR_210015125307 /* STPPostalCodeValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_106629285128 = {isa = PBXBuildFile; fileRef = FR_616663993966 /* STPPaymentContext+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_108622356685 = {isa = PBXBuildFile; fileRef = FR_283825756115 /* STPSourceSEPADebitDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_108952959052 = {isa = PBXBuildFile; fileRef = "FR_114615500587-1" /* PKPayment+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_109020910743 = {isa = PBXBuildFile; fileRef = FR_920174354034 /* STPFormTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_110448265214 = {isa = PBXBuildFile; fileRef = FR_168416049633 /* PKPayment+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_110846874273 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_417020094137 /* STPURLCallbackHandler.m */; };
-		BF_111622152037 = {isa = PBXBuildFile; fileRef = FR_727895182634 /* STPCoreViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_113208380786 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_490229470460-1" /* NSURLComponents+Stripe.m */; };
-		BF_113700983294 = {isa = PBXBuildFile; fileRef = "FR_611231413868-1" /* PINDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_113702447379 = {isa = PBXBuildFile; fileRef = FR_713747347031 /* UINavigationBar+Stripe_Theme.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_115260107093 = {isa = PBXBuildFile; fileRef = FR_523050043014 /* PINOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_115695607156 = {isa = PBXBuildFile; fileRef = "FR_856763993418-1" /* NSCharacterSet+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_115987268580 = {isa = PBXBuildFile; fileRef = FR_398400160687 /* STPInternalAPIResponseDecodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_116171698724 /* STPPaymentCardTextFieldViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_352992722793 /* STPPaymentCardTextFieldViewModel.m */; };
-		BF_116260859004 = {isa = PBXBuildFile; fileRef = FR_851062106152 /* UIToolbar+Stripe_InputAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_117078049933 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_451065136063 /* UIViewController+Stripe_NavigationItemProxy.m */; };
 		BF_117209957966 /* stp_card_form_front.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_597218262530 /* stp_card_form_front.png */; };
 		BF_118399563058 /* STPPaymentMethodTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_318471428702 /* STPPaymentMethodTuple.m */; };
 		BF_119119096972 /* stp_card_visa_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_535609714789 /* stp_card_visa_template.png */; };
-		BF_119525916253 = {isa = PBXBuildFile; fileRef = FR_600589277732 /* STPPaymentMethodsViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_119958508776 = {isa = PBXBuildFile; fileRef = FR_606866437089 /* STPPaymentMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_120539862880 /* stp_card_error_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_684957154701 /* stp_card_error_amex@2x.png */; };
-		BF_121213897536 = {isa = PBXBuildFile; fileRef = FR_203274481819 /* STPWeakStrongMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_121572758316 = {isa = PBXBuildFile; fileRef = FR_479483572541 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_122454680258 /* NSString+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_383186939534-1" /* NSString+Stripe.m */; };
-		BF_123591214361 = {isa = PBXBuildFile; fileRef = FR_875549008649 /* ios-app-bin.a */; };
+		BF_123619201349 /* Some.cc in Sources */ = {isa = PBXBuildFile; fileRef = FR_282022996649 /* Some.cc */; };
 		BF_123692580182 /* stp_card_visa_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_161686194489 /* stp_card_visa_template@3x.png */; };
-		BF_123989713154 = {isa = PBXBuildFile; fileRef = FR_905090839392 /* STPCoreViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_124234759863 /* STPFile.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_227675484416 /* STPFile.m */; };
 		BF_125879088495 /* stp_card_applepay@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_458974510861 /* stp_card_applepay@2x.png */; };
-		BF_128163407739 = {isa = PBXBuildFile; fileRef = FR_778052571267 /* STPBankAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_129573605972 /* STPPaymentConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_454291026560 /* STPPaymentConfiguration.m */; };
-		BF_129594906938 = {isa = PBXBuildFile; fileRef = "FR_180708382140-1" /* STPCustomer+SourceTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_129899263403 /* stp_card_jcb_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_584192437806 /* stp_card_jcb_template.png */; };
 		BF_131628923074 /* stp_card_unionpay_template_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_438548292773 /* stp_card_unionpay_template_zh@3x.png */; };
-		BF_131838062268 = {isa = PBXBuildFile; fileRef = FR_388629378203 /* STPCustomerContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_134489940213 = {isa = PBXBuildFile; fileRef = FR_426141564195 /* STPPaymentMethodTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_134756017029 = {isa = PBXBuildFile; fileRef = "FR_417020094137-1" /* STPURLCallbackHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_135181373888 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_549793573278 /* Localizable.strings */; };
 		BF_135378480492 /* stp_card_unknown@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_313827850627 /* stp_card_unknown@3x.png */; };
 		BF_135530049807 /* stp_card_form_front@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_767601582739 /* stp_card_form_front@3x.png */; };
-		BF_135869600287 = {isa = PBXBuildFile; fileRef = FR_326473329617 /* STPSourceOwner.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_136123455694 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_863295555018 /* STPDispatchFunctions.m */; };
 		BF_138461404074 /* stp_card_amex_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_766928612639 /* stp_card_amex_template@3x.png */; };
-		BF_141031389617 = {isa = PBXBuildFile; fileRef = FR_674978004924 /* PINCacheMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_141061591332 = {isa = PBXBuildFile; fileRef = FR_460374501185 /* STPRedirectContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_141539721156 = {isa = PBXBuildFile; fileRef = FR_897080895086 /* STPCustomer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_143072106178 = {isa = PBXBuildFile; fileRef = FR_555038450084 /* STPCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_144207460583 /* stp_card_jcb_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_348062610832 /* stp_card_jcb_template@3x.png */; };
-		BF_145227339410 = {isa = PBXBuildFile; fileRef = FR_680138288521 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_147040944679 = {isa = PBXBuildFile; fileRef = FR_584380253982 /* PINDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_148443531231 = {isa = PBXBuildFile; fileRef = FR_573665251373 /* STPImageLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_149555850306 /* stp_card_discover_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_732161840902 /* stp_card_discover_template.png */; };
 		BF_150885512820 /* stp_card_cvc.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_275604636587 /* stp_card_cvc.png */; };
-		BF_151447233881 = {isa = PBXBuildFile; fileRef = FR_737799052203 /* STPAddCardViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_151721930308 /* STPTelemetryClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_836284080868 /* STPTelemetryClient.m */; };
 		BF_151757672103 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_549793573278 /* Localizable.strings */; };
-		BF_152213643841 = {isa = PBXBuildFile; fileRef = FR_319111102880 /* NSBundle+Stripe_AppName.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_152533994136 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_784978928035 /* UIViewController+Stripe_KeyboardAvoiding.m */; };
-		BF_154122029020 = {isa = PBXBuildFile; fileRef = FR_392500181869 /* STPBundleLocator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_154555917311 = {isa = PBXBuildFile; fileRef = FR_688345473974 /* STPBackendAPIAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_154630146271 = {isa = PBXBuildFile; fileRef = FR_560961278475 /* STPPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_154672173585 /* stp_card_diners@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_499280427849 /* stp_card_diners@2x.png */; };
-		BF_156642719422 = {isa = PBXBuildFile; fileRef = FR_284380484049 /* STPSectionHeaderView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_157414689128 /* STPSourceOwner.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_761061955139 /* STPSourceOwner.m */; };
-		BF_157757955333 = {isa = PBXBuildFile; fileRef = FR_823402288931 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_158126484869 = {isa = PBXBuildFile; fileRef = "FR_344823093939-1" /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_158572982416 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_447194245190 /* Tests2.m */; };
-		BF_158669846489 = {isa = PBXBuildFile; fileRef = FR_537648693821 /* STPSourceCardDetails+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_160337935150 = {isa = PBXBuildFile; fileRef = FR_237398221790 /* STPBankAccountParams+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_160678947043 = {isa = PBXBuildFile; fileRef = FR_891431900870 /* STPDispatchFunctions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_161201171252 = {isa = PBXBuildFile; fileRef = FR_642952555060 /* PINCacheObjectSubscripting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_161320671413 = {isa = PBXBuildFile; fileRef = FR_283825756115 /* STPSourceSEPADebitDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_161334189326 /* STPEmailAddressValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_820602908988 /* STPEmailAddressValidator.m */; };
-		BF_163894138192 = {isa = PBXBuildFile; fileRef = FR_549563930037 /* STPTheme.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_163946310940 = {isa = PBXBuildFile; fileRef = FR_736834917512 /* PINOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_164244000470 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_353990188355 /* GoogleAppIndexing.framework */; };
 		BF_164275633159 /* stp_card_amex_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_766928612639 /* stp_card_amex_template@3x.png */; };
-		BF_166878142038 = {isa = PBXBuildFile; fileRef = FR_388629378203 /* STPCustomerContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_167823982318 /* stp_card_diners@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_786618818576 /* stp_card_diners@3x.png */; };
 		BF_169258158277 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_171962769898-1" /* UIImage+Stripe.m */; };
 		BF_170318754028 /* STPLegalEntityParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_863581397541 /* STPLegalEntityParams.m */; };
 		BF_170396008124 /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_616218057689 /* stp_card_visa@3x.png */; };
 		BF_172554538252 /* NSMutableURLRequest+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_829657687628 /* NSMutableURLRequest+Stripe.m */; };
-		BF_173308572548 = {isa = PBXBuildFile; fileRef = FR_328574352852 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_174250750566 = {isa = PBXBuildFile; fileRef = FR_736834917512 /* PINOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_175039259109 = {isa = PBXBuildFile; fileRef = FR_473219612446 /* STPCard+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_175144406060 = {isa = PBXBuildFile; fileRef = FR_813949290948 /* STPCoreScrollViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_175455447258 = {isa = PBXBuildFile; fileRef = FR_887633340860 /* STPCardBrand.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_176492720158 /* libios-app-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_610748361952 /* libios-app-bin.a */; };
-		BF_176669940994 = {isa = PBXBuildFile; fileRef = FR_525936809580 /* PINCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_176827721742 = {isa = PBXBuildFile; fileRef = FR_744357543627 /* PINCacheObjectSubscripting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_177223813351 = {isa = PBXBuildFile; fileRef = FR_523050043014 /* PINOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_177540651906 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_426141564192 /* STPPaymentMethodTableViewCell.m */; };
-		BF_178059853786 = {isa = PBXBuildFile; fileRef = FR_911085306196 /* STPConnectAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_178316544941 = {isa = PBXBuildFile; fileRef = FR_233450545627 /* STPRedirectContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_178336098514 = {isa = PBXBuildFile; fileRef = FR_161131115028 /* NSDictionary+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_178424035570 = {isa = PBXBuildFile; fileRef = FR_776001027518 /* PINOperation-ios-9.0.a */; };
-		BF_180856998657 = {isa = PBXBuildFile; fileRef = FR_655732831542 /* STPCard+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_182065928914 = {isa = PBXBuildFile; fileRef = FR_311576797096 /* STPMultipartFormDataPart.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_182151248631 /* stp_card_unionpay_template_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_607555391478 /* stp_card_unionpay_template_en.png */; };
-		BF_184177538226 = {isa = PBXBuildFile; fileRef = FR_113418609357 /* STPLegalEntityParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_184627840073 /* libPINOperation-ios-11.3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_578888125127 /* libPINOperation-ios-11.3.a */; };
 		BF_187128133490 /* stp_card_visa_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_535609714789 /* stp_card_visa_template.png */; };
-		BF_188980102191 = {isa = PBXBuildFile; fileRef = FR_686972168627 /* PINCache-Core-ios-9.0.a */; };
-		BF_190057763113 = {isa = PBXBuildFile; fileRef = FR_303088832029 /* STPPaymentMethodsInternalViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_191206565194 /* stp_card_amex_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_766919050802 /* stp_card_amex_template@2x.png */; };
-		BF_192584525390 = {isa = PBXBuildFile; fileRef = "FR_451065136063-1" /* UIViewController+Stripe_NavigationItemProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_193532044368 = {isa = PBXBuildFile; fileRef = FR_761930139089 /* Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_193918489552 = {isa = PBXBuildFile; fileRef = FR_754231351934 /* STPSourceCardDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_194186227016 = {isa = PBXBuildFile; fileRef = "FR_225093974291-1" /* STPAspects.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_194808752686 /* UIToolbar+Stripe_InputAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_851062106151 /* UIToolbar+Stripe_InputAccessory.m */; };
 		BF_195019623962 /* stp_card_unionpay_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_127100525052 /* stp_card_unionpay_zh@3x.png */; };
 		BF_196243295751 /* StripeError.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_276366160308 /* StripeError.m */; };
-		BF_197159497044 = {isa = PBXBuildFile; fileRef = FR_518632870935 /* STPCardValidationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_197519452180 /* UIToolbar+Stripe_InputAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_851062106151 /* UIToolbar+Stripe_InputAccessory.m */; };
 		BF_198135154768 /* stp_shipping_form@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_587518550104 /* stp_shipping_form@3x.png */; };
-		BF_198487358803 = {isa = PBXBuildFile; fileRef = FR_563291007487 /* STPCoreViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_200612128808 = {isa = PBXBuildFile; fileRef = "FR_670697261324-1" /* STPBINRange.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_202421252734 /* stp_card_form_back@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_471192665951 /* stp_card_form_back@2x.png */; };
 		BF_202713209090 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_742895067730 /* libPINOperation-ios-9.0.a */; };
-		BF_203862080934 = {isa = PBXBuildFile; fileRef = FR_669064331373 /* STPShippingMethodsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_204553293200 /* STPSourceSEPADebitDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_639248881296 /* STPSourceSEPADebitDetails.m */; };
-		BF_205114222295 = {isa = PBXBuildFile; fileRef = FR_376986173380 /* STPPaymentCardTextField+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_205442017048 /* StripeError.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_276366160308 /* StripeError.m */; };
-		BF_206649981149 = {isa = PBXBuildFile; fileRef = FR_746622612454 /* UINavigationController+Stripe_Completion.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_207493300672 = {isa = PBXBuildFile; fileRef = FR_397431763487 /* STPValidatedTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_208370307566 /* stp_card_unionpay_template_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_607555391478 /* stp_card_unionpay_template_en.png */; };
-		BF_209189513202 = {isa = PBXBuildFile; fileRef = FR_319645862806 /* STPSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_209980421254 = {isa = PBXBuildFile; fileRef = FR_841504889253 /* AppDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_210290178530 /* stp_card_unionpay_template_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_436922295096 /* stp_card_unionpay_template_en@3x.png */; };
-		BF_211151206352 = {isa = PBXBuildFile; fileRef = FR_296053825144 /* STPPaymentActivityIndicatorView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_211705597766 /* stp_icon_add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_644827855298 /* stp_icon_add@3x.png */; };
-		BF_212277229056 = {isa = PBXBuildFile; fileRef = FR_380861112100 /* STPFormEncodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_212485280648 /* stp_card_error_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_684957151634 /* stp_card_error_amex@3x.png */; };
 		BF_214005761075 /* STPCardIOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_803655950633-1" /* STPCardIOProxy.m */; };
 		BF_214401364839 /* stp_card_error_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_728079807747 /* stp_card_error_amex.png */; };
 		BF_214591006498 /* STPSourceCardDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_689735932342 /* STPSourceCardDetails.m */; };
-		BF_215627057382 = {isa = PBXBuildFile; fileRef = FR_657046115910 /* STPEmailAddressValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_216392517782 = {isa = PBXBuildFile; fileRef = FR_828784758374 /* STPSourcePoller.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_217006239142 /* STPShippingMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_190239098214 /* STPShippingMethodsViewController.m */; };
-		BF_217744269071 = {isa = PBXBuildFile; fileRef = "FR_573822806939-1" /* STPColorUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_218428149371 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_104204687231 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
 		BF_218677791532 /* stp_card_discover_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_732161840902 /* stp_card_discover_template.png */; };
-		BF_220366835215 = {isa = PBXBuildFile; fileRef = FR_118440206517 /* PINOperationTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_220528984491 = {isa = PBXBuildFile; fileRef = FR_326473329617 /* STPSourceOwner.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_220854336514 = {isa = PBXBuildFile; fileRef = "FR_433875149495-1" /* STPBundleLocator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_220972781253 = {isa = PBXBuildFile; fileRef = FR_820602908989 /* STPEmailAddressValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_221014046589 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_149668560898 /* STPPaymentResult.m */; };
 		BF_221385638621 /* stp_card_cvc_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_916856507218 /* stp_card_cvc_amex@3x.png */; };
 		BF_223339887562 /* STPEphemeralKeyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_170908667679 /* STPEphemeralKeyManager.m */; };
 		BF_224019183693 /* stp_test_upload_image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = FR_791168379253 /* stp_test_upload_image.jpeg */; };
 		BF_225946189938 /* stp_card_error@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_550565498786 /* stp_card_error@3x.png */; };
-		BF_227117438007 = {isa = PBXBuildFile; fileRef = FR_544048132697 /* STPBlocks.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_227967645512 = {isa = PBXBuildFile; fileRef = FR_832542114231 /* PINOperation-ios-11.3.a */; };
-		BF_228517149931 = {isa = PBXBuildFile; fileRef = FR_835891206247 /* PINOperationQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_229174307200 /* STPSourceReceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_793128565775 /* STPSourceReceiver.m */; };
 		BF_230346920582 /* stp_card_visa_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_161685209527 /* stp_card_visa_template@2x.png */; };
-		BF_230833361753 = {isa = PBXBuildFile; fileRef = FR_474857769163 /* UIView+Stripe_FirstResponder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_230910628428 = {isa = PBXBuildFile; fileRef = FR_618474416247 /* STPAddCardViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_233106130787 = {isa = PBXBuildFile; fileRef = "FR_836284080868-1" /* STPTelemetryClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_233625798884 = {isa = PBXBuildFile; fileRef = FR_474857769163 /* UIView+Stripe_FirstResponder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_234494727001 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
-		BF_235992551083 = {isa = PBXBuildFile; fileRef = FR_282440445482 /* STPBankAccountParams+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BF_236406319029 /* Some.cc in Sources */ = {isa = PBXBuildFile; fileRef = FR_282022996649 /* Some.cc */; };
 		BF_238970309620 /* stp_icon_checkmark@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_454974753213 /* stp_icon_checkmark@3x.png */; };
-		BF_240137375338 = {isa = PBXBuildFile; fileRef = FR_809418927836 /* STPDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_242512122548 = {isa = PBXBuildFile; fileRef = "FR_670697261324-1" /* STPBINRange.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_242970045520 = {isa = PBXBuildFile; fileRef = FR_731018226313 /* UIViewController+Stripe_ParentViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_243456734649 = {isa = PBXBuildFile; fileRef = FR_476338718337 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_243636708199 /* stp_card_cvc_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_441695822925 /* stp_card_cvc_amex@2x.png */; };
 		BF_244355728562 /* stp_card_diners.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_315436813377 /* stp_card_diners.png */; };
-		BF_244861228656 = {isa = PBXBuildFile; fileRef = FR_904866835750 /* UIViewController+Stripe_Promises.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_247694760221 = {isa = PBXBuildFile; fileRef = FR_905090839392 /* STPCoreViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_248271752273 /* UIView+Stripe_FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_270060349354-1" /* UIView+Stripe_FirstResponder.m */; };
-		BF_248655038543 = {isa = PBXBuildFile; fileRef = FR_564276906433 /* STPPaymentCardTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_248973686403 = {isa = PBXBuildFile; fileRef = FR_221232691705 /* STPAddressFieldTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_249076402477 = {isa = PBXBuildFile; fileRef = FR_135654520087 /* STPFormEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_249342805273 /* STPPaymentMethodTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_318471428702 /* STPPaymentMethodTuple.m */; };
-		BF_249926372240 = {isa = PBXBuildFile; fileRef = FR_287994782021 /* STPFormEncodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_250175477903 /* stp_card_form_back.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_581387210768 /* stp_card_form_back.png */; };
-		BF_254800216829 = {isa = PBXBuildFile; fileRef = FR_271701757351 /* STPCustomer+SourceTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_255630649023 = {isa = PBXBuildFile; fileRef = FR_135608655768 /* STPBankAccount.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_258555341245 = {isa = PBXBuildFile; fileRef = FR_507863811111 /* STPCustomer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_260333157646 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_388157799616 /* main.m */; };
 		BF_261510315068 /* stp_card_visa.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_620185860855 /* stp_card_visa.png */; };
-		BF_261754714385 = {isa = PBXBuildFile; fileRef = FR_744357543627 /* PINCacheObjectSubscripting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_263148238203 /* stp_card_discover@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_867716578881 /* stp_card_discover@2x.png */; };
 		BF_263324905251 /* STPColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_573822806939 /* STPColorUtils.m */; };
 		BF_264785220441 /* stp_card_form_front@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_767601579243 /* stp_card_form_front@2x.png */; };
-		BF_265148746315 = {isa = PBXBuildFile; fileRef = FR_756124038298 /* STPSwitchTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_267320673418 = {isa = PBXBuildFile; fileRef = FR_584380253982 /* PINDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_268552014829 = {isa = PBXBuildFile; fileRef = FR_871742726913 /* STPAPIClient+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_269295894987 = {isa = PBXBuildFile; fileRef = FR_397431763487 /* STPValidatedTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_269301665033 = {isa = PBXBuildFile; fileRef = FR_489565775328 /* STPSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_272462891012 = {isa = PBXBuildFile; fileRef = "FR_114615500587-1" /* PKPayment+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_273592227048 = {isa = PBXBuildFile; fileRef = FR_882551670748 /* UITableViewCell+Stripe_Borders.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_274919599119 = {isa = PBXBuildFile; fileRef = FR_212529072788 /* STPCoreTableViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_275397151973 /* STPPaymentConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_454291026560 /* STPPaymentConfiguration.m */; };
 		BF_276095752437 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_888449823097-1" /* STPSectionHeaderView.m */; };
 		BF_278663538510 /* stp_card_mastercard.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_819492685632 /* stp_card_mastercard.png */; };
 		BF_279020500217 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_161131115028-1" /* NSDictionary+Stripe.m */; };
 		BF_279596883188 /* empty-main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_838972687587 /* empty-main.m */; };
-		BF_279964695128 = {isa = PBXBuildFile; fileRef = FR_793362014210 /* STPSwitchTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_279982316915 = {isa = PBXBuildFile; fileRef = FR_674978004924 /* PINCacheMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_281249274181 = {isa = PBXBuildFile; fileRef = FR_711084170905 /* STPFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_281575970960 = {isa = PBXBuildFile; fileRef = FR_233450545627 /* STPRedirectContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_281675059895 = {isa = PBXBuildFile; fileRef = FR_529018358997 /* STPPaymentMethodTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_283185832665 = {isa = PBXBuildFile; fileRef = FR_674978004924 /* PINCacheMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_283711612373 = {isa = PBXBuildFile; fileRef = FR_190239098217 /* STPShippingMethodsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_283769270364 /* stp_card_discover_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_162583091328 /* stp_card_discover_template@2x.png */; };
-		BF_285085086514 = {isa = PBXBuildFile; fileRef = FR_697405215088 /* STPLegalEntityParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_285731628152 = {isa = PBXBuildFile; fileRef = "FR_573822806939-1" /* STPColorUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_285927550174 /* STPApplePayPaymentMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_543365396645 /* STPApplePayPaymentMethod.m */; };
-		BF_287331456132 = {isa = PBXBuildFile; fileRef = FR_525936809580 /* PINCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_289584464573 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_417020094137 /* STPURLCallbackHandler.m */; };
-		BF_289628673199 = {isa = PBXBuildFile; fileRef = FR_201151680337 /* PINCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_290024877381 = {isa = PBXBuildFile; fileRef = FR_173102942353 /* GeneratedFiles */; };
 		BF_290778906678 /* stp_card_unionpay_template_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_607867791021 /* stp_card_unionpay_template_zh.png */; };
-		BF_292927554402 = {isa = PBXBuildFile; fileRef = "FR_611231413868-1" /* PINDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_293411348661 /* PINOperationGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_100956106934 /* PINOperationGroup.m */; };
-		BF_295910271949 = {isa = PBXBuildFile; fileRef = FR_582257680537 /* STPToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_296262923336 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_691812537693 /* stp_card_amex@2x.png */; };
 		BF_296805053083 /* stp_card_error_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_684957151634 /* stp_card_error_amex@3x.png */; };
 		BF_297270047166 /* stp_card_unionpay_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_351629510243 /* stp_card_unionpay_zh.png */; };
 		BF_298426479289 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_353990188355 /* GoogleAppIndexing.framework */; };
-		BF_302591142888 = {isa = PBXBuildFile; fileRef = FR_553085332782 /* STPCardValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_302656837146 = {isa = PBXBuildFile; fileRef = FR_774763671036 /* STPSourceVerification+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_304341012138 = {isa = PBXBuildFile; fileRef = FR_694358125905 /* Fabric+FABKits.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_304667849339 /* stp_card_jcb_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_348062610832 /* stp_card_jcb_template@3x.png */; };
 		BF_305816078570 /* stp_card_applepay@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_458974510861 /* stp_card_applepay@2x.png */; };
 		BF_306186377385 /* STPCardValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_716273040248 /* STPCardValidator.m */; };
-		BF_306466012489 = {isa = PBXBuildFile; fileRef = FR_190239098217 /* STPShippingMethodsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_307032330867 = {isa = PBXBuildFile; fileRef = FR_828800361135 /* STPSourceParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_307058568177 = {isa = PBXBuildFile; fileRef = FR_805980394109 /* STPShippingMethodTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_307101022873 = {isa = PBXBuildFile; fileRef = FR_426141564195 /* STPPaymentMethodTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_307222715199 /* stp_card_error.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_550412986688 /* stp_card_error.png */; };
-		BF_308487690237 = {isa = PBXBuildFile; fileRef = FR_234015152924 /* STPImageLibrary+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_309156400099 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_235441027813 /* STPSource.m */; };
-		BF_309472228023 = {isa = PBXBuildFile; fileRef = FR_515018785028 /* PINCache-Arc-exception-safe-ios-11.3.a */; };
-		BF_309519251362 = {isa = PBXBuildFile; fileRef = FR_680138288521 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_309570989202 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_390212303514 /* stp_card_amex.png */; };
-		BF_309982076123 = {isa = PBXBuildFile; fileRef = FR_201151680337 /* PINCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_310147481663 /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_153681520641 /* stp_card_applepay.png */; };
 		BF_310592570415 /* stp_card_error@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_849166683791 /* stp_card_error@2x.png */; };
 		BF_312420450925 /* stp_card_error.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_550412986688 /* stp_card_error.png */; };
-		BF_312617644827 = {isa = PBXBuildFile; fileRef = FR_244377844184 /* STPAddCardViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_313626589426 = {isa = PBXBuildFile; fileRef = FR_192292988800 /* PINCacheMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_314158884179 /* stp_card_diners_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_329418993821 /* stp_card_diners_template@2x.png */; };
 		BF_316466910586 /* STPCategoryLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_383188188562-1" /* STPCategoryLoader.m */; };
 		BF_317591589294 /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_221232691707 /* STPAddressFieldTableViewCell.m */; };
 		BF_317838552798 /* stp_icon_checkmark.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_213958106393 /* stp_icon_checkmark.png */; };
-		BF_318246319821 = {isa = PBXBuildFile; fileRef = FR_691297741334 /* STPAddressFieldTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_320484575899 = {isa = PBXBuildFile; fileRef = FR_752684654079 /* STPAPIClient+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_320837076228 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_838405705884 /* stp_card_amex@3x.png */; };
-		BF_320936725019 = {isa = PBXBuildFile; fileRef = FR_387879201639 /* Fabric+FABKits.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_321486603389 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_171962769898-1" /* UIImage+Stripe.m */; };
-		BF_322564119714 = {isa = PBXBuildFile; fileRef = FR_138203417337 /* STPAPIClient+ApplePay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_323071047002 = {isa = PBXBuildFile; fileRef = FR_474473428077 /* UITableViewCell+Stripe_Borders.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_325235565479 = {isa = PBXBuildFile; fileRef = FR_393824443137 /* STPPaymentContextAmountModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_325491988734 = {isa = PBXBuildFile; fileRef = FR_314191844776 /* UnitTests.xctest */; };
-		BF_325517831007 = {isa = PBXBuildFile; fileRef = FR_791050653111 /* UIViewController+Stripe_NavigationItemProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_327075980396 = {isa = PBXBuildFile; fileRef = FR_118015691316 /* STPFormTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_327750466455 = {isa = PBXBuildFile; fileRef = FR_900194878155 /* STPCoreScrollViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_328451804865 = {isa = PBXBuildFile; fileRef = FR_387879201639 /* Fabric+FABKits.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_329364151827 = {isa = PBXBuildFile; fileRef = FR_606586344904 /* STPAspects.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_329490898862 = {isa = PBXBuildFile; fileRef = FR_493781913276 /* STPColorUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_329594723251 = {isa = PBXBuildFile; fileRef = FR_661735356868 /* STPPaymentContextAmountModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_331120889263 = {isa = PBXBuildFile; fileRef = FR_544048132697 /* STPBlocks.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_332238646659 /* STPPhoneNumberValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_845699426889 /* STPPhoneNumberValidator.m */; };
 		BF_333370963763 /* STPPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_177669650679-1" /* STPPromise.m */; };
 		BF_333697809308 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_595618312739 /* libPINCache-Core-ios-9.0.a */; };
-		BF_334272034699 = {isa = PBXBuildFile; fileRef = FR_704991007882 /* STPImageLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_337592025421 = {isa = PBXBuildFile; fileRef = "FR_857114782727-1" /* NSArray+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_338818230603 = {isa = PBXBuildFile; fileRef = FR_851062106152 /* UIToolbar+Stripe_InputAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_340672610509 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_353990188355 /* GoogleAppIndexing.framework */; };
 		BF_340860741059 /* STPPaymentMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_394482207665 /* STPPaymentMethodsViewController.m */; };
 		BF_341351208907 /* stp_card_jcb@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_554896677909 /* stp_card_jcb@3x.png */; };
-		BF_341797763551 = {isa = PBXBuildFile; fileRef = FR_651430382944 /* STPShippingMethodTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_341904587881 /* stp_card_unionpay_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_256481006549 /* stp_card_unionpay_en.png */; };
-		BF_341966299764 = {isa = PBXBuildFile; fileRef = FR_113779000903 /* STPSourceSEPADebitDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_342219681722 = {isa = PBXBuildFile; fileRef = FR_631274162632 /* STPBINRange.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_342334117828 = {isa = PBXBuildFile; fileRef = FR_346842595418 /* STPAddressViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_343082518654 /* STPPaymentCardTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_786851096829 /* STPPaymentCardTextFieldCell.m */; };
 		BF_343953132595 /* stp_card_unionpay_template_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_438548292773 /* stp_card_unionpay_template_zh@3x.png */; };
-		BF_344370388780 = {isa = PBXBuildFile; fileRef = FR_824435249884 /* Fabric.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_344516029993 /* stp_card_jcb.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_739797562620 /* stp_card_jcb.png */; };
-		BF_345205681868 = {isa = PBXBuildFile; fileRef = FR_900194878155 /* STPCoreScrollViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_345388472655 = {isa = PBXBuildFile; fileRef = FR_193256557604 /* STPApplePayPaymentMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_347400375504 = {isa = PBXBuildFile; fileRef = FR_123089320494 /* STPPaymentMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_349014713506 = {isa = PBXBuildFile; fileRef = FR_752684654079 /* STPAPIClient+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_349880824923 /* STPAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_744571361438-1" /* STPAPIRequest.m */; };
-		BF_351703462301 = {isa = PBXBuildFile; fileRef = FR_803655950633 /* STPCardIOProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_351955321695 = {isa = PBXBuildFile; fileRef = FR_829657687624 /* NSMutableURLRequest+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_354900207481 = {isa = PBXBuildFile; fileRef = FR_642952555060 /* PINCacheObjectSubscripting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_356059242114 = {isa = PBXBuildFile; fileRef = FR_171962769898 /* UIImage+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_356751292946 = {isa = PBXBuildFile; fileRef = FR_301377298368 /* STPPaymentConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_357121410090 = {isa = PBXBuildFile; fileRef = FR_747893419826 /* NSDecimalNumber+Stripe_Currency.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_357314905437 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_838405705884 /* stp_card_amex@3x.png */; };
 		BF_357489808821 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_393824443136 /* STPPaymentContextAmountModel.m */; };
 		BF_358123724804 /* stp_card_unionpay_template_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_607867791021 /* stp_card_unionpay_template_zh.png */; };
 		BF_359877986903 /* STPFormTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_118015691316-1" /* STPFormTextField.m */; };
-		BF_360170443110 = {isa = PBXBuildFile; fileRef = FR_546285993684 /* NSString+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_360915304424 = {isa = PBXBuildFile; fileRef = "FR_181346025846-1" /* STPPostalCodeValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_360971188773 = {isa = PBXBuildFile; fileRef = FR_683299749236 /* NSDictionary+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_362461023323 /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_201151680337-1" /* PINCache.m */; };
 		BF_362750078846 /* STPCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_764679247202 /* STPCustomerContext.m */; };
-		BF_362865184644 = {isa = PBXBuildFile; fileRef = FR_746622612454 /* UINavigationController+Stripe_Completion.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_363066368412 /* stp_card_discover@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_460546061817 /* stp_card_discover@3x.png */; };
 		BF_363607041405 /* stp_card_discover_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_162624925573 /* stp_card_discover_template@3x.png */; };
 		BF_364718393009 /* stp_icon_add.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_446151064510 /* stp_icon_add.png */; };
-		BF_365183015589 = {isa = PBXBuildFile; fileRef = FR_411830352510 /* STPBackendAPIAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_365572872399 /* STPMultipartFormDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_344043994903 /* STPMultipartFormDataEncoder.m */; };
 		BF_365968776464 /* stp_icon_add@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_701860410388 /* stp_icon_add@2x.png */; };
-		BF_366621800726 = {isa = PBXBuildFile; fileRef = FR_411830352510 /* STPBackendAPIAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_367284426572 /* STPAddCardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_670019473135 /* STPAddCardViewController.m */; };
-		BF_367688300560 = {isa = PBXBuildFile; fileRef = FR_385860430238 /* STPCategoryLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_368587116363 = {isa = PBXBuildFile; fileRef = FR_177669650679 /* STPPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_370160187128 = {isa = PBXBuildFile; fileRef = FR_638194865189 /* STPSourceParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_370608658701 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_983798454349 /* STPCardParams.m */; };
-		BF_371026716476 = {isa = PBXBuildFile; fileRef = FR_551038918304 /* STPToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_371536116472 /* stp_card_visa.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_620185860855 /* stp_card_visa.png */; };
-		BF_371927548775 = {isa = PBXBuildFile; fileRef = FR_270060349354 /* UIView+Stripe_FirstResponder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_372976146971 = {isa = PBXBuildFile; fileRef = FR_203734164041 /* STPPaymentMethodsViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_373842051609 = {isa = PBXBuildFile; fileRef = FR_662890025590 /* STPCustomerContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_374487985675 = {isa = PBXBuildFile; fileRef = FR_763956267392 /* STPPaymentConfiguration+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_374495291268 = {isa = PBXBuildFile; fileRef = FR_545855187610 /* STPPaymentMethodsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_375874592492 = {isa = PBXBuildFile; fileRef = FR_763956267392 /* STPPaymentConfiguration+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_376657278382 /* stp_card_discover@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_867716578881 /* stp_card_discover@2x.png */; };
-		BF_377801338894 = {isa = PBXBuildFile; fileRef = FR_169157621063 /* STPPaymentResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_378840913279 /* STPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_729837640388 /* STPAPIClient.m */; };
 		BF_379613470386 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
 		BF_380829518120 /* stp_card_discover_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_162583091328 /* stp_card_discover_template@2x.png */; };
-		BF_381776815951 = {isa = PBXBuildFile; fileRef = FR_454126136560 /* STPAPIResponseDecodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_381871517932 /* STPFormEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_375651978668 /* STPFormEncoder.m */; };
 		BF_381896389344 /* stp_card_mastercard@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_160191336416 /* stp_card_mastercard@3x.png */; };
 		BF_382005665511 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_114615500587 /* PKPayment+Stripe.m */; };
 		BF_382809687329 /* stp_card_unionpay_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_119347389557 /* stp_card_unionpay_en@3x.png */; };
 		BF_383261352520 /* STPAddressViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_650044337253-1" /* STPAddressViewModel.m */; };
-		BF_385362307205 = {isa = PBXBuildFile; fileRef = FR_365229780069 /* STPValidatedTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_386792578073 = {isa = PBXBuildFile; fileRef = FR_117348292070 /* STPWeakStrongMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_388766661431 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_611231413868 /* PINDiskCache.m */; };
-		BF_389453027708 = {isa = PBXBuildFile; fileRef = FR_912348913657 /* STPCoreViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_389902562892 /* share-extension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_243789410170 /* share-extension.appex */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		BF_389902562892 /* share-extension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_243789410170 /* share-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		BF_391600535834 /* stp_card_diners_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_341722897024 /* stp_card_diners_template.png */; };
-		BF_392588383791 = {isa = PBXBuildFile; fileRef = FR_357921302656 /* STPSourceRedirect.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_393302497834 = {isa = PBXBuildFile; fileRef = FR_813949290948 /* STPCoreScrollViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_394100016281 = {isa = PBXBuildFile; fileRef = FR_515110400273 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_394241908903 = {isa = PBXBuildFile; fileRef = FR_774763671036 /* STPSourceVerification+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_396367102140 /* stp_card_cvc@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_150617010141 /* stp_card_cvc@3x.png */; };
 		BF_397345146558 /* stp_icon_add.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_446151064510 /* stp_icon_add.png */; };
-		BF_398004394249 = {isa = PBXBuildFile; fileRef = FR_537648693821 /* STPSourceCardDetails+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_398172019025 = {isa = PBXBuildFile; fileRef = FR_613101804389 /* STPSourceReceiver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_399571997734 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_841504889387 /* AppDelegate.m */; };
-		BF_400717540269 = {isa = PBXBuildFile; fileRef = FR_266252253452 /* UIBarButtonItem+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_401299920441 = {isa = PBXBuildFile; fileRef = FR_744571361438 /* STPAPIRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_403497198976 = {isa = PBXBuildFile; fileRef = FR_328574352852 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_403902621459 = {isa = PBXBuildFile; fileRef = FR_113779000903 /* STPSourceSEPADebitDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_405126167311 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_518266894407 /* libStripe-ios-9.0.a */; };
 		BF_408232004094 /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_720396073744 /* stp_shipping_form.png */; };
-		BF_409700183515 = {isa = PBXBuildFile; fileRef = FR_393824443137 /* STPPaymentContextAmountModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_412227068955 /* stp_card_unionpay_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_127100545188 /* stp_card_unionpay_zh@2x.png */; };
 		BF_412364227267 /* stp_icon_add@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_701860410388 /* stp_icon_add@2x.png */; };
-		BF_413116921378 = {isa = PBXBuildFile; fileRef = FR_609916384487 /* STPPaymentCardTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_413191422141 = {isa = PBXBuildFile; fileRef = FR_613113088567 /* STPSourceEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_413861440512 /* UIBarButtonItem+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_266252253452-1" /* UIBarButtonItem+Stripe.m */; };
-		BF_414266942052 = {isa = PBXBuildFile; fileRef = FR_352992724052 /* STPPaymentCardTextFieldViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_415521091941 = {isa = PBXBuildFile; fileRef = "FR_344823093939-1" /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_415785036251 = {isa = PBXBuildFile; fileRef = FR_460374501185 /* STPRedirectContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_418274553626 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166622418620 /* Tests.m */; };
-		BF_421460215015 = {isa = PBXBuildFile; fileRef = FR_661294188967 /* STPShippingAddressViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_421616336702 = {isa = PBXBuildFile; fileRef = FR_641873512346 /* UIView+Stripe_SafeAreaBounds.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_422246274668 = {isa = PBXBuildFile; fileRef = FR_641873512346 /* UIView+Stripe_SafeAreaBounds.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_423050148924 /* NSError+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_136387137481-1" /* NSError+Stripe.m */; };
-		BF_424424429424 = {isa = PBXBuildFile; fileRef = FR_346842595418 /* STPAddressViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_424540904917 /* STPCoreViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_547792905644 /* STPCoreViewController.m */; };
 		BF_424698683183 /* STPSourceParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_748997447722 /* STPSourceParams.m */; };
-		BF_425303061676 = {isa = PBXBuildFile; fileRef = FR_171962769898 /* UIImage+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_427007859872 = {isa = PBXBuildFile; fileRef = FR_780452303071 /* STPTheme.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_428513331366 = {isa = PBXBuildFile; fileRef = FR_709442092021 /* STPPaymentMethodTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_428886690198 = {isa = PBXBuildFile; fileRef = FR_460131545307 /* UrlGetClasses-ios-11.3.a */; };
-		BF_428892778555 = {isa = PBXBuildFile; fileRef = FR_546285993684 /* NSString+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_429234782635 = {isa = PBXBuildFile; fileRef = FR_778052571267 /* STPBankAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_429793154274 = {isa = PBXBuildFile; fileRef = FR_744357543627 /* PINCacheObjectSubscripting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_430195555076 = {isa = PBXBuildFile; fileRef = FR_147204469035 /* STPConnectAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_431247232736 /* stp_card_unionpay_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_119347408405 /* stp_card_unionpay_en@2x.png */; };
-		BF_431606848161 = {isa = PBXBuildFile; fileRef = FR_161131115028 /* NSDictionary+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_433098327180 /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_308451946297 /* STPAPIClient+ApplePay.m */; };
 		BF_436043688776 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_390212303514 /* stp_card_amex.png */; };
 		BF_437340004481 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_149668560898 /* STPPaymentResult.m */; };
-		BF_437789603259 = {isa = PBXBuildFile; fileRef = "FR_430199726738-1" /* STPMultipartFormDataPart.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_437877517776 = {isa = PBXBuildFile; fileRef = FR_870129501381 /* UITests.xctest */; };
-		BF_440858072903 = {isa = PBXBuildFile; fileRef = FR_479483572541 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_441704086879 = {isa = PBXBuildFile; fileRef = FR_136387137481 /* NSError+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_443170250501 = {isa = PBXBuildFile; fileRef = FR_897080895086 /* STPCustomer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_444049534671 /* STPSourceParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_748997447722 /* STPSourceParams.m */; };
-		BF_445035133632 = {isa = PBXBuildFile; fileRef = "FR_170908667679-1" /* STPEphemeralKeyManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_445080671684 = {isa = PBXBuildFile; fileRef = FR_760644560579 /* STPPhoneNumberValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_445155630300 = {isa = PBXBuildFile; fileRef = FR_778931539736 /* STPSourceParams+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_445949043870 /* STPEphemeralKey.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_118429332705 /* STPEphemeralKey.m */; };
 		BF_447084161359 /* stp_card_form_front@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_767601582739 /* stp_card_form_front@3x.png */; };
 		BF_447601669755 /* STPShippingAddressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_744666232521 /* STPShippingAddressViewController.m */; };
-		BF_448144481207 = {isa = PBXBuildFile; fileRef = FR_642952555060 /* PINCacheObjectSubscripting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_448507476666 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_401789639718-1" /* STPStringUtils.m */; };
-		BF_448590610219 = {isa = PBXBuildFile; fileRef = "FR_118429332705-1" /* STPEphemeralKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_449062528510 = {isa = PBXBuildFile; fileRef = FR_651430382944 /* STPShippingMethodTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_449892321630 /* STPShippingMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_190239098214 /* STPShippingMethodsViewController.m */; };
-		BF_450973247176 = {isa = PBXBuildFile; fileRef = FR_347917955852 /* STPSourceVerification+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_452582267011 = {isa = PBXBuildFile; fileRef = FR_123089320494 /* STPPaymentMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_452758362099 /* STPAnalyticsClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_140569352166 /* STPAnalyticsClient.m */; };
-		BF_452870870440 = {isa = PBXBuildFile; fileRef = FR_784978929968 /* UIViewController+Stripe_KeyboardAvoiding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_453248911725 = {isa = PBXBuildFile; fileRef = FR_688345473974 /* STPBackendAPIAdapter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_453568682923 /* STPSourceVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_431507780270 /* STPSourceVerification.m */; };
 		BF_453613883928 /* stp_card_unknown@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_313827850627 /* stp_card_unknown@3x.png */; };
-		BF_453700753695 = {isa = PBXBuildFile; fileRef = FR_862049125356 /* STPFile+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_454119922131 = {isa = PBXBuildFile; fileRef = FR_398400160687 /* STPInternalAPIResponseDecodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_454318076844 /* STPCoreScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_651201787786 /* STPCoreScrollViewController.m */; };
 		BF_455180069893 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_426141564192 /* STPPaymentMethodTableViewCell.m */; };
-		BF_455553241975 = {isa = PBXBuildFile; fileRef = FR_761930139089 /* Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_456142095854 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_691812537693 /* stp_card_amex@2x.png */; };
-		BF_457350655845 = {isa = PBXBuildFile; fileRef = FR_891417925643 /* STPSourceRedirect+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_457382615413 /* STPCustomer+SourceTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_180708382140 /* STPCustomer+SourceTuple.m */; };
-		BF_457402325377 = {isa = PBXBuildFile; fileRef = FR_711062668967 /* STPCard.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_457943934341 /* stp_card_unionpay_template_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_438213232580 /* stp_card_unionpay_template_zh@2x.png */; };
-		BF_458970707708 = {isa = PBXBuildFile; fileRef = FR_484428159681 /* STPCoreTableViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_459375429499 = {isa = PBXBuildFile; fileRef = FR_383186939534 /* NSString+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_459562626629 = {isa = PBXBuildFile; fileRef = FR_504172386443 /* STPPaymentCardTextFieldCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_461158900801 = {isa = PBXBuildFile; fileRef = FR_100119553883 /* NSURLComponents+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_461338526634 /* STPAddCardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_670019473135 /* STPAddCardViewController.m */; };
 		BF_462455659113 /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_153681520641 /* stp_card_applepay.png */; };
-		BF_464452993381 = {isa = PBXBuildFile; fileRef = FR_485300186976 /* NSDecimalNumber+Stripe_Currency.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_464817123306 = {isa = PBXBuildFile; fileRef = "FR_430199726738-1" /* STPMultipartFormDataPart.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_465102090736 = {isa = PBXBuildFile; fileRef = FR_352992724052 /* STPPaymentCardTextFieldViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_465243962720 = {isa = PBXBuildFile; fileRef = FR_275055915589 /* STPSource+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_465898508268 = {isa = PBXBuildFile; fileRef = FR_175704718595 /* UrlGetClasses-ios-9.0.a */; };
-		BF_466132364574 = {isa = PBXBuildFile; fileRef = FR_772386701230 /* Fabric.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_467013923609 /* UIView+Stripe_FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_270060349354-1" /* UIView+Stripe_FirstResponder.m */; };
-		BF_467313555321 = {isa = PBXBuildFile; fileRef = FR_889566942228 /* STPSourceRedirect.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_468726244056 /* STPAnalyticsClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_140569352166 /* STPAnalyticsClient.m */; };
-		BF_468759786887 = {isa = PBXBuildFile; fileRef = FR_275055915589 /* STPSource+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_469132547938 = {isa = PBXBuildFile; fileRef = FR_680787884007 /* STPPaymentCardTextField+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_469499390768 = {isa = PBXBuildFile; fileRef = FR_560961278475 /* STPPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_469815406960 = {isa = PBXBuildFile; fileRef = FR_341536377834 /* STPSourceParams+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_470929899408 /* STPCustomer.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_775444959222 /* STPCustomer.m */; };
-		BF_471084279869 = {isa = PBXBuildFile; fileRef = FR_514597362078 /* STPAPIClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_471167991953 /* libUrlGetClasses-ios-11.3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_262777658410 /* libUrlGetClasses-ios-11.3.a */; };
-		BF_471351062941 = {isa = PBXBuildFile; fileRef = FR_888449823097 /* STPSectionHeaderView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_471380831706 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
-		BF_472482368601 = {isa = PBXBuildFile; fileRef = FR_699697656028 /* STPShippingAddressViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_473725115787 /* stp_shipping_form@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_587518550104 /* stp_shipping_form@3x.png */; };
-		BF_473809857064 = {isa = PBXBuildFile; fileRef = FR_305934251603 /* STPPaymentMethodsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_474140462599 /* STPFormTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_118015691316-1" /* STPFormTextField.m */; };
 		BF_474989706909 /* stp_card_diners_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_341722897024 /* stp_card_diners_template.png */; };
 		BF_475917700354 /* stp_card_amex_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_222214992417 /* stp_card_amex_template.png */; };
-		BF_476585328798 = {isa = PBXBuildFile; fileRef = FR_805980394109 /* STPShippingMethodTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_477621904475 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_401789639718-1" /* STPStringUtils.m */; };
-		BF_478396002849 = {isa = PBXBuildFile; fileRef = FR_401789639718 /* STPStringUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_481323010287 = {isa = PBXBuildFile; fileRef = "FR_451065136063-1" /* UIViewController+Stripe_NavigationItemProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_484695201271 = {isa = PBXBuildFile; fileRef = FR_168416049633 /* PKPayment+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_484844982921 /* STPSwitchTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_793362014210-1" /* STPSwitchTableViewCell.m */; };
-		BF_485410344512 = {isa = PBXBuildFile; fileRef = FR_617610467620 /* NSMutableURLRequest+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_485489969990 = {isa = PBXBuildFile; fileRef = FR_301377298368 /* STPPaymentConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_485817685451 /* stp_card_unionpay_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_127100525052 /* stp_card_unionpay_zh@3x.png */; };
-		BF_486952489935 = {isa = PBXBuildFile; fileRef = FR_135608655768 /* STPBankAccount.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_487480432537 = {isa = PBXBuildFile; fileRef = FR_777337581099 /* STPBankAccount.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_488089343346 = {isa = PBXBuildFile; fileRef = FR_239638141147 /* StripeError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_489322762158 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_522111507539 /* STPRedirectContext.m */; };
-		BF_489619478350 = {isa = PBXBuildFile; fileRef = FR_436439106628 /* NSCharacterSet+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_489787044526 /* STPMultipartFormDataPart.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_430199726738 /* STPMultipartFormDataPart.m */; };
 		BF_490736564052 /* stp_icon_checkmark.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_213958106393 /* stp_icon_checkmark.png */; };
 		BF_492261497607 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_888449823097-1" /* STPSectionHeaderView.m */; };
 		BF_492945389948 /* UIView+Stripe_SafeAreaBounds.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_394531061746-1" /* UIView+Stripe_SafeAreaBounds.m */; };
 		BF_492946219688 /* stp_card_unionpay_template_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_440272897295 /* stp_card_unionpay_template_en@2x.png */; };
-		BF_493297664684 = {isa = PBXBuildFile; fileRef = FR_443002457585 /* ios-app.app */; };
-		BF_493372100790 = {isa = PBXBuildFile; fileRef = FR_878727202200 /* STPEphemeralKeyProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_493722597919 = {isa = PBXBuildFile; fileRef = FR_265776775943 /* UIToolbar+Stripe_InputAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_494386386181 = {isa = PBXBuildFile; fileRef = FR_519940329301 /* STPUserInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_494934828578 = {isa = PBXBuildFile; fileRef = FR_824435249884 /* Fabric.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_495247038231 = {isa = PBXBuildFile; fileRef = FR_201151680337 /* PINCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_496632965049 = {isa = PBXBuildFile; fileRef = FR_898827650356 /* PINOperationQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_497758348623 = {isa = PBXBuildFile; fileRef = FR_468896292749 /* STPEphemeralKeyProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_498128473604 /* STPLocalizationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_374398035813 /* STPLocalizationUtils.m */; };
-		BF_501025658096 = {isa = PBXBuildFile; fileRef = FR_747893419826 /* NSDecimalNumber+Stripe_Currency.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_501120341185 = {isa = PBXBuildFile; fileRef = FR_777944667952 /* STPSourceProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_503400796960 /* STPDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_240384147848 /* STPDelegateProxy.m */; };
 		BF_504461851187 /* NSMutableURLRequest+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_829657687628 /* NSMutableURLRequest+Stripe.m */; };
-		BF_504469662098 = {isa = PBXBuildFile; fileRef = FR_177669650679 /* STPPromise.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_504960305938 = {isa = PBXBuildFile; fileRef = FR_270060349354 /* UIView+Stripe_FirstResponder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_506403901135 /* STPLegalEntityParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_863581397541 /* STPLegalEntityParams.m */; };
-		BF_506862138075 = {isa = PBXBuildFile; fileRef = FR_691297741334 /* STPAddressFieldTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_507098214312 = {isa = PBXBuildFile; fileRef = FR_887633340860 /* STPCardBrand.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_508371033097 = {isa = PBXBuildFile; fileRef = FR_302600842104 /* STPPaymentContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_510117431774 = {isa = PBXBuildFile; fileRef = FR_912348913657 /* STPCoreViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_511005352156 = {isa = PBXBuildFile; fileRef = FR_898827650356 /* PINOperationQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_511460737422 = {isa = PBXBuildFile; fileRef = FR_714908972385 /* Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_512255367993 = {isa = PBXBuildFile; fileRef = FR_609916384487 /* STPPaymentCardTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_512885476152 /* stp_card_diners_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_329419374230 /* stp_card_diners_template@3x.png */; };
-		BF_512997436436 = {isa = PBXBuildFile; fileRef = FR_697115907292 /* FauxPasAnnotations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_513577914721 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_841504889387 /* AppDelegate.m */; };
 		BF_513813635076 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_863295555018 /* STPDispatchFunctions.m */; };
-		BF_513813761296 = {isa = PBXBuildFile; fileRef = FR_290482945381 /* STPAddCardViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_514201498933 = {isa = PBXBuildFile; fileRef = FR_756124038298 /* STPSwitchTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_515478026660 /* STPEmailAddressValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_820602908988 /* STPEmailAddressValidator.m */; };
-		BF_516549899025 = {isa = PBXBuildFile; fileRef = FR_859356790791 /* STPTelemetryClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_516940004574 = {isa = PBXBuildFile; fileRef = FR_357921302656 /* STPSourceRedirect.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_517115879287 = {isa = PBXBuildFile; fileRef = FR_100956106933 /* PINOperationGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_518343626882 = {isa = PBXBuildFile; fileRef = FR_238855777613 /* STPBankAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_520797163878 = {isa = PBXBuildFile; fileRef = FR_573089660403 /* UIViewController+Stripe_KeyboardAvoiding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_521622366374 = {isa = PBXBuildFile; fileRef = FR_662890025590 /* STPCustomerContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_522340134300 /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_181346025846 /* STPPostalCodeValidator.m */; };
-		BF_522533571246 = {isa = PBXBuildFile; fileRef = FR_680138288521 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_522935875969 /* STPFile.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_227675484416 /* STPFile.m */; };
-		BF_523229133978 = {isa = PBXBuildFile; fileRef = FR_609969202553 /* STPPaymentResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_523457148489 /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_720396073744 /* stp_shipping_form.png */; };
 		BF_524688171203 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
 		BF_525198602071 /* NoArc.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_454823234837 /* NoArc.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		BF_526088750340 = {isa = PBXBuildFile; fileRef = FR_240384147847 /* STPDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_527046135878 /* PINOperationGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_100956106934 /* PINOperationGroup.m */; };
 		BF_527047701434 /* UIBarButtonItem+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_266252253452-1" /* UIBarButtonItem+Stripe.m */; };
 		BF_529356427113 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_479483572541-1" /* PINMemoryCache.m */; };
 		BF_529924854363 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
-		BF_530832467817 = {isa = PBXBuildFile; fileRef = FR_506863260541 /* STPCoreScrollViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_532444640647 /* STPCardValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_716273040248 /* STPCardValidator.m */; };
-		BF_533046495946 = {isa = PBXBuildFile; fileRef = FR_683299749236 /* NSDictionary+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_533133985084 = {isa = PBXBuildFile; fileRef = FR_680787884007 /* STPPaymentCardTextField+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_534245496321 /* STPSourceSEPADebitDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_639248881296 /* STPSourceSEPADebitDetails.m */; };
-		BF_535858915052 = {isa = PBXBuildFile; fileRef = "FR_170908667679-1" /* STPEphemeralKeyManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_536264315342 = {isa = PBXBuildFile; fileRef = FR_331004124905 /* STPCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_536278332551 = {isa = PBXBuildFile; fileRef = FR_357507703280 /* FauxPasAnnotations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_536302022069 /* stp_card_error@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_849166683791 /* stp_card_error@2x.png */; };
-		BF_536314803819 = {isa = PBXBuildFile; fileRef = FR_476338718337 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_538200182522 = {isa = PBXBuildFile; fileRef = FR_387477859828 /* FABKitProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_539205021843 = {isa = PBXBuildFile; fileRef = FR_394531061746 /* UIView+Stripe_SafeAreaBounds.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_539816430774 = {isa = PBXBuildFile; fileRef = FR_518632870935 /* STPCardValidationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_540163603984 /* stp_card_jcb_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_348062819194 /* stp_card_jcb_template@2x.png */; };
 		BF_540876532481 /* STPCategoryLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_383188188562-1" /* STPCategoryLoader.m */; };
-		BF_541245984203 = {isa = PBXBuildFile; fileRef = FR_699697656028 /* STPShippingAddressViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_541601624736 /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_397431763487-1" /* STPValidatedTextField.m */; };
 		BF_541822299127 /* STPMultipartFormDataPart.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_430199726738 /* STPMultipartFormDataPart.m */; };
 		BF_542584147501 /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_397431763487-1" /* STPValidatedTextField.m */; };
 		BF_542676579977 /* UIViewController+Stripe_ParentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_866814615747 /* UIViewController+Stripe_ParentViewController.m */; };
-		BF_544431997809 = {isa = PBXBuildFile; fileRef = FR_327069580859 /* STPSource+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_545260635462 /* STPBankAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_520364995872 /* STPBankAccount.m */; };
 		BF_545657128345 /* stp_card_diners@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_499280427849 /* stp_card_diners@2x.png */; };
-		BF_545886429226 = {isa = PBXBuildFile; fileRef = FR_637944311431 /* ios-ext-bin.a */; };
-		BF_546206697860 = {isa = PBXBuildFile; fileRef = FR_349373308093 /* STPSourceReceiver.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_547002784427 = {isa = PBXBuildFile; fileRef = FR_903454413342 /* STPFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_547740684006 /* UINavigationController+Stripe_Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_746622613527 /* UINavigationController+Stripe_Completion.m */; };
-		BF_549787213822 = {isa = PBXBuildFile; fileRef = FR_271701757351 /* STPCustomer+SourceTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_550396607124 /* STPMultipartFormDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_344043994903 /* STPMultipartFormDataEncoder.m */; };
-		BF_550819428828 = {isa = PBXBuildFile; fileRef = FR_911085306196 /* STPConnectAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_550931196942 /* stp_icon_checkmark@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_454974753213 /* stp_icon_checkmark@3x.png */; };
 		BF_551106090485 /* stp_card_mastercard@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_160191336416 /* stp_card_mastercard@3x.png */; };
 		BF_551145990127 /* stp_card_mastercard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_160191367084 /* stp_card_mastercard@2x.png */; };
-		BF_551221616887 = {isa = PBXBuildFile; fileRef = FR_407393141614 /* STPSourceProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_551403318368 = {isa = PBXBuildFile; fileRef = FR_828784758374 /* STPSourcePoller.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_553050859875 = {isa = PBXBuildFile; fileRef = FR_661735356868 /* STPPaymentContextAmountModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_555361758086 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_747790741358-1" /* STPSourcePoller.m */; };
-		BF_556087101131 = {isa = PBXBuildFile; fileRef = FR_179612585631 /* UINavigationController+Stripe_Completion.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_556861454386 = {isa = PBXBuildFile; fileRef = FR_612435877299 /* STPSourceOwner.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_556944891381 /* STPCoreTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_175464452737 /* STPCoreTableViewController.m */; };
-		BF_557128847637 = {isa = PBXBuildFile; fileRef = FR_895047324232 /* STPStringUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_557157962944 /* STPSourceRedirect.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_770817608373 /* STPSourceRedirect.m */; };
-		BF_557251780380 = {isa = PBXBuildFile; fileRef = FR_266252253452 /* UIBarButtonItem+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_558507126140 /* stp_card_unknown@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_653524283850 /* stp_card_unknown@2x.png */; };
-		BF_558808952817 = {isa = PBXBuildFile; fileRef = FR_600589277732 /* STPPaymentMethodsViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_559687923944 = {isa = PBXBuildFile; fileRef = FR_365229780069 /* STPValidatedTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_559836411561 /* STPShippingMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_805980394107 /* STPShippingMethodTableViewCell.m */; };
 		BF_559895246776 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_388157799616 /* main.m */; };
-		BF_561108185246 = {isa = PBXBuildFile; fileRef = FR_440606856915 /* STPCustomer+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_561983665983 = {isa = PBXBuildFile; fileRef = FR_609969202553 /* STPPaymentResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_563013784716 /* STPCoreScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_651201787786 /* STPCoreScrollViewController.m */; };
 		BF_563626665274 /* STPPaymentMethodsInternalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_303088826339 /* STPPaymentMethodsInternalViewController.m */; };
-		BF_564751766966 = {isa = PBXBuildFile; fileRef = FR_536748644256 /* STPPaymentConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_564964647160 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
 		BF_565142811584 /* stp_card_unionpay_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_351629510243 /* stp_card_unionpay_zh.png */; };
 		BF_565454288660 /* stp_card_amex_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_766919050802 /* stp_card_amex_template@2x.png */; };
 		BF_566176482817 /* STPTelemetryClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_836284080868 /* STPTelemetryClient.m */; };
-		BF_566754655014 = {isa = PBXBuildFile; fileRef = FR_617610467620 /* NSMutableURLRequest+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_566756308829 = {isa = PBXBuildFile; fileRef = FR_212529072788 /* STPCoreTableViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_566891501383 /* stp_card_unionpay_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_119347408405 /* stp_card_unionpay_en@2x.png */; };
-		BF_567308874258 = {isa = PBXBuildFile; fileRef = FR_480331574684 /* UINavigationBar+Stripe_Theme.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_568508761573 /* UINavigationBar+Stripe_Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_486615080111 /* UINavigationBar+Stripe_Theme.m */; };
-		BF_568661006107 = {isa = PBXBuildFile; fileRef = FR_779405691145 /* STPCoreTableViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_570175859519 = {isa = PBXBuildFile; fileRef = FR_895047324232 /* STPStringUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_570367328430 /* stp_card_discover_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_162624925573 /* stp_card_discover_template@3x.png */; };
-		BF_570768771927 = {isa = PBXBuildFile; fileRef = FR_888449823097 /* STPSectionHeaderView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_571503791175 = {isa = PBXBuildFile; fileRef = FR_669064331373 /* STPShippingMethodsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_571681387310 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_595618312739 /* libPINCache-Core-ios-9.0.a */; };
-		BF_572547216982 = {isa = PBXBuildFile; fileRef = FR_239638141147 /* StripeError.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_572562371593 = {isa = PBXBuildFile; fileRef = FR_309446203354 /* STPCard.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_572810307310 = {isa = PBXBuildFile; fileRef = FR_525936809580 /* PINCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_573330003515 = {isa = PBXBuildFile; fileRef = FR_159129633610 /* STPCardValidationState.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_574162666878 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166622418620 /* Tests.m */; };
 		BF_574178145405 /* STPAspects.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_225093974291 /* STPAspects.m */; };
 		BF_575244002306 /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_464213115625 /* stp_card_visa@2x.png */; };
 		BF_575343219227 /* stp_card_jcb_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_348062819194 /* stp_card_jcb_template@2x.png */; };
-		BF_575922298711 = {isa = PBXBuildFile; fileRef = FR_117348292070 /* STPWeakStrongMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_576665603244 = {isa = PBXBuildFile; fileRef = FR_473219612446 /* STPCard+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_578541352057 /* STPApplePayPaymentMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_543365396645 /* STPApplePayPaymentMethod.m */; };
-		BF_578605770030 = {isa = PBXBuildFile; fileRef = FR_215562581198 /* STPEphemeralKeyManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_579672973360 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_983798454349 /* STPCardParams.m */; };
-		BF_580625203980 = {isa = PBXBuildFile; fileRef = FR_713747347031 /* UINavigationBar+Stripe_Theme.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_582530802914 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
-		BF_582977654615 = {isa = PBXBuildFile; fileRef = FR_307274708587 /* UIImage+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_583118057431 = {isa = PBXBuildFile; fileRef = FR_440606856915 /* STPCustomer+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_583178766090 /* stp_card_form_back@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_435082555494 /* stp_card_form_back@3x.png */; };
-		BF_583591408070 = {isa = PBXBuildFile; fileRef = FR_454126136560 /* STPAPIResponseDecodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_584014844802 = {isa = PBXBuildFile; fileRef = FR_234015152924 /* STPImageLibrary+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_584409096743 = {isa = PBXBuildFile; fileRef = FR_326429966766 /* STPSourceEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_584648393362 = {isa = PBXBuildFile; fileRef = FR_367740908522 /* NSBundle+Stripe_AppName.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_585378562575 /* STPSwitchTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_793362014210-1" /* STPSwitchTableViewCell.m */; };
-		BF_586326720572 = {isa = PBXBuildFile; fileRef = FR_841504889253 /* AppDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_588141243996 /* stp_card_diners@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_786618818576 /* stp_card_diners@3x.png */; };
 		BF_589173441158 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_161131115028-1" /* NSDictionary+Stripe.m */; };
 		BF_590384333602 /* stp_card_unionpay_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_127100545188 /* stp_card_unionpay_zh@2x.png */; };
-		BF_590703061110 = {isa = PBXBuildFile; fileRef = FR_865850458143 /* STPLocalizationUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_591718251943 /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_181346025846 /* STPPostalCodeValidator.m */; };
 		BF_591758609732 /* libios-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_107900841834 /* libios-ext-bin.a */; };
-		BF_592019983882 = {isa = PBXBuildFile; fileRef = FR_380861112100 /* STPFormEncodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_592256582686 = {isa = PBXBuildFile; fileRef = FR_674978004924 /* PINCacheMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_592286488997 /* stp_card_applepay@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_866423752002 /* stp_card_applepay@3x.png */; };
 		BF_594617974909 /* STPCoreViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_547792905644 /* STPCoreViewController.m */; };
-		BF_594700148771 = {isa = PBXBuildFile; fileRef = FR_150667978887 /* PINOperationGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_597354886609 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_887010092861 /* UrlGetViewController.xib */; };
-		BF_598465238180 = {isa = PBXBuildFile; fileRef = FR_160370391416 /* STPSourceCardDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_600213518152 = {isa = PBXBuildFile; fileRef = FR_739869940011 /* STPAPIClient+ApplePay.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_600853055738 = {isa = PBXBuildFile; fileRef = FR_303363389556 /* NSError+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_601678502290 /* stp_card_mastercard_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_914734393950 /* stp_card_mastercard_template@3x.png */; };
-		BF_604355301598 = {isa = PBXBuildFile; fileRef = FR_524308052075 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */; };
-		BF_604663226147 = {isa = PBXBuildFile; fileRef = FR_200260125720 /* STPEphemeralKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_605229525146 = {isa = PBXBuildFile; fileRef = FR_169948489485 /* STPSourceVerification.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_606131506463 = {isa = PBXBuildFile; fileRef = FR_627505725116 /* STPFile+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_606449406959 /* STPUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_634891479805 /* STPUserInformation.m */; };
-		BF_606517652790 = {isa = PBXBuildFile; fileRef = FR_113418609357 /* STPLegalEntityParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_607172519619 = {isa = PBXBuildFile; fileRef = "FR_611231413868-1" /* PINDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_608120527845 = {isa = PBXBuildFile; fileRef = FR_618722400902 /* StripeError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_608151538300 /* STPCard.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_371561332475 /* STPCard.m */; };
-		BF_608759314674 = {isa = PBXBuildFile; fileRef = FR_573089660403 /* UIViewController+Stripe_KeyboardAvoiding.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_609777712924 = {isa = PBXBuildFile; fileRef = FR_540393113192 /* PINCache-Arc-exception-safe-ios-9.0.a */; };
-		BF_610094106674 = {isa = PBXBuildFile; fileRef = FR_344043994904 /* STPMultipartFormDataEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_610780267021 = {isa = PBXBuildFile; fileRef = FR_367740908522 /* NSBundle+Stripe_AppName.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_611499251324 = {isa = PBXBuildFile; fileRef = FR_793362014210 /* STPSwitchTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_613056099577 /* NSArray+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_857114782727 /* NSArray+Stripe.m */; };
-		BF_613455501196 = {isa = PBXBuildFile; fileRef = "FR_845699426889-1" /* STPPhoneNumberValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_613662118617 = {isa = PBXBuildFile; fileRef = FR_883876637273 /* PINOperationMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_614157202241 /* libPINCache-Arc-exception-safe-ios-11.3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_413373192620 /* libPINCache-Arc-exception-safe-ios-11.3.a */; };
-		BF_616423449294 = {isa = PBXBuildFile; fileRef = FR_150667978887 /* PINOperationGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_616863535740 = {isa = PBXBuildFile; fileRef = FR_347917955852 /* STPSourceVerification+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_617180186827 = {isa = PBXBuildFile; fileRef = FR_679194175341 /* STPBlocks.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_619165246202 /* STPPaymentActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_847087900331 /* STPPaymentActivityIndicatorView.m */; };
 		BF_619760599042 /* STPSourceOwner.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_761061955139 /* STPSourceOwner.m */; };
-		BF_619933653443 = {isa = PBXBuildFile; fileRef = FR_507863811111 /* STPCustomer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_621558360376 = {isa = PBXBuildFile; fileRef = FR_192292988800 /* PINCacheMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_622220407417 /* NSError+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_136387137481-1" /* NSError+Stripe.m */; };
 		BF_624140904670 /* stp_card_unknown.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_458081448840 /* stp_card_unknown.png */; };
 		BF_624388286307 /* STPTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_218958582687 /* STPTheme.m */; };
 		BF_624533472251 /* stp_card_jcb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_498036443375 /* stp_card_jcb@2x.png */; };
-		BF_624596357421 = {isa = PBXBuildFile; fileRef = FR_243789410170 /* share-extension.appex */; };
-		BF_625326543835 = {isa = PBXBuildFile; fileRef = FR_813294530495 /* Stripe-ios-9.0.a */; };
 		BF_625777932861 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_887010092861 /* UrlGetViewController.xib */; };
 		BF_625910032218 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_747790741358-1" /* STPSourcePoller.m */; };
 		BF_626697178248 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_353990188355 /* GoogleAppIndexing.framework */; };
 		BF_627749579000 /* stp_card_mastercard_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_914737022420 /* stp_card_mastercard_template@2x.png */; };
 		BF_628380396410 /* UIViewController+Stripe_Promises.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_904866835747 /* UIViewController+Stripe_Promises.m */; };
-		BF_628838191712 = {isa = PBXBuildFile; fileRef = FR_828800361135 /* STPSourceParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_629716594941 = {isa = PBXBuildFile; fileRef = FR_884927251036 /* STPAPIResponseDecodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_632117953374 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_447194245190 /* Tests2.m */; };
 		BF_632167503271 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_887010092861 /* UrlGetViewController.xib */; };
-		BF_632480246006 = {isa = PBXBuildFile; fileRef = FR_149344760381 /* STPCoreScrollViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_632971591497 = {isa = PBXBuildFile; fileRef = FR_319111102880 /* NSBundle+Stripe_AppName.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_633647804116 /* STPSourceRedirect.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_770817608373 /* STPSourceRedirect.m */; };
 		BF_638181999525 /* NSDecimalNumber+Stripe_Currency.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_485300186977 /* NSDecimalNumber+Stripe_Currency.m */; };
 		BF_638318951126 /* STPCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_764679247202 /* STPCustomerContext.m */; };
-		BF_638709779649 = {isa = PBXBuildFile; fileRef = FR_720729207925 /* STPCardIOProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_639097854181 = {isa = PBXBuildFile; fileRef = FR_296053825144 /* STPPaymentActivityIndicatorView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_639227349035 = {isa = PBXBuildFile; fileRef = FR_476338718337 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_639971554994 = {isa = PBXBuildFile; fileRef = FR_551038918304 /* STPToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_640845129218 = {isa = PBXBuildFile; fileRef = "FR_375651978668-1" /* STPFormEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_641847747226 /* STPAddressViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_650044337253-1" /* STPAddressViewModel.m */; };
-		BF_644061343087 = {isa = PBXBuildFile; fileRef = FR_544868232734 /* STPPaymentContext+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_644423025658 /* libStripe-ios-11.3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_334313231181 /* libStripe-ios-11.3.a */; };
 		BF_644483827733 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_235441027813 /* STPSource.m */; };
-		BF_645021865063 = {isa = PBXBuildFile; fileRef = FR_192292988800 /* PINCacheMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_645283015181 = {isa = PBXBuildFile; fileRef = FR_411337456535 /* STPAnalyticsClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_647200911547 /* STPAspects.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_225093974291 /* STPAspects.m */; };
 		BF_647333681922 /* STPCardIOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_803655950633-1" /* STPCardIOProxy.m */; };
 		BF_648083042725 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_490229470460-1" /* NSURLComponents+Stripe.m */; };
 		BF_650211204451 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_205813692671 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
 		BF_651974698404 /* stp_card_form_front@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_767601579243 /* stp_card_form_front@2x.png */; };
-		BF_654894276374 = {isa = PBXBuildFile; fileRef = FR_479483572541 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_657456269763 /* stp_card_unknown@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_653524283850 /* stp_card_unknown@2x.png */; };
 		BF_657639625002 /* NoArc.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_454823234837 /* NoArc.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		BF_658953945027 = {isa = PBXBuildFile; fileRef = FR_778931539736 /* STPSourceParams+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_659100709688 = {isa = PBXBuildFile; fileRef = FR_226012233892 /* STPPaymentConfiguration+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_659673992742 = {isa = PBXBuildFile; fileRef = FR_319645862806 /* STPSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_659702176864 = {isa = PBXBuildFile; fileRef = "FR_836284080868-1" /* STPTelemetryClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_659706535381 = {isa = PBXBuildFile; fileRef = FR_383188188562 /* STPCategoryLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_659978449515 = {isa = PBXBuildFile; fileRef = FR_711062668967 /* STPCard.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_660095557431 = {isa = PBXBuildFile; fileRef = FR_699522203998 /* NSArray+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_660644608808 /* STPColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_573822806939 /* STPColorUtils.m */; };
-		BF_660937928878 = {isa = PBXBuildFile; fileRef = FR_835891206247 /* PINOperationQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_661377798121 = {isa = PBXBuildFile; fileRef = FR_149344760381 /* STPCoreScrollViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_661627496843 = {isa = PBXBuildFile; fileRef = FR_138203417337 /* STPAPIClient+ApplePay.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_662578892143 /* STPPaymentActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_847087900331 /* STPPaymentActivityIndicatorView.m */; };
-		BF_662895701526 = {isa = PBXBuildFile; fileRef = FR_328574352852 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_663288025947 = {isa = PBXBuildFile; fileRef = FR_401789639718 /* STPStringUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_663833034266 = {isa = PBXBuildFile; fileRef = FR_519940329301 /* STPUserInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_663916914655 = {isa = PBXBuildFile; fileRef = FR_704991007882 /* STPImageLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_663981271360 = {isa = PBXBuildFile; fileRef = FR_694358125905 /* Fabric+FABKits.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_665438464028 = {isa = PBXBuildFile; fileRef = FR_485300186976 /* NSDecimalNumber+Stripe_Currency.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_665687528743 = {isa = PBXBuildFile; fileRef = FR_141732336605 /* STPCardValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_665946496524 = {isa = PBXBuildFile; fileRef = FR_573019928512 /* STPPaymentActivityIndicatorView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_666481012883 = {isa = PBXBuildFile; fileRef = FR_754231351934 /* STPSourceCardDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_668170811388 = {isa = PBXBuildFile; fileRef = FR_871742726913 /* STPAPIClient+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_668455642732 = {isa = PBXBuildFile; fileRef = FR_282440445482 /* STPBankAccountParams+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_668530090837 = {isa = PBXBuildFile; fileRef = FR_264154326158 /* STPPaymentContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_668720262946 = {isa = PBXBuildFile; fileRef = FR_326429966766 /* STPSourceEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_668749165824 = {isa = PBXBuildFile; fileRef = FR_708756170642 /* STPSourceCardDetails+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_669507786727 = {isa = PBXBuildFile; fileRef = FR_448345672017 /* FABKitProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_670384869498 /* STPConnectAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_795421255062 /* STPConnectAccountParams.m */; };
-		BF_671862045309 = {isa = PBXBuildFile; fileRef = FR_305934251603 /* STPPaymentMethodsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_671889331007 /* UrlGetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_761662219184-1" /* UrlGetViewController.m */; };
-		BF_672742706904 = {isa = PBXBuildFile; fileRef = FR_385860430238 /* STPCategoryLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_672812697537 /* STPPhoneNumberValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_845699426889 /* STPPhoneNumberValidator.m */; };
 		BF_673363358977 /* STPCustomer+SourceTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_180708382140 /* STPCustomer+SourceTuple.m */; };
-		BF_673603844240 = {isa = PBXBuildFile; fileRef = FR_266195411392 /* STPMultipartFormDataEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_675484410931 = {isa = PBXBuildFile; fileRef = "FR_375651978668-1" /* STPFormEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_676108111271 /* STPUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_634891479805 /* STPUserInformation.m */; };
-		BF_677866349175 = {isa = PBXBuildFile; fileRef = FR_953710188013 /* UIViewController+Stripe_Promises.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_677961554122 /* STPImageLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_314016843022 /* STPImageLibrary.m */; };
-		BF_679368332157 = {isa = PBXBuildFile; fileRef = FR_238855777613 /* STPBankAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_680096215864 /* stp_card_error_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_728079807747 /* stp_card_error_amex.png */; };
-		BF_680172924599 = {isa = PBXBuildFile; fileRef = FR_307274708587 /* UIImage+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_680336332058 = {isa = PBXBuildFile; fileRef = FR_169948489485 /* STPSourceVerification.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_680393245728 = {isa = PBXBuildFile; fileRef = FR_606866437089 /* STPPaymentMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_680660202627 = {isa = PBXBuildFile; fileRef = FR_468896292749 /* STPEphemeralKeyProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_682536272872 /* UIView+Stripe_SafeAreaBounds.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_394531061746-1" /* UIView+Stripe_SafeAreaBounds.m */; };
 		BF_682900860588 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_447194245190 /* Tests2.m */; };
-		BF_683140226702 = {isa = PBXBuildFile; fileRef = FR_490229470460 /* NSURLComponents+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_685362898514 = {isa = PBXBuildFile; fileRef = FR_891431900870 /* STPDispatchFunctions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_688145523837 = {isa = PBXBuildFile; fileRef = FR_407393141614 /* STPSourceProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_688727038308 = {isa = PBXBuildFile; fileRef = "FR_857114782727-1" /* NSArray+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_690195866293 = {isa = PBXBuildFile; fileRef = FR_838755216449 /* STPImageLibrary+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_691269567943 /* stp_card_jcb_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_584192437806 /* stp_card_jcb_template.png */; };
-		BF_691351938899 = {isa = PBXBuildFile; fileRef = FR_657046115910 /* STPEmailAddressValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_692419577420 = {isa = PBXBuildFile; fileRef = FR_779405691145 /* STPCoreTableViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_693048742907 = {isa = PBXBuildFile; fileRef = FR_760644560579 /* STPPhoneNumberValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_693216638111 = {isa = PBXBuildFile; fileRef = FR_544868232734 /* STPPaymentContext+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_693418203202 /* STPBINRange.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_670697261324 /* STPBINRange.m */; };
 		BF_695166312425 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_205813692671 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
 		BF_696239529970 /* stp_card_mastercard_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_719224241995 /* stp_card_mastercard_template.png */; };
 		BF_696341792458 /* STPAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_744571361438-1" /* STPAPIRequest.m */; };
-		BF_698299247491 = {isa = PBXBuildFile; fileRef = FR_135654520087 /* STPFormEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_698953236161 = {isa = PBXBuildFile; fileRef = "FR_611231413868-1" /* PINDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_699048025356 = {isa = PBXBuildFile; fileRef = FR_416552303869 /* STPCardBrand.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_702488203596 /* STPPaymentCardTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_438132085983 /* STPPaymentCardTextField.m */; };
 		BF_703680853725 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_784978928035 /* UIViewController+Stripe_KeyboardAvoiding.m */; };
-		BF_703966474743 = {isa = PBXBuildFile; fileRef = FR_709442092021 /* STPPaymentMethodTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_703994405433 /* STPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_538535395111 /* STPToken.m */; };
 		BF_704390356650 /* STPBINRange.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_670697261324 /* STPBINRange.m */; };
-		BF_705037015553 = {isa = PBXBuildFile; fileRef = FR_118440206517 /* PINOperationTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_705044688044 = {isa = PBXBuildFile; fileRef = FR_328574352852 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_707814673242 = {isa = PBXBuildFile; fileRef = FR_699522203998 /* NSArray+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_707958902606 /* stp_test_upload_image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = FR_791168379253 /* stp_test_upload_image.jpeg */; };
-		BF_708314003879 = {isa = PBXBuildFile; fileRef = FR_676905157532 /* STPURLCallbackHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_708592615926 = {isa = PBXBuildFile; fileRef = FR_394531061746 /* UIView+Stripe_SafeAreaBounds.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_709812349499 /* stp_icon_checkmark@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_462265337593 /* stp_icon_checkmark@2x.png */; };
 		BF_709965398842 /* stp_shipping_form@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_166108154819 /* stp_shipping_form@2x.png */; };
 		BF_710724944264 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_319111102880-1" /* NSBundle+Stripe_AppName.m */; };
-		BF_711188535180 = {isa = PBXBuildFile; fileRef = FR_525936809580 /* PINCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_711601184052 = {isa = PBXBuildFile; fileRef = FR_859356790791 /* STPTelemetryClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_711845287527 = {isa = PBXBuildFile; fileRef = "FR_318471428702-1" /* STPPaymentMethodTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_712538039722 = {isa = PBXBuildFile; fileRef = FR_790877768775 /* STPPaymentCardTextFieldViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_712602684753 /* stp_card_diners_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_329418993821 /* stp_card_diners_template@2x.png */; };
-		BF_713704607583 = {isa = PBXBuildFile; fileRef = FR_169157621063 /* STPPaymentResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_713769800062 = {isa = PBXBuildFile; fileRef = FR_179612585631 /* UINavigationController+Stripe_Completion.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_714670612580 = {isa = PBXBuildFile; fileRef = FR_582943901244 /* STPUserInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_715768618037 = {isa = PBXBuildFile; fileRef = FR_196722873933 /* Stripe-ios-11.3.a */; };
-		BF_716054629237 = {isa = PBXBuildFile; fileRef = FR_480331574684 /* UINavigationBar+Stripe_Theme.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_716143536218 /* STPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_538535395111 /* STPToken.m */; };
 		BF_716920207658 /* stp_card_diners_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_329419374230 /* stp_card_diners_template@3x.png */; };
 		BF_719520352570 /* stp_card_error@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_550565498786 /* stp_card_error@3x.png */; };
-		BF_720418627751 = {isa = PBXBuildFile; fileRef = FR_829657687624 /* NSMutableURLRequest+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_720610071695 = {isa = PBXBuildFile; fileRef = FR_489565775328 /* STPSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_720651212683 = {isa = PBXBuildFile; fileRef = FR_612435877299 /* STPSourceOwner.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_721028611198 = {isa = PBXBuildFile; fileRef = FR_484428159681 /* STPCoreTableViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_721271532741 /* STPFormEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_375651978668 /* STPFormEncoder.m */; };
-		BF_721387192174 = {isa = PBXBuildFile; fileRef = "FR_180708382140-1" /* STPCustomer+SourceTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_724018934696 /* stp_card_visa_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_161686194489 /* stp_card_visa_template@3x.png */; };
-		BF_724308403804 = {isa = PBXBuildFile; fileRef = FR_707080851040 /* Stripe-Stripe_Bundle_Stripe-ios-11.3.bundle */; };
-		BF_724710090995 = {isa = PBXBuildFile; fileRef = FR_309446203354 /* STPCard.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_725333150487 = {isa = PBXBuildFile; fileRef = FR_627505725116 /* STPFile+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_725809361769 = {isa = PBXBuildFile; fileRef = FR_891417925643 /* STPSourceRedirect+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_725926496061 = {isa = PBXBuildFile; fileRef = FR_761662219184 /* UrlGetViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_726182205540 /* STPShippingMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_805980394107 /* STPShippingMethodTableViewCell.m */; };
 		BF_726887199051 /* stp_card_unknown.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_458081448840 /* stp_card_unknown.png */; };
-		BF_729358124219 = {isa = PBXBuildFile; fileRef = FR_327069580859 /* STPSource+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_729370779234 = {isa = PBXBuildFile; fileRef = FR_141732336605 /* STPCardValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_729565343289 /* PINOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_898827650356-1" /* PINOperationQueue.m */; };
 		BF_729766328605 /* STPPaymentCardTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_438132085983 /* STPPaymentCardTextField.m */; };
-		BF_730186687386 = {isa = PBXBuildFile; fileRef = FR_635484072488 /* PINOperationMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_730365141006 /* STPPaymentCardTextFieldViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_352992722793 /* STPPaymentCardTextFieldViewModel.m */; };
 		BF_730930168105 /* UrlGetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_761662219184-1" /* UrlGetViewController.m */; };
 		BF_730994754938 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_518266894407 /* libStripe-ios-9.0.a */; };
-		BF_733476817034 = {isa = PBXBuildFile; fileRef = FR_863295554989 /* STPDispatchFunctions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_733652606465 = {isa = PBXBuildFile; fileRef = FR_661294188967 /* STPShippingAddressViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_734763667839 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_104204687231 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
 		BF_735260424658 /* STPPaymentMethodsInternalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_303088826339 /* STPPaymentMethodsInternalViewController.m */; };
-		BF_735799510610 = {isa = PBXBuildFile; fileRef = FR_383188188562 /* STPCategoryLoader.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_736853355674 = {isa = PBXBuildFile; fileRef = FR_349373308093 /* STPSourceReceiver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_737308335445 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_740003049424 /* STPBankAccountParams.m */; };
 		BF_737678661541 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_114615500587 /* PKPayment+Stripe.m */; };
-		BF_737795439122 = {isa = PBXBuildFile; fileRef = FR_501678888554 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_741290718883 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_595618312739 /* libPINCache-Core-ios-9.0.a */; };
-		BF_741348994208 = {isa = PBXBuildFile; fileRef = FR_903454413342 /* STPFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_742918505912 = {isa = PBXBuildFile; fileRef = FR_616663993966 /* STPPaymentContext+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_743198081299 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_104204687231 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
 		BF_743467796528 /* stp_card_mastercard_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_914734393950 /* stp_card_mastercard_template@3x.png */; };
-		BF_744129290163 = {isa = PBXBuildFile; fileRef = FR_490229470460 /* NSURLComponents+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_744852022199 = {isa = PBXBuildFile; fileRef = FR_584380253982 /* PINDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_746261684005 /* STPSourceCardDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_689735932342 /* STPSourceCardDetails.m */; };
-		BF_746284640752 = {isa = PBXBuildFile; fileRef = FR_226012233892 /* STPPaymentConfiguration+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_746767725611 = {isa = PBXBuildFile; fileRef = FR_679194175341 /* STPBlocks.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_749423264532 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_344823093939 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */; };
 		BF_750570579564 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_611231413868 /* PINDiskCache.m */; };
 		BF_750850029603 /* UINavigationController+Stripe_Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_746622613527 /* UINavigationController+Stripe_Completion.m */; };
 		BF_751036638648 /* STPCard.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_371561332475 /* STPCard.m */; };
 		BF_751727897601 /* stp_card_discover.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_485714325221 /* stp_card_discover.png */; };
-		BF_753115900519 = {isa = PBXBuildFile; fileRef = FR_529018358997 /* STPPaymentMethodTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_753205124319 = {isa = PBXBuildFile; fileRef = FR_676905157532 /* STPURLCallbackHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_754436355955 /* stp_card_mastercard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_160191367084 /* stp_card_mastercard@2x.png */; };
 		BF_755282272245 /* UIViewController+Stripe_ParentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_866814615747 /* UIViewController+Stripe_ParentViewController.m */; };
-		BF_758061132601 = {isa = PBXBuildFile; fileRef = FR_504172386443 /* STPPaymentCardTextFieldCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_759141593816 /* stp_card_visa_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_161685209527 /* stp_card_visa_template@2x.png */; };
-		BF_759212323776 = {isa = PBXBuildFile; fileRef = FR_237398221790 /* STPBankAccountParams+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_759468879883 /* stp_card_jcb@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_554896677909 /* stp_card_jcb@3x.png */; };
 		BF_761040028655 /* STPSourceVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_431507780270 /* STPSourceVerification.m */; };
-		BF_761696366169 = {isa = PBXBuildFile; fileRef = FR_780452303071 /* STPTheme.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_763994124514 = {isa = PBXBuildFile; fileRef = FR_159160499476 /* PINOperationTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_764139746955 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_518266894407 /* libStripe-ios-9.0.a */; };
 		BF_764589198900 /* STPCoreTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_175464452737 /* STPCoreTableViewController.m */; };
-		BF_764790607394 = {isa = PBXBuildFile; fileRef = FR_244377844184 /* STPAddCardViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_765177499875 /* stp_card_discover@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_460546061817 /* stp_card_discover@3x.png */; };
 		BF_765712413593 /* STPBankAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_520364995872 /* STPBankAccount.m */; };
-		BF_767464321021 = {isa = PBXBuildFile; fileRef = FR_211137171978 /* STPApplePayPaymentMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_768185306849 /* stp_card_form_back@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_471192665951 /* stp_card_form_back@2x.png */; };
 		BF_768471797584 /* stp_icon_add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_644827855298 /* stp_icon_add@3x.png */; };
 		BF_769011939867 /* STPCustomer.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_775444959222 /* STPCustomer.m */; };
-		BF_769834796822 = {isa = PBXBuildFile; fileRef = FR_714908972385 /* Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_770253189892 = {isa = PBXBuildFile; fileRef = FR_203734164041 /* STPPaymentMethodsViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_770908080194 /* STPBundleLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_433875149495 /* STPBundleLocator.m */; };
 		BF_771252936417 /* STPBundleLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_433875149495 /* STPBundleLocator.m */; };
-		BF_772017657414 = {isa = PBXBuildFile; fileRef = FR_448345672017 /* FABKitProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_772473928618 = {isa = PBXBuildFile; fileRef = FR_720729207925 /* STPCardIOProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_773821964844 = {isa = PBXBuildFile; fileRef = "FR_118429332705-1" /* STPEphemeralKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_773929079120 = {isa = PBXBuildFile; fileRef = FR_582257680537 /* STPToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_774226341197 = {isa = PBXBuildFile; fileRef = FR_584380253982 /* PINDiskCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_774781025937 = {isa = PBXBuildFile; fileRef = "FR_225093974291-1" /* STPAspects.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_775094636110 = {isa = PBXBuildFile; fileRef = FR_744357543627 /* PINCacheObjectSubscripting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_775869817833 /* stp_card_mastercard.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_819492685632 /* stp_card_mastercard.png */; };
 		BF_776995690719 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_104204687231 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
 		BF_777042903596 /* NSArray+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_857114782727 /* NSArray+Stripe.m */; };
-		BF_778260386524 = {isa = PBXBuildFile; fileRef = FR_889566942228 /* STPSourceRedirect.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_778389135851 /* UITableViewCell+Stripe_Borders.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_882551670747 /* UITableViewCell+Stripe_Borders.m */; };
 		BF_778975644784 /* stp_card_form_back.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_581387210768 /* stp_card_form_back.png */; };
-		BF_780046012091 = {isa = PBXBuildFile; fileRef = FR_865850458143 /* STPLocalizationUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_780353267060 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_205813692671 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
-		BF_780762639223 = {isa = PBXBuildFile; fileRef = FR_210015125307 /* STPPostalCodeValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_782817186675 = {isa = PBXBuildFile; fileRef = FR_753050319742 /* UIBarButtonItem+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_783445718536 = {isa = PBXBuildFile; fileRef = FR_631274162632 /* STPBINRange.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_785042106556 = {isa = PBXBuildFile; fileRef = FR_387477859828 /* FABKitProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_785144964550 /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_616218057689 /* stp_card_visa@3x.png */; };
-		BF_786030656966 = {isa = PBXBuildFile; fileRef = FR_697092322085 /* STPPaymentMethodsInternalViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_786152625492 = {isa = PBXBuildFile; fileRef = FR_458863902474 /* STPSourceVerification.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_786387336558 = {isa = PBXBuildFile; fileRef = FR_501678888554 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_786464893976 /* stp_card_jcb.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_739797562620 /* stp_card_jcb.png */; };
-		BF_787898877021 = {isa = PBXBuildFile; fileRef = FR_193256557604 /* STPApplePayPaymentMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_788247927438 /* NSString+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_383186939534-1" /* NSString+Stripe.m */; };
 		BF_788315800256 /* stp_card_cvc_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_916856507218 /* stp_card_cvc_amex@3x.png */; };
-		BF_788451627612 = {isa = PBXBuildFile; fileRef = FR_747790741358 /* STPSourcePoller.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_788545040584 = {isa = PBXBuildFile; fileRef = FR_791050653111 /* UIViewController+Stripe_NavigationItemProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_789294932168 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_147245088243 /* libUrlGetClasses-ios-9.0.a */; };
 		BF_790723168256 /* STPPaymentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_466427502225 /* STPPaymentContext.m */; };
 		BF_790802022403 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_388157799616 /* main.m */; };
-		BF_791002913120 = {isa = PBXBuildFile; fileRef = FR_203274481819 /* STPWeakStrongMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_791196815534 = {isa = PBXBuildFile; fileRef = FR_136387137481 /* NSError+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_792086645442 = {isa = PBXBuildFile; fileRef = FR_582943901244 /* STPUserInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_792540141787 /* stp_card_discover.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_485714325221 /* stp_card_discover.png */; };
-		BF_792540246941 = {isa = PBXBuildFile; fileRef = FR_302600842104 /* STPPaymentContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_793403134062 = {isa = PBXBuildFile; fileRef = FR_863295554989 /* STPDispatchFunctions.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_793519242004 = {isa = PBXBuildFile; fileRef = FR_635484072488 /* PINOperationMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_794704307481 /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_308451946297 /* STPAPIClient+ApplePay.m */; };
 		BF_794972634449 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_147245088243 /* libUrlGetClasses-ios-9.0.a */; };
-		BF_795683456547 = {isa = PBXBuildFile; fileRef = FR_573665251373 /* STPImageLibrary.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_795798416899 /* stp_icon_checkmark@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_462265337593 /* stp_icon_checkmark@2x.png */; };
-		BF_795844462272 = {isa = PBXBuildFile; fileRef = FR_805275538402 /* PINCache-Core-ios-11.3.a */; };
-		BF_795981928142 = {isa = PBXBuildFile; fileRef = FR_381304510417 /* STPAPIClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_796039839460 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166622418620 /* Tests.m */; };
 		BF_797689592140 /* stp_card_mastercard_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_719224241995 /* stp_card_mastercard_template.png */; };
-		BF_798223623430 = {isa = PBXBuildFile; fileRef = FR_536748644256 /* STPPaymentConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_798653366710 = {isa = PBXBuildFile; fileRef = FR_192292988800 /* PINCacheMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_798749616868 /* STPConnectAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_795421255062 /* STPConnectAccountParams.m */; };
-		BF_799505379295 = {isa = PBXBuildFile; fileRef = FR_777337581099 /* STPBankAccount.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_799643590551 /* stp_card_error_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_684957154701 /* stp_card_error_amex@2x.png */; };
 		BF_799923208158 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_451065136063 /* UIViewController+Stripe_NavigationItemProxy.m */; };
 		BF_801105503627 /* STPDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_240384147848 /* STPDelegateProxy.m */; };
-		BF_801351537039 = {isa = PBXBuildFile; fileRef = FR_708756170642 /* STPSourceCardDetails+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_801577774717 = {isa = PBXBuildFile; fileRef = FR_493781913276 /* STPColorUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_801730223798 /* NSCharacterSet+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_856763993418 /* NSCharacterSet+Stripe.m */; };
 		BF_801846914366 /* UITableViewCell+Stripe_Borders.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_882551670747 /* UITableViewCell+Stripe_Borders.m */; };
 		BF_803250566133 /* stp_card_amex_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_222214992417 /* stp_card_amex_template.png */; };
-		BF_804248485101 = {isa = PBXBuildFile; fileRef = FR_376986173380 /* STPPaymentCardTextField+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_805521780698 /* UIViewController+Stripe_Promises.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_904866835747 /* UIViewController+Stripe_Promises.m */; };
-		BF_805613178901 = {isa = PBXBuildFile; fileRef = FR_697405215088 /* STPLegalEntityParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_807240198227 /* stp_card_form_front.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_597218262530 /* stp_card_form_front.png */; };
-		BF_807280516748 = {isa = PBXBuildFile; fileRef = FR_159160499476 /* PINOperationTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_809361463000 /* stp_card_cvc.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_275604636587 /* stp_card_cvc.png */; };
 		BF_811880897715 /* STPPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_177669650679-1" /* STPPromise.m */; };
-		BF_814992830555 = {isa = PBXBuildFile; fileRef = FR_638194865189 /* STPSourceParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_815163134429 = {isa = PBXBuildFile; fileRef = FR_820602908989 /* STPEmailAddressValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_816415835885 = {isa = PBXBuildFile; fileRef = FR_737799052203 /* STPAddCardViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_816451214134 = {isa = PBXBuildFile; fileRef = FR_655732831542 /* STPCard+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_817197405994 = {isa = PBXBuildFile; fileRef = FR_266195411392 /* STPMultipartFormDataEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_817202556448 = {isa = PBXBuildFile; fileRef = "FR_140569352166-1" /* STPAnalyticsClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_818170556215 = {isa = PBXBuildFile; fileRef = FR_476338718337 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_819923078927 /* STPShippingAddressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_744666232521 /* STPShippingAddressViewController.m */; };
-		BF_820268426499 = {isa = PBXBuildFile; fileRef = FR_618722400902 /* StripeError.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_822100990639 = {isa = PBXBuildFile; fileRef = FR_803655950633 /* STPCardIOProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_822482091386 = {isa = PBXBuildFile; fileRef = FR_100119553883 /* NSURLComponents+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_822557121935 /* STPTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_218958582687 /* STPTheme.m */; };
-		BF_824758280332 = {isa = PBXBuildFile; fileRef = FR_392500181869 /* STPBundleLocator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_824976249397 = {isa = PBXBuildFile; fileRef = "FR_417020094137-1" /* STPURLCallbackHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_829660382426 = {isa = PBXBuildFile; fileRef = FR_200260125720 /* STPEphemeralKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_830016591366 = {isa = PBXBuildFile; fileRef = FR_772386701230 /* Fabric.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_830617785463 = {isa = PBXBuildFile; fileRef = FR_215562581198 /* STPEphemeralKeyManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_831094931137 = {isa = PBXBuildFile; fileRef = "FR_181346025846-1" /* STPPostalCodeValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_831697474059 /* libPINCache-Core-ios-11.3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_683369487726 /* libPINCache-Core-ios-11.3.a */; };
-		BF_832188576818 = {isa = PBXBuildFile; fileRef = FR_290482945381 /* STPAddCardViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_832477120178 = {isa = PBXBuildFile; fileRef = FR_479483572541 /* PINMemoryCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_832513147851 = {isa = PBXBuildFile; fileRef = FR_374398035812 /* STPLocalizationUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_833762840956 = {isa = PBXBuildFile; fileRef = FR_416552303869 /* STPCardBrand.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_834502484694 /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_464213115625 /* stp_card_visa@2x.png */; };
-		BF_835036587262 = {isa = PBXBuildFile; fileRef = FR_555038450084 /* STPCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_835142956640 = {isa = PBXBuildFile; fileRef = FR_264154326158 /* STPPaymentContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_837589283931 /* UINavigationBar+Stripe_Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_486615080111 /* UINavigationBar+Stripe_Theme.m */; };
 		BF_839039646076 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_393824443136 /* STPPaymentContextAmountModel.m */; };
-		BF_839427036108 = {isa = PBXBuildFile; fileRef = FR_515110400273 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_839626557771 = {isa = PBXBuildFile; fileRef = FR_809418927836 /* STPDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_840089615448 = {isa = PBXBuildFile; fileRef = FR_986136575822 /* STPInternalAPIResponseDecodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_840726057911 = {isa = PBXBuildFile; fileRef = FR_175169517365 /* STPCoreTableViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_841935752095 = {isa = PBXBuildFile; fileRef = FR_563291007487 /* STPCoreViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_842714463720 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_207298251625 /* STPAddress.m */; };
 		BF_843119778099 /* STPPaymentCardTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_786851096829 /* STPPaymentCardTextFieldCell.m */; };
 		BF_843248890798 /* stp_card_form_back@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_435082555494 /* stp_card_form_back@3x.png */; };
-		BF_844633371340 = {isa = PBXBuildFile; fileRef = FR_697092322085 /* STPPaymentMethodsInternalViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_845240551496 = {isa = PBXBuildFile; fileRef = FR_100956106933 /* PINOperationGroup.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_846406569992 = {isa = PBXBuildFile; fileRef = "FR_845699426889-1" /* STPPhoneNumberValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_846443168559 = {isa = PBXBuildFile; fileRef = "FR_318471428702-1" /* STPPaymentMethodTuple.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_846830351357 = {isa = PBXBuildFile; fileRef = FR_458863902474 /* STPSourceVerification.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_846899687257 = {isa = PBXBuildFile; fileRef = FR_650044337253 /* STPAddressViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_847176220872 = {isa = PBXBuildFile; fileRef = FR_175169517365 /* STPCoreTableViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_847552913861 = {isa = PBXBuildFile; fileRef = FR_583546727827 /* UnitTestsWithHost.xctest */; };
-		BF_848756351332 = {isa = PBXBuildFile; fileRef = FR_344043994904 /* STPMultipartFormDataEncoder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_849479514763 /* NSCharacterSet+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_856763993418 /* NSCharacterSet+Stripe.m */; };
 		BF_851253922391 /* stp_card_cvc_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_648806668237 /* stp_card_cvc_amex.png */; };
-		BF_852284787970 = {isa = PBXBuildFile; fileRef = FR_549563930037 /* STPTheme.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_853313240353 = {isa = PBXBuildFile; fileRef = FR_240384147847 /* STPDelegateProxy.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_853426292601 = {isa = PBXBuildFile; fileRef = "FR_433875149495-1" /* STPBundleLocator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_854863965172 = {isa = PBXBuildFile; fileRef = FR_786851096828 /* STPPaymentCardTextFieldCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_854999455782 /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_201151680337-1" /* PINCache.m */; };
-		BF_857208219836 = {isa = PBXBuildFile; fileRef = FR_506863260541 /* STPCoreScrollViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_857559394474 = {isa = PBXBuildFile; fileRef = FR_731018226313 /* UIViewController+Stripe_ParentViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_858745824810 = {isa = PBXBuildFile; fileRef = FR_504279331501 /* STPAPIRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_859207755337 /* stp_card_mastercard_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_914737022420 /* stp_card_mastercard_template@2x.png */; };
-		BF_859685365676 = {isa = PBXBuildFile; fileRef = FR_147204469035 /* STPConnectAccountParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_860171403765 = {isa = PBXBuildFile; fileRef = "FR_866814615747-1" /* UIViewController+Stripe_ParentViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_860471874636 = {isa = PBXBuildFile; fileRef = FR_201151680337 /* PINCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_860519968012 = {isa = PBXBuildFile; fileRef = FR_374398035812 /* STPLocalizationUtils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_860651083458 = {isa = PBXBuildFile; fileRef = FR_618474416247 /* STPAddCardViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_860744836015 = {isa = PBXBuildFile; fileRef = FR_284380484049 /* STPSectionHeaderView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_861336833852 /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_221232691707 /* STPAddressFieldTableViewCell.m */; };
-		BF_861488228472 = {isa = PBXBuildFile; fileRef = FR_882551670748 /* UITableViewCell+Stripe_Borders.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_862511456394 = {isa = PBXBuildFile; fileRef = FR_411337456535 /* STPAnalyticsClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_863800981163 = {isa = PBXBuildFile; fileRef = FR_753050319742 /* UIBarButtonItem+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_864636632695 = {isa = PBXBuildFile; fileRef = FR_553085332782 /* STPCardValidator.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_865076893494 = {isa = PBXBuildFile; fileRef = "FR_866814615747-1" /* UIViewController+Stripe_ParentViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_865102949522 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_344823093939 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */; };
-		BF_867136225251 = {isa = PBXBuildFile; fileRef = FR_953710188013 /* UIViewController+Stripe_Promises.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_868096046116 = {isa = PBXBuildFile; fileRef = FR_904866835750 /* UIViewController+Stripe_Promises.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_868282965233 /* stp_card_unionpay_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_256481006549 /* stp_card_unionpay_en.png */; };
 		BF_869586500948 /* stp_card_cvc_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_441695822925 /* stp_card_cvc_amex@2x.png */; };
-		BF_872499368347 = {isa = PBXBuildFile; fileRef = FR_777944667952 /* STPSourceProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_874745161620 = {isa = PBXBuildFile; fileRef = FR_838755216449 /* STPImageLibrary+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_875070309461 = {isa = PBXBuildFile; fileRef = FR_519916175206 /* STPCustomer+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_875649997485 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_742895067730 /* libPINOperation-ios-9.0.a */; };
 		BF_876890323199 /* stp_card_cvc@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_202016520148 /* stp_card_cvc@2x.png */; };
-		BF_876900004338 = {isa = PBXBuildFile; fileRef = FR_311576797096 /* STPMultipartFormDataPart.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_878073784080 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_742895067730 /* libPINOperation-ios-9.0.a */; };
-		BF_878372444665 = {isa = PBXBuildFile; fileRef = FR_265776775943 /* UIToolbar+Stripe_InputAccessory.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_879023557676 = {isa = PBXBuildFile; fileRef = FR_823402288931 /* STPAddress.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_879210300637 = {isa = PBXBuildFile; fileRef = FR_514597362078 /* STPAPIClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_881459130844 /* STPSourceReceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_793128565775 /* STPSourceReceiver.m */; };
-		BF_883762723460 = {isa = PBXBuildFile; fileRef = FR_642952555060 /* PINCacheObjectSubscripting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_884995049144 /* STPEphemeralKeyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_170908667679 /* STPEphemeralKeyManager.m */; };
 		BF_885899011351 /* stp_card_diners.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_315436813377 /* stp_card_diners.png */; };
 		BF_887553915782 /* stp_card_jcb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_498036443375 /* stp_card_jcb@2x.png */; };
-		BF_888478259638 = {isa = PBXBuildFile; fileRef = FR_573019928512 /* STPPaymentActivityIndicatorView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_888620683913 /* stp_card_unionpay_template_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_440272897295 /* stp_card_unionpay_template_en@2x.png */; };
-		BF_888908348293 = {isa = PBXBuildFile; fileRef = FR_341536377834 /* STPSourceParams+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_889037580985 = {isa = PBXBuildFile; fileRef = FR_884927251036 /* STPAPIResponseDecodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_889500150747 = {isa = PBXBuildFile; fileRef = FR_474473428077 /* UITableViewCell+Stripe_Borders.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_889743287133 = {isa = PBXBuildFile; fileRef = FR_808039309519 /* STPSourceRedirect+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_892241538456 /* stp_card_cvc@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_202016520148 /* stp_card_cvc@2x.png */; };
-		BF_892368339957 = {isa = PBXBuildFile; fileRef = FR_331004124905 /* STPCardParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_892762272109 /* stp_card_cvc@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_150617010141 /* stp_card_cvc@3x.png */; };
 		BF_892886647641 /* stp_card_unionpay_template_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_438213232580 /* stp_card_unionpay_template_zh@2x.png */; };
-		BF_893880327647 = {isa = PBXBuildFile; fileRef = FR_519916175206 /* STPCustomer+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_895555773411 = {isa = PBXBuildFile; fileRef = FR_786851096828 /* STPPaymentCardTextFieldCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_896932005981 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_522111507539 /* STPRedirectContext.m */; };
-		BF_897363794332 = {isa = PBXBuildFile; fileRef = FR_697115907292 /* FauxPasAnnotations.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_897852631263 = {isa = PBXBuildFile; fileRef = FR_862049125356 /* STPFile+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_898858379336 = {isa = PBXBuildFile; fileRef = FR_680138288521 /* PINCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_899497438648 = {isa = PBXBuildFile; fileRef = "FR_140569352166-1" /* STPAnalyticsClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_900114457141 = {isa = PBXBuildFile; fileRef = FR_883876637273 /* PINOperationMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_900832224223 = {isa = PBXBuildFile; fileRef = FR_504279331501 /* STPAPIRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_902260122620 = {isa = PBXBuildFile; fileRef = FR_381304510417 /* STPAPIClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_902797237263 = {isa = PBXBuildFile; fileRef = FR_606586344904 /* STPAspects.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_903449840898 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_147245088243 /* libUrlGetClasses-ios-9.0.a */; };
-		BF_903548823705 = {isa = PBXBuildFile; fileRef = FR_790877768775 /* STPPaymentCardTextFieldViewModel.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_903899752134 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_740003049424 /* STPBankAccountParams.m */; };
 		BF_905507208473 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_479483572541-1" /* PINMemoryCache.m */; };
-		BF_905612453820 = {isa = PBXBuildFile; fileRef = FR_287994782021 /* STPFormEncodable.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_906180987591 = {isa = PBXBuildFile; fileRef = FR_613101804389 /* STPSourceReceiver.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_908160770801 = {isa = PBXBuildFile; fileRef = FR_436439106628 /* NSCharacterSet+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_908168907899 /* STPImageLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_314016843022 /* STPImageLibrary.m */; };
-		BF_908739877432 = {isa = PBXBuildFile; fileRef = FR_221232691705 /* STPAddressFieldTableViewCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_909193330161 = {isa = PBXBuildFile; fileRef = FR_920174354034 /* STPFormTextField.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_910614995151 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_207298251625 /* STPAddress.m */; };
-		BF_911004974888 = {isa = PBXBuildFile; fileRef = FR_383186939534 /* NSString+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_911269974269 = {isa = PBXBuildFile; fileRef = FR_727895182634 /* STPCoreViewController+Private.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_912053652725 = {isa = PBXBuildFile; fileRef = FR_545855187610 /* STPPaymentMethodsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_912080281901 /* stp_card_cvc_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_648806668237 /* stp_card_cvc_amex.png */; };
-		BF_912131400259 = {isa = PBXBuildFile; fileRef = FR_744571361438 /* STPAPIRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_913334204211 = {isa = PBXBuildFile; fileRef = FR_303088832029 /* STPPaymentMethodsInternalViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_913430782260 = {isa = PBXBuildFile; fileRef = FR_761662219184 /* UrlGetViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_914150910917 /* STPPaymentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_466427502225 /* STPPaymentContext.m */; };
-		BF_914315484667 = {isa = PBXBuildFile; fileRef = FR_784978929968 /* UIViewController+Stripe_KeyboardAvoiding.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_914665933472 /* stp_shipping_form@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_166108154819 /* stp_shipping_form@2x.png */; };
-		BF_915250501259 = {isa = PBXBuildFile; fileRef = FR_613113088567 /* STPSourceEnums.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_916682364312 /* STPPaymentMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_394482207665 /* STPPaymentMethodsViewController.m */; };
-		BF_916759185284 = {isa = PBXBuildFile; fileRef = FR_357507703280 /* FauxPasAnnotations.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_917099122644 /* PINOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_898827650356-1" /* PINOperationQueue.m */; };
-		BF_918305709368 = {isa = PBXBuildFile; fileRef = FR_878727202200 /* STPEphemeralKeyProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_920165268680 /* STPLocalizationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_374398035813 /* STPLocalizationUtils.m */; };
-		BF_921405190855 = {isa = PBXBuildFile; fileRef = FR_160370391416 /* STPSourceCardDetails.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_922288850271 = {isa = PBXBuildFile; fileRef = FR_211137171978 /* STPApplePayPaymentMethod.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_932136825821 = {isa = PBXBuildFile; fileRef = FR_739869940011 /* STPAPIClient+ApplePay.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BF_949644424763 /* stp_card_unionpay_template_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_436922295096 /* stp_card_unionpay_template_en@3x.png */; };
 		BF_969469422979 /* stp_card_unionpay_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_119347389557 /* stp_card_unionpay_en@3x.png */; };
-		BF_971667789727 = {isa = PBXBuildFile; fileRef = FR_711084170905 /* STPFile.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_977629621462 = {isa = PBXBuildFile; fileRef = "FR_856763993418-1" /* NSCharacterSet+Stripe.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BF_987459362810 = {isa = PBXBuildFile; fileRef = FR_747790741358 /* STPSourcePoller.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1178,10 +539,9 @@
 		"FR_170908667679-1" /* STPEphemeralKeyManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyManager.h; sourceTree = "<group>"; };
 		FR_171962769898 /* UIImage+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Stripe.h"; sourceTree = "<group>"; };
 		"FR_171962769898-1" /* UIImage+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Stripe.m"; sourceTree = "<group>"; };
-		FR_173102942353 /* GeneratedFiles */ = {isa = PBXFileReference; includeInIndex = 0; path = GeneratedFiles; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_175169517365 /* STPCoreTableViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreTableViewController+Private.h"; sourceTree = "<group>"; };
 		FR_175464452737 /* STPCoreTableViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreTableViewController.m; sourceTree = "<group>"; };
-		FR_175704718595 /* UrlGetClasses-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "UrlGetClasses-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_175704718595 /* UrlGetClasses-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "UrlGetClasses-ios-9.0.a"; path = "libUrlGetClasses-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_177669650679 /* STPPromise.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPromise.h; sourceTree = "<group>"; };
 		"FR_177669650679-1" /* STPPromise.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPromise.m; sourceTree = "<group>"; };
 		FR_179612585631 /* UINavigationController+Stripe_Completion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+Stripe_Completion.h"; sourceTree = "<group>"; };
@@ -1189,12 +549,11 @@
 		"FR_180708382140-1" /* STPCustomer+SourceTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+SourceTuple.h"; sourceTree = "<group>"; };
 		FR_181346025846 /* STPPostalCodeValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidator.m; sourceTree = "<group>"; };
 		"FR_181346025846-1" /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
-		FR_183987345262 /* UpdateXcodeProject */ = {isa = PBXFileReference; includeInIndex = 0; path = UpdateXcodeProject; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_190239098214 /* STPShippingMethodsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingMethodsViewController.m; sourceTree = "<group>"; };
 		FR_190239098217 /* STPShippingMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodsViewController.h; sourceTree = "<group>"; };
 		FR_192292988800 /* PINCacheMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheMacros.h; sourceTree = "<group>"; };
 		FR_193256557604 /* STPApplePayPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPApplePayPaymentMethod.h; sourceTree = "<group>"; };
-		FR_196722873933 /* Stripe-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "Stripe-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_196722873933 /* Stripe-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "Stripe-ios-11.3.a"; path = "libStripe-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_200260125720 /* STPEphemeralKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKey.h; sourceTree = "<group>"; };
 		FR_201151680337 /* PINCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCache.h; sourceTree = "<group>"; };
 		"FR_201151680337-1" /* PINCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINCache.m; sourceTree = "<group>"; };
@@ -1225,7 +584,7 @@
 		FR_239638141147 /* StripeError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeError.h; sourceTree = "<group>"; };
 		FR_240384147847 /* STPDelegateProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDelegateProxy.h; sourceTree = "<group>"; };
 		FR_240384147848 /* STPDelegateProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPDelegateProxy.m; sourceTree = "<group>"; };
-		FR_243789410170 /* share-extension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = "share-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_243789410170 /* share-extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "share-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_244377844184 /* STPAddCardViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAddCardViewController+Private.h"; sourceTree = "<group>"; };
 		FR_256481006549 /* stp_card_unionpay_en.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_en.png; sourceTree = "<group>"; };
 		FR_262777658410 /* libUrlGetClasses-ios-11.3.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libUrlGetClasses-ios-11.3.a"; sourceTree = "<group>"; };
@@ -1237,9 +596,11 @@
 		FR_270060349354 /* UIView+Stripe_FirstResponder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_FirstResponder.h"; sourceTree = "<group>"; };
 		"FR_270060349354-1" /* UIView+Stripe_FirstResponder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+Stripe_FirstResponder.m"; sourceTree = "<group>"; };
 		FR_271701757351 /* STPCustomer+SourceTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+SourceTuple.h"; sourceTree = "<group>"; };
+		FR_272405693051 /* Some.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Some.hpp; sourceTree = "<group>"; };
 		FR_275055915589 /* STPSource+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSource+Private.h"; sourceTree = "<group>"; };
 		FR_275604636587 /* stp_card_cvc.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_cvc.png; sourceTree = "<group>"; };
 		FR_276366160308 /* StripeError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StripeError.m; sourceTree = "<group>"; };
+		FR_282022996649 /* Some.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Some.cc; sourceTree = "<group>"; };
 		FR_282440445482 /* STPBankAccountParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPBankAccountParams+Private.h"; sourceTree = "<group>"; };
 		FR_283825756115 /* STPSourceSEPADebitDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceSEPADebitDetails.h; sourceTree = "<group>"; };
 		FR_284380484049 /* STPSectionHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSectionHeaderView.h; sourceTree = "<group>"; };
@@ -1359,7 +720,7 @@
 		FR_458081448840 /* stp_card_unknown.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unknown.png; sourceTree = "<group>"; };
 		FR_458863902474 /* STPSourceVerification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceVerification.h; sourceTree = "<group>"; };
 		FR_458974510861 /* stp_card_applepay@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_applepay@2x.png"; sourceTree = "<group>"; };
-		FR_460131545307 /* UrlGetClasses-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "UrlGetClasses-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_460131545307 /* UrlGetClasses-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "UrlGetClasses-ios-11.3.a"; path = "libUrlGetClasses-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_460374501185 /* STPRedirectContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPRedirectContext.h; sourceTree = "<group>"; };
 		FR_460546061817 /* stp_card_discover@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover@3x.png"; sourceTree = "<group>"; };
 		FR_462265337593 /* stp_icon_checkmark@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_checkmark@2x.png"; sourceTree = "<group>"; };
@@ -1391,7 +752,7 @@
 		FR_506863260541 /* STPCoreScrollViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreScrollViewController.h; sourceTree = "<group>"; };
 		FR_507863811111 /* STPCustomer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomer.h; sourceTree = "<group>"; };
 		FR_514597362078 /* STPAPIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIClient.h; sourceTree = "<group>"; };
-		FR_515018785028 /* PINCache-Arc-exception-safe-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Arc-exception-safe-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_515018785028 /* PINCache-Arc-exception-safe-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Arc-exception-safe-ios-11.3.a"; path = "libPINCache-Arc-exception-safe-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_515110400273 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.h"; sourceTree = "<group>"; };
 		FR_518266894407 /* libStripe-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libStripe-ios-9.0.a"; sourceTree = "<group>"; };
 		FR_518632870935 /* STPCardValidationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidationState.h; sourceTree = "<group>"; };
@@ -1407,7 +768,7 @@
 		FR_536748644256 /* STPPaymentConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentConfiguration.h; sourceTree = "<group>"; };
 		FR_537648693821 /* STPSourceCardDetails+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceCardDetails+Private.h"; sourceTree = "<group>"; };
 		FR_538535395111 /* STPToken.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPToken.m; sourceTree = "<group>"; };
-		FR_540393113192 /* PINCache-Arc-exception-safe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Arc-exception-safe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_540393113192 /* PINCache-Arc-exception-safe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Arc-exception-safe-ios-9.0.a"; path = "libPINCache-Arc-exception-safe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_543365396645 /* STPApplePayPaymentMethod.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPApplePayPaymentMethod.m; sourceTree = "<group>"; };
 		FR_544048132697 /* STPBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBlocks.h; sourceTree = "<group>"; };
 		FR_544868232734 /* STPPaymentContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentContext+Private.h"; sourceTree = "<group>"; };
@@ -1465,7 +826,7 @@
 		FR_631274162632 /* STPBINRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBINRange.h; sourceTree = "<group>"; };
 		FR_634891479805 /* STPUserInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPUserInformation.m; sourceTree = "<group>"; };
 		FR_635484072488 /* PINOperationMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationMacros.h; sourceTree = "<group>"; };
-		FR_637944311431 /* ios-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_637944311431 /* ios-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "ios-ext-bin.a"; path = "libios-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_638194865189 /* STPSourceParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceParams.h; sourceTree = "<group>"; };
 		FR_639248881296 /* STPSourceSEPADebitDetails.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceSEPADebitDetails.m; sourceTree = "<group>"; };
 		FR_641873512346 /* UIView+Stripe_SafeAreaBounds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_SafeAreaBounds.h"; sourceTree = "<group>"; };
@@ -1496,7 +857,7 @@
 		FR_683369487726 /* libPINCache-Core-ios-11.3.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Core-ios-11.3.a"; sourceTree = "<group>"; };
 		FR_684957151634 /* stp_card_error_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error_amex@3x.png"; sourceTree = "<group>"; };
 		FR_684957154701 /* stp_card_error_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error_amex@2x.png"; sourceTree = "<group>"; };
-		FR_686972168627 /* PINCache-Core-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Core-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_686972168627 /* PINCache-Core-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Core-ios-9.0.a"; path = "libPINCache-Core-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_688345473974 /* STPBackendAPIAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBackendAPIAdapter.h; sourceTree = "<group>"; };
 		FR_689735932342 /* STPSourceCardDetails.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceCardDetails.m; sourceTree = "<group>"; };
 		FR_691297741334 /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
@@ -1562,7 +923,7 @@
 		FR_772386701230 /* Fabric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
 		FR_774763671036 /* STPSourceVerification+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceVerification+Private.h"; sourceTree = "<group>"; };
 		FR_775444959222 /* STPCustomer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCustomer.m; sourceTree = "<group>"; };
-		FR_776001027518 /* PINOperation-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINOperation-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_776001027518 /* PINOperation-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINOperation-ios-9.0.a"; path = "libPINOperation-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_776344734580 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		FR_777337581099 /* STPBankAccount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccount.h; sourceTree = "<group>"; };
 		FR_777944667952 /* STPSourceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceProtocol.h; sourceTree = "<group>"; };
@@ -1577,19 +938,19 @@
 		FR_786851096829 /* STPPaymentCardTextFieldCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextFieldCell.m; sourceTree = "<group>"; };
 		FR_790877768775 /* STPPaymentCardTextFieldViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldViewModel.h; sourceTree = "<group>"; };
 		FR_791050653111 /* UIViewController+Stripe_NavigationItemProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_NavigationItemProxy.h"; sourceTree = "<group>"; };
-		FR_791168379253 /* stp_test_upload_image.jpeg */ = {isa = PBXFileReference; path = stp_test_upload_image.jpeg; sourceTree = "<group>"; };
+		FR_791168379253 /* stp_test_upload_image.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = stp_test_upload_image.jpeg; sourceTree = "<group>"; };
 		FR_793128565775 /* STPSourceReceiver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceReceiver.m; sourceTree = "<group>"; };
 		FR_793362014210 /* STPSwitchTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSwitchTableViewCell.h; sourceTree = "<group>"; };
 		"FR_793362014210-1" /* STPSwitchTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSwitchTableViewCell.m; sourceTree = "<group>"; };
 		FR_795421255062 /* STPConnectAccountParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPConnectAccountParams.m; sourceTree = "<group>"; };
 		FR_803655950633 /* STPCardIOProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardIOProxy.h; sourceTree = "<group>"; };
 		"FR_803655950633-1" /* STPCardIOProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardIOProxy.m; sourceTree = "<group>"; };
-		FR_805275538402 /* PINCache-Core-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Core-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_805275538402 /* PINCache-Core-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Core-ios-11.3.a"; path = "libPINCache-Core-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_805980394107 /* STPShippingMethodTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingMethodTableViewCell.m; sourceTree = "<group>"; };
 		FR_805980394109 /* STPShippingMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodTableViewCell.h; sourceTree = "<group>"; };
 		FR_808039309519 /* STPSourceRedirect+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceRedirect+Private.h"; sourceTree = "<group>"; };
 		FR_809418927836 /* STPDelegateProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDelegateProxy.h; sourceTree = "<group>"; };
-		FR_813294530495 /* Stripe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "Stripe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_813294530495 /* Stripe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "Stripe-ios-9.0.a"; path = "libStripe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_813949290948 /* STPCoreScrollViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreScrollViewController+Private.h"; sourceTree = "<group>"; };
 		FR_819492685632 /* stp_card_mastercard.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_mastercard.png; sourceTree = "<group>"; };
 		FR_820602908988 /* STPEmailAddressValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEmailAddressValidator.m; sourceTree = "<group>"; };
@@ -1600,7 +961,7 @@
 		FR_828800361135 /* STPSourceParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceParams.h; sourceTree = "<group>"; };
 		FR_829657687624 /* NSMutableURLRequest+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Stripe.h"; sourceTree = "<group>"; };
 		FR_829657687628 /* NSMutableURLRequest+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSMutableURLRequest+Stripe.m"; sourceTree = "<group>"; };
-		FR_832542114231 /* PINOperation-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINOperation-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_832542114231 /* PINOperation-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINOperation-ios-11.3.a"; path = "libPINOperation-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_835891206247 /* PINOperationQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationQueue.h; sourceTree = "<group>"; };
 		FR_836284080868 /* STPTelemetryClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPTelemetryClient.m; sourceTree = "<group>"; };
 		"FR_836284080868-1" /* STPTelemetryClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTelemetryClient.h; sourceTree = "<group>"; };
@@ -1632,7 +993,7 @@
 		FR_867716578881 /* stp_card_discover@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover@2x.png"; sourceTree = "<group>"; };
 		FR_870129501381 /* UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_871742726913 /* STPAPIClient+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+Private.h"; sourceTree = "<group>"; };
-		FR_875549008649 /* ios-app-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-app-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_875549008649 /* ios-app-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "ios-app-bin.a"; path = "libios-app-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_878727202200 /* STPEphemeralKeyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyProvider.h; sourceTree = "<group>"; };
 		FR_882551670747 /* UITableViewCell+Stripe_Borders.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UITableViewCell+Stripe_Borders.m"; sourceTree = "<group>"; };
 		FR_882551670748 /* UITableViewCell+Stripe_Borders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UITableViewCell+Stripe_Borders.h"; sourceTree = "<group>"; };
@@ -2017,6 +1378,8 @@
 				FR_841504889253 /* AppDelegate.h */,
 				FR_841504889387 /* AppDelegate.m */,
 				FR_454823234837 /* NoArc.m */,
+				FR_282022996649 /* Some.cc */,
+				FR_272405693051 /* Some.hpp */,
 				FR_761662219184 /* UrlGetViewController.h */,
 				"FR_761662219184-1" /* UrlGetViewController.m */,
 				FR_887010092861 /* UrlGetViewController.xib */,
@@ -2346,7 +1709,6 @@
 		G_8620238527590 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				FR_173102942353 /* GeneratedFiles */,
 				FR_515018785028 /* PINCache-Arc-exception-safe-ios-11.3.a */,
 				FR_540393113192 /* PINCache-Arc-exception-safe-ios-9.0.a */,
 				FR_805275538402 /* PINCache-Core-ios-11.3.a */,
@@ -2360,7 +1722,6 @@
 				FR_870129501381 /* UITests.xctest */,
 				FR_314191844776 /* UnitTests.xctest */,
 				FR_583546727827 /* UnitTestsWithHost.xctest */,
-				FR_183987345262 /* UpdateXcodeProject */,
 				FR_460131545307 /* UrlGetClasses-ios-11.3.a */,
 				FR_175704718595 /* UrlGetClasses-ios-9.0.a */,
 				FR_875549008649 /* ios-app-bin.a */,
@@ -2530,11 +1891,27 @@
 /* End PBXGroup section */
 
 /* Begin PBXLegacyTarget section */
+		LT_100178272237 /* ResetLLDBInit */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "-c 'echo \"settings clear target.source-map\" > ~/.lldbinit-tulsiproj'";
+			buildConfigurationList = CL_100178272237 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */;
+			buildPhases = (
+				SBP_10017827223 /* Sources */,
+			);
+			buildToolPath = /bin/bash;
+			buildWorkingDirectory = "/Users/jerry/Projects/xchammer-github/sample/UrlGet";
+			dependencies = (
+			);
+			name = ResetLLDBInit;
+			passBuildSettingsInEnvironment = 1;
+			productName = ResetLLDBInit;
+		};
 		LT_173102942353 /* GeneratedFiles */ = {
 			isa = PBXLegacyTarget;
 			buildArgumentsString = "-c '[[ \"$(ACTION)\" == \"clean\" ]] && (/Users/jerry/Projects/xchammer-github/sample/UrlGet/tools/bazelwrapper clean) || (/Users/jerry/Projects/xchammer-github/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/retry.sh /Users/jerry/Projects/xchammer-github/sample/UrlGet/tools/bazelwrapper build --experimental_show_artifacts //ios-app:share-extension_entitlements //ios-app:ios-app_entitlements //Vendor/PINOperation:PINOperation_module_map_module_map_file //Vendor/PINCache:PINCache_module_map_module_map_file //Vendor/GoogleAppIndexing:GoogleAppIndexing_module_map_module_map_file //UrlGet.xcodeproj/XCHammerAssets:ios-app-share-extension_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-ios-app_entitlements)'";
 			buildConfigurationList = CL_173102942353 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */;
 			buildPhases = (
+				SBP_17310294235 /* Sources */,
 			);
 			buildToolPath = /bin/bash;
 			buildWorkingDirectory = "/Users/jerry/Projects/xchammer-github/sample/UrlGet";
@@ -2543,13 +1920,13 @@
 			name = GeneratedFiles;
 			passBuildSettingsInEnvironment = 1;
 			productName = GeneratedFiles;
-			productReference = FR_173102942353 /* GeneratedFiles */;
 		};
 		LT_183987345262 /* UpdateXcodeProject */ = {
 			isa = PBXLegacyTarget;
 			buildArgumentsString = "-c /Users/jerry/Projects/xchammer-github/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/updateXcodeProj.sh";
 			buildConfigurationList = CL_183987345262 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */;
 			buildPhases = (
+				SBP_18398734526 /* Sources */,
 			);
 			buildToolPath = /bin/bash;
 			buildWorkingDirectory = "/Users/jerry/Projects/xchammer-github/sample/UrlGet";
@@ -2558,7 +1935,6 @@
 			name = UpdateXcodeProject;
 			passBuildSettingsInEnvironment = 1;
 			productName = UpdateXcodeProject;
-			productReference = FR_183987345262 /* UpdateXcodeProject */;
 		};
 /* End PBXLegacyTarget section */
 
@@ -2873,7 +2249,66 @@
 		P_4793904575952 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 0930;
+				TargetAttributes = {
+					NT_175704718595 = {
+						ProvisioningStyle = manual;
+					};
+					NT_196722873933 = {
+						ProvisioningStyle = manual;
+					};
+					NT_243789410170 = {
+						ProvisioningStyle = manual;
+					};
+					NT_314191844776 = {
+						ProvisioningStyle = manual;
+					};
+					NT_443002457585 = {
+						ProvisioningStyle = manual;
+					};
+					NT_460131545307 = {
+						ProvisioningStyle = manual;
+					};
+					NT_515018785028 = {
+						ProvisioningStyle = manual;
+					};
+					NT_524308052075 = {
+						ProvisioningStyle = manual;
+					};
+					NT_540393113192 = {
+						ProvisioningStyle = manual;
+					};
+					NT_583546727827 = {
+						ProvisioningStyle = manual;
+					};
+					NT_637944311431 = {
+						ProvisioningStyle = manual;
+					};
+					NT_686972168627 = {
+						ProvisioningStyle = manual;
+					};
+					NT_707080851040 = {
+						ProvisioningStyle = manual;
+					};
+					NT_776001027518 = {
+						ProvisioningStyle = manual;
+					};
+					NT_805275538402 = {
+						ProvisioningStyle = manual;
+					};
+					NT_813294530495 = {
+						ProvisioningStyle = manual;
+					};
+					NT_832542114231 = {
+						ProvisioningStyle = manual;
+					};
+					NT_870129501381 = {
+						ProvisioningStyle = manual;
+					};
+					NT_875549008649 = {
+						ProvisioningStyle = manual;
+					};
+				};
 			};
 			buildConfigurationList = CL_479390457595 /* Build configuration list for PBXProject "UrlGet" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -2901,6 +2336,7 @@
 				NT_686972168627 /* PINCache-Core-ios-9.0 */,
 				NT_832542114231 /* PINOperation-ios-11.3 */,
 				NT_776001027518 /* PINOperation-ios-9.0 */,
+				LT_100178272237 /* ResetLLDBInit */,
 				NT_707080851040 /* Stripe-Stripe_Bundle_Stripe-ios-11.3 */,
 				NT_524308052075 /* Stripe-Stripe_Bundle_Stripe-ios-9.0 */,
 				NT_196722873933 /* Stripe-ios-11.3 */,
@@ -3175,19 +2611,40 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/Users/jerry/Projects/xchammer-github/.build/debug/XCHammer process-ipa";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		SBP_10017827223 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_17310294235 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		SBP_17570471859 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				BF_513577914721 /* AppDelegate.m in Sources */,
 				BF_525198602071 /* NoArc.m in Sources */,
+				BF_123619201349 /* Some.cc in Sources */,
 				BF_671889331007 /* UrlGetViewController.m in Sources */,
 				BF_559895246776 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_18398734526 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3330,6 +2787,7 @@
 			files = (
 				BF_399571997734 /* AppDelegate.m in Sources */,
 				BF_657639625002 /* NoArc.m in Sources */,
+				BF_236406319029 /* Some.cc in Sources */,
 				BF_730930168105 /* UrlGetViewController.m in Sources */,
 				BF_260333157646 /* main.m in Sources */,
 			);
@@ -3597,13 +3055,19 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -3622,15 +3086,66 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wno-everything -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wno-everything",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/",
+					"-fmodule-name=Stripe_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -3649,16 +3164,28 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ios-app/ShareExtension/ShareExtension-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
 				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-share-extension_entitlements.entitlements";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-sectcreate",
+					__TEXT,
+					__entitlements,
+					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-share-extension_entitlements.entitlements",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.ShareExtension;
 				PRODUCT_NAME = "share-extension";
 				SDKROOT = iphoneos;
@@ -3679,16 +3206,53 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -fobjc-arc-exceptions -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-fobjc-arc-exceptions",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -3707,15 +3271,66 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wno-everything -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wno-everything",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/",
+					"-fmodule-name=Stripe_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -3733,7 +3348,10 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -3758,16 +3376,53 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -fobjc-arc-exceptions -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-fobjc-arc-exceptions",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -3787,16 +3442,69 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -3816,14 +3524,34 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"-DEXAMPLE_DEF=1",
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -3844,16 +3572,117 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
 				PRODUCT_NAME = UITests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -3875,17 +3704,32 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_229340051279 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -3900,16 +3744,53 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -fobjc-arc-exceptions -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-fobjc-arc-exceptions",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -3929,16 +3810,104 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ios-app/UrlGet/UrlGet-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
-				OTHER_LDFLAGS = "-lWeChatSDK -ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-lWeChatSDK -ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"-DEXAMPLE_DEF=1",
+				);
+				OTHER_LDFLAGS = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+					"-sectcreate",
+					__TEXT,
+					__entitlements,
+					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet;
 				PRODUCT_NAME = "ios-app";
 				SDKROOT = iphoneos;
@@ -3961,16 +3930,117 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
 				PRODUCT_NAME = UnitTestsWithHost;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4001,16 +4071,104 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ios-app/UrlGet/UrlGet-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
-				OTHER_LDFLAGS = "-lWeChatSDK -ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-lWeChatSDK -ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"-DEXAMPLE_DEF=1",
+				);
+				OTHER_LDFLAGS = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+					"-sectcreate",
+					__TEXT,
+					__entitlements,
+					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet;
 				PRODUCT_NAME = "ios-app";
 				SDKROOT = iphoneos;
@@ -4030,7 +4188,10 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -4055,16 +4216,52 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4091,7 +4288,10 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -4118,16 +4318,117 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
 				PRODUCT_NAME = UITests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4149,16 +4450,69 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4180,6 +4534,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -4187,6 +4542,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -4219,7 +4575,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
-				XCHAMMER_DEPS_HASH = "version:0.1.6:-6288358196755028991-1525999147-625159552080923365-8127581152973408225-60382488214343808365756812780883331840-4134277424566218741-33471522196820527261494421402726165876-8839739632762004211-3935263738151507838-12529439719501099551299719477725641299-85193012119446840954353427595767363882-78103355334899461277791444040232288752-91726274820630955822459605020710812557-4395783669294421523671055742255511353-8822673737589657742523858672589095422184843977743635452434652312105692804628-7104213273274908219-679758369357832177774856805636566944918728930450344164141-6364728089032654954-37141080762521604717102645385897174716-81707277196853556924606631192293875317-5992982697423040041-8503096995296581571-5693332235794888449-3739679205833104590-5716230757708248057-5693332235794885884-7737114960902499877-5716230757708245492-1732183231285476262-56864347441565759853405109534272837352-5001526426879369789-8714641112548879863-15259960781653423645369305858-15259960781535272661249519582-1231456848849360626-8817116352631290858-36685524108807757306871601550350133619-1660401336883226802-10751367000041273135609641346650520204412609616195565490461807385810137608646180738581000641062869019523553946014-3150152898142868814-758833836900320754144124855096254243098994248409200432061-640852832733112164-3660228457884885351-37940045754428571794413993649482312166817687830895753030463087453622734908942518354807250625054-35832094876687772714122486084028201955-81725562811829785908723483767102732987-5509955735824431380605651250255462328642453609645804892718736311004822068933-7911379599757626890861814268814732118-541563006182789555844139936496852085266895369639536811830642613850307539377280517594734901758289163415439253565236-6791071612180950727-47499881102777279064701900514049240134-22087499345364872392832779069942261149279653861633057628450388512715606404503067917672245375856-4490755223333312164-54777546916441753924522846082039178979-1377999300503704183-8352863455740276520-7265374971314436328606344796120491980989862848830671688278635119860005799164-3156972200500211178-4493159448240012765-69131764098912094768368280218004325673-1292022443148885165-3304070505721311237-9104941123779470997862440537597727494340911856049021524504917806429534330-8298398878721488180-9072952628057915309720125349985307316565498659862126372976439946659928569726-1304025089714858154-63348993169125690149127853244747763338-75896003231532701288626367840418750907-2543721056211164657-5400898642633017152637432928446907742-47935626744626292172591680521115146342567522416347926615926512144663207289428178307958062628175-6468027630610319028-24274113546014331534538352151123026577-1606305425425100434-3378163957947613866-32675788494881577566868730365892065291-1525996078-9278278889258167827812566175111307445-3388684295977440382-467454110316041951268893238645299588751410324345331634547-65518513432487852601955092935153676901-127107518028814312945444905855249199003851830458968974476515522585727202066822505909922428546254810439674437739922-6009988230364387241-5530889120317796390515522585592984338338518304589689744864954272239225251404-6009988230364387266-53915641762257413468120114134405404565-6053821571507700452-15259960784991462368640860393-1525996078-6535893435448276227-7549966625382093590-7549966625382093600-864675401283116154944385674070531325259868862224566973562551257469915666158721958841837778039767321946876941677036064951070679673554434796172552000035764102606912655296726860257567108315047330502488487087512-51199860848237072084735710110545979212-5121459089157315136-5119986084823707043-8019589190449692488-5121459089157314971-2943110492078492025-511954238653118418486175646611307595964702320203394361545-1493776466535590959-5786574452792301155-8193766277298226014-7372569299459468694613401205547220211512655729595570523316551544805842737354596929215555455716559690104099946444655594785526635334326646793480659812552736762066623385500186551537049181670093-4082528341162969899-4584897314664415541-697721589413323834-515758622529230778629511889041549217333954367703552417477-87449488076115256607730087201848753486-791826700871607171392023070781433963457348366877321640952-303949132564988907165052298528417761298323510707194550374671607470464566480056783238092400219942299337771898097735-6218426627557843349-2142975147178256778297842119271503999385713212815202832323828387268151704065-19254712518070027655710838486732434529-1312661305193337751-38121431069173323337904110709232165900652677249264547734255925204982213198615590255469807305396-232847168952895043-6128270926062666841813627502981808093-8255568557670335926-3110406363332343134-5885884301849734180-17702799406753401991327143278253392019-2426301133938682948-17605455274075522996096886364394299575-9130031900143787567-3634511927604692285-2547487143021962340-77894130125660470041428113427913782253-8139139091374531323-8788292607868676777-3536551646188057639-5495793161182187571-4839495152964052892-1766875904516558259223092050874357732050241649474135257383798857740177320715310651746146655037-5099991733499811856380084100999441365-84795810900725735947480126719217394896-2646263051364931312-6553012701856755620-8148026740222166766-3877569293499869223-6740491435518123343-6843729515811553360483471999817582618110634294523412750265401167873245196411-3581858263665924974502581146052373343-5246314261841494417-6971485427664312224-2492181068180577426-6272770664104426303-3458436744370090110685073043780896537-2683429451122438016-80492147277249894492378868911304670439-3532658024982605066-480990759049690748249905294733503774578210355282521841931-5444233158795058188-43572083742123282438258327158363157783-16212486351755729301613999331611416448-6284912160447001145-5150004768672759937-35172559553004190039133129064392374691-1818347041014484598-8271036204017983677-8045810691566207509-25944656568100315584133539807507962803929830206370206044759003682818229339-81493537965891670395108318206660716665-78429075671085670592890694604298872771-7421062955816903248-648268335646231646122134470019866346982213438154152153033-2610806757536177900-2610811181487170285-7694039359625333515-6310197009568247227-6310197559852805815-2610833301242132210-3522019436007647199-542064694272627824-7694039374775523592-8474226909220024064-7309776704094514855-8111374297628993354821978319853532376563039625497418051316835015287969738065429176999834868582-7362205280966450237256170680221278981155935718221191645761110143800563465822-4858077158909826693-8492987856046367286-24100286959201428651688981508573441181-82869700787217278658976807282019227458-79221780915896233819021224226522360184855354868402289927-69146104409732824595910938465956068880-524144191079761359232497833882361565798713389432766028737183947079129660212-3699089071454493504111019698872830984253799976542656500817898661046773997236733538305730352048510802385169512846996581767030127137418-23446731408255419914321642933617249167-3521904517777048536-2610837725193124595-2610842149144116980-2610824453340147440-2610828877291139825-26108200293891550558555452417355842313-2610815605438162670-2938822436793690161-1232413468740098129-9135079840563352670-5482526698923264350719586268854206016364695106565051439962274313002832105037-8393787989959356178-16885366532351566091746975511865627126807542795537168648-58251264939399509481956047681886922091-6966748678664356642-765544592097642657660176597029632869011262160510426388191063250000745609258-15259960786155837777447791185555180580880402987961306462437014925523792103567000533931-35794562027322895977899856359537626651-405845017607979129-15259960787376824730530108946-15259960782141334976549772774032517707741090651-4233624876059059156-15259960781526724274310261010-7705606381917502926311924942741305459-3303403580083128353-1401392915548016578-1525996079-4640083926643311264-1525996079-7167310544517755913-3316872733268048282-2668102879498243495-664410252426410991610198059207230991775762501857920134745695603996541480416-15804293884346022471697734091693268603696962731817779273712251549250807186542268319702637163130-8133296424509437734-23419927703472351036839031271405954017-152599607836443575754559281241886184408902292833572995912405592613928898098684645666101545678329232201323900674989980358531816614207252015835298398670188157077426473839883826916265520896612127145770477308095928619283807580639712350944267-129552346130861408435462566494140444113791493290785673680-3113082661175420430-752112867173593273548180549681873431194984058908126699501-5642191498403160420-42765478873000687525427933236270554864-719581521975744232163636048431725347262385408550854413300-8549361376419041361-689372826271862954-7832057291281250321478598462420017430257106903880620427-90316216614184603025680420442155517370-5802799747169749908-34313714234312231328324149825656375221-4157034761695768357-45813488770335126265083617786186329315-816146917602113489290435416493488488883119889522755866645-152404704165266564-8018059094158124527-88933772053968241685930654023487599300-1470305967770704319816173866538981706723057264362530467521941257820937696134-7966503142036655973-8186879483480321576-245112927284386498970090366387613466788055045448335830937-269423830264515204436199529985541009-57546285782371287227865521963022381768139746612049277764-1388079287242474083-2025467090525392655-2542361022372236877-856735154416247845-73142352787238482113884905246360781714343621198860804247-13164294875514461547156173040526735466-39552854090526584367750854517315209896-3558641751975588251-5307793940765268648-5796475101255899363-15259960796387044576134307705-3485449558707374494-6126100305044383500-2444744535384534045-46909909151583635512128532207145735214-87211691994778592055415113031084758205460804251727766172-241967167414164755-3676008832771799094-8990617093888060255-5297356217388820075-40745482773221536836011112225283823097-39144061772924761098950047545965747566-7015353696821060680-1579301499827916139-6413151576581837856-35485240421127288516849031811278465648-3064615879736349805176908159358548186529366318458330011569477899761402113883880711270529188492-2708080657353942040-1410722059457395103-157084949046356119168459032928027751625939837956867378818519554173062751367424278191108217666875841360244493395880-392187327751438698863280246876434770871671793224851524891-1669610491412207910-1778780224350574478921985491080305686-6030169184083256257-1635371613213251644385508353664111379-2276897842253992548-875091218057005008453420783053029545746841353373555654079-88974720570347094031960525005642892228-10437746484191304546899747735441604015021977251994593724-6927344446959083812-296124874273086486231913519200555018595568768902497164670-1173678623890283459531927443983515257-5822033789854788956-12038502526192760318073618972548190059-3352750878535187145-8923540001637630438-43007052939834261545611524726921317207-6896431049687450580-4317934488736766973-5893873044751362001-7704705721171217913-179654088986104428772847863863115833983259891880731193657227512743134386866-6209193207895986590-9188556577077433606947004906043926540-1993350364200522510-11880320480377782533057920468480903929679534660323266005-5076917254627924371-82774216565313773258733551190231226107-8895871284016191026451841227937266037-52171793776686923385385943019454172803-8019814682953850220-73400584296079757985700573827528268674-8008864640877665075-159070591036284715384770914844941766738140414324908999250-6732028858017753634-88566507269653756057379297498523217449-620553260615532224443719295194668317073274229143885165688-6821530191601417588-4845417309374295134-628669444307311506185620041632768463883788060588556392641-697289421152423575851865240563483979-281452600067992742942808963382399254548691486668433783059-8747829503930845748-13827412628222951488767991288218703684-69781443842047776604004899083114571213-5227130954526229024747898033952934414761201275354845044574801444093347979140-3678437330460054427-4148559062256021758-4237219235271458093-168473074510757286-659271926917205019636347453833172549865154280816800775607-4153106297453231996-4699621326843683556-8840135289005628215-6614052580508916645-3714072650663389391489197319920024748-88401352890056285402445822445969515804-3059819806956708943-1525996079-367651417536274514652978464690012906491570271255273625290-90508664226033576046541374480621629046-1525996079-8495077373402898375-7158351082335208479-1525996079-4281405130236941053-1247917881884048830-23586488972818944028793801566945969261-4926124019704711310-516969096345500119960315296318748353331175793694254356330-3337262563397200767-88392372722003355237396472256889830577-3570124156817500637-26727143729482778011746638970359548279-779555999714973585-3803898622829410383-6253402244944497348-58482862531945420982752647107835212628-1650750338012684784-7405417351542802688-4196715802433962758883516146679463748128261779232741037663600975661636535417-6409119042869162750-2331876988663372174-48901896218876547258607564926471855562822936233212702306652761779294653713346067273396248792443-8460245407341213094-8784977012973368003255457605804662363-1821098838944477813817413682076660702419096326314421075694401153039050997490606727339591324811852761779294652894092283807083293135489-1821098838944457328255457605804703328-8460245407341218219-878497701163119071819096326314421485348174136820766607014-4769125909986744838-7089411941337306861-1482278719767534408-13879718724105986978500498416650184647-4730396681227033416-34666060187450514265782004295749229887592534963366664913733668326896137017187546082815954945665-7728251334121590463776152710382900280333370530391011912417370354282556040507-28057986324603352825733148137726783808-647913010554090743745268656733795945657034953454014679118-7994178997434863040-52405420766156640483280832349823300162-31924158696330469271652425007508807513-7092128994452957331-10117687892159397196628703684387339185-978924658430755964-6814424480501123310-428500297394963693753680732731535994865061922473371401594-775219604413685410635197989192209018173279903404400494775324020955351607823609094715711074677-6420595460832702265-81705260889416332097979883999726146511-7658332669860033457-7527786287270510380787146444951694907624103136369554518655238289236063704153-5778029752892243500-1280964652117995692-9051092036890502186180914886264953531826457492904018005142043189999572686062-13732344322756171044335158747632751988-1187337684368004705-3764858474401804361-82116294091253688621580898021197091384527658396219463332-1818789359085383238-7949714289438322898-4852496667562251914-49330014766263951665889211618073531318-1525996078-796698872077264795-1525996078-9705690220589269214894475122324269683-1134802210541538244-6981328987040365716-3761028139933987244599610089539580712-2335175417995500276-7825050461549711416-4190327535115935436-5224225365818131410-695310636263247159937783147299798738289267060533725875976610885368846609149-1145725280989078071-8331088544884050051-47073307720292397997482902163776257269-51543058188856340017630987525852641074553871026313709650869619230614339331493993821553587047365-8784910000677868388-42394731512372507823033071542972004757-8906932480921727047-21342637900629975501767597606508428790-6297180371633691519-2435692012266303023-81157518549531440771124877710314046893-2185874182097205458-2493809555682829118723530668948626402312825230460559288331066760166897520798-85401125260060689331374695540483144458-22780466765244210833190716878713886697328288937314110232229749539995554786626276504865909496445658444023949512010532703582412105962735620341621538218831-60264547054174536153388909567958875526-3681831097160434328-3825673016599373018-362038276754229057847910017371247864726492267745067904480-6383333960957439677-505207853501188168-38931055807486979291783505921171904038-1117833916971200837-710678880438284705848960986276193744326334622409326022540329204699559799870138052726182407048013651651794195345426-37869279876550222884957546957237518182475225670818043574290594145668374470524214750079921792109-77499385959976405786120311778853240688-4417989449255371425377831472997987382435710440331184744-6368823670957377827679496471087770455-80770474512936943894445027262682731084-4941421946963987101-194720502399117992719888456442691776595627137871089238366226579386925720408530846831014965430718084334424535979078146306076646178546321662421663083303375431591389028275282-2749938126786598549-4138688844168568479-522747398434249721848244047682938197443565155604958783054885414626564913748829448263756839378631084166433269544550242989290628210248-956425109723390313-2252140799583057280-80737601256801804816150487541201987838419511270404986154459409472819923382435558760739261283116-612302088774376839341644041463963408634081368468737051325681727140279122642-2475939619058811992-42258036252217919726202195774299064068207590181924755594-3248139340991688318-61596041144185443583335988715141230219-1396431592173809361-7629794126152141378-20493206733217627727087227858069801285-956054997040117908-8031520077650822904948861400660369852-25376367290126234646258739680571891916-51211463866599433229084102088106898188197512632790680259-3132144599918905887-6349868605803841123-294336752141612712386187687392667880951788968703341843580-365672157178991430639828274884758080156893070955585607512577460713172325752-242057754228751994962455446241351541942851851314011213384-1815539201523113347-5440571645688278963-84280052588953959723450816954283867668863942548652000572189240974340584555177486074495789338887249241495753847910-2475939619058811947-1121670015686922814-8312572403905222273-3057990127772671874-4760663122245964105898304023302542698-25376367397500417091444580081107484972-81964178377097427728859023305497089540-4700079979463845974-2922752271709623641-622766075745936341-7629794126152141353-383275316815624095-3560599915257403304834995625705456424521357289150235939178238030736751008143880278428263086739-422360132388858314-35643138251131329824286108716968703249-5638518492402163506-1210458290321899040-4317784823175390936197512634132857544-146396473886458636866095342403302349593702366119596222270-542699011557158948135309001640809287284202563305331138122783755365303432833-7727153335992152264-5147636565884801150234923782235186148771838776343510838427388705766054149557-5251102098307496386689307095558560776-8268432357580995279-8242415928239843003-383275316815624095768579975401281857-49292671792139049328377855220943777643-433589210379710431383781651793674137206517715242925410729-1385587311556693283-62560646674672679616739506027368347365-6631847261576796971-4819967658118989137-232236568116642575457134080565997708776244422481184492783-5349335554349965019-793789065559052559286452801125796420687134260618390311564-63753977149370812418887196445534816291-20062022828119874698781747288799986714-79378906552549812677134260623759020689-12481407919191348118645280109895287503-5715938921756588203-453826424638266473931141660782921230679149486959577439271793318455059610473861486619584928949811270809287876861343785399047269400097-6827640233400367351-803548438005299195654670574257348150655303976015542186802-7329035232613196696-652921852511752981443735454979812234636488742889849078382-27515224415587985525303976015877731127-8853827456403007628-7329035235297551261-4899542165720367545677201468636457042-8718637113309757071616748972592429731761779114499820525872454438601534579496-414753801771366765-47761256332218572616112510257972573286-56506370599155184821075507973400796189-527697267655882601213817212841006084794432873544769820729-3463398475174406645363457827493890105-377380452828307662-3576712009430851538-28751945045309080297676473101380465256-2046290019668225379-2044847011721766957-2586747201859103924496045819375785809-2834409725670062551556778747359356958-556142774201423509075137505798447849313077890917403635090-1934455437485110875692159179162814988580134672606633490636741683406090929104695648167124305420-2613936363181450758636891760207466969173335216756648208183101770413255601284-8747694897020393319-9044045487838555760896493232373482113-468168173449263395841980199264015086775204398177347571604-9079423103187971832-7914365130613526057-2161305099059717292-6881507665145303421125465987847273358934136075210837350933049929642648430674-6086182942847453352-79151382290148458356008141613074661144-8539093572240009966-1471377448348504661115138708192653618872701121801659062467813391160768779693309006681396163437-8176887294210299528-3187414774956826235-14097729885598808965981941226029992265-4210367345068762426-2005289398849250087-676211606060863145781468850420823335944281173655498665400-5182002791343488684-4194705972447136740-3087479124259976392-316862878396732553-1136163601765758374-3394435455270461177-8753763127249139155-11139204834187901-8902501216086666906-518315659964919314025096356924677422279855117440019763786894422349044473807-36951272019531002037287544762683465481-5169250964253841592-895069337183609468649720969796310265987246435784668698021-459542983181964665617782749238038358011805798600681899613-174529502478264952046748174294343777933198188370418870922-3892074700216424717-50107783746536494677632735796393743205-9184590275627758538-1933604428369329255-2132431483438464960-4097893930779672652-8317667152951061421-8212891282038274847-177981802027109634760669590734648473342433508380788769877-60573679895741308867311023945053348411-7067143704493272960-544389227494426691061563134373995685056377030719274067120-5898058651976115520-659559807688989539816657332197579667695575505883293818809-1802668167165076527-8491105828757425142-3341232965002024060-25822137990489100341011050961120084925-8577410666130197131-176530929071345311833822812235273495061105355693358873102-62843760032514585464133339305079997843-53781778847673809775710378855343154874-661284435205144056092070049297286619312942924024171453781130346421586413440777032975222720752657914825941018893214-339624676403354735131580606116742358403274716637676675931-45426619553725244183593526948187400416-7877796003287710063-84742623437248225562408252047810758816-52940718149050335692835329850097754668-270961683254164430410624132812476947695307487593622156123-9064801347735411090-25359223904984151891525240527319828837-75790594034630166034604076767023126228-274995838780632132225918181117081134951821327664221711191-8837035345947275893-7414344868247230091-6165225340869716025-3078878278168535299-5829871064434219095-307348737599347256-2053078631430210142-225792610789366642-3789191180834355794-4468664412698789925-6229389359367994440-5460644930889091694-1820226575366482416-5573366829382614831-26265617814103096765933289971719634064960709126412218700-6205603455155531845-4243704448529556532823810542351631234382581734847029032483940238870328980430-5522260092838658363-171706353693440383280382597315432398624576440848861309251-644522185878028136839464769835835238765575505987278203309-82056129026594002436679239721899280307250153808669790427-280826729832133390112968069048073409683438361088646894565-72957878487359753863923198511947394696-1503842792422343715561061114868528351890331319288134335297468858970196430091-42262585803711774485767184731584216991-7599115033518445073-100781923161547993249353132049547197142307127630215586469-501902008888689262349394948191629446786379528637582071411217583037964858282160217696816962918706423003791250816757-3223371535339445124-3127135808500121966-2901994304945086137-49885317861984911119964001945432188957683605686430710402-401693023802682824931662634035034969733546218473837268331530000919095425544187002701608283592813443945910834607110-1091048355475292934045701469602030601430815936674340509157590955782073770374110190893232214876522525865532224748-4852523154984809169-70718095985075663798812948801769003369-1526638894741725860646502009357437980-4726768779329668485095151908418333511-19957731731786434874474910567404422694-689550462957005544614214623266641433387652590408139119650-31873746830631747602217329615139190510520417320871753470-8527897472928073793-3596554501154075776-35176863685813184556615201382845956654658619235282262685-4388364184419427017-2468094558179903037-2222634759248221485-2918033024608143503-1546085490897988135-512167485709632371834740260997164482671795508156564397824-5051274922166090834-33450118452945996614312735637225355000-345150458064632478568239690213948552-70986664510769432286317154337942495606-848742215927515011460975615218769663-6730167001796923238-52820576065816381383947262113824803323-2661182248811255-3357994968678479832-5118389374596138463699918911829966200588144810616297866443916804426418544366-73388165254640875281096274672067789202-59841872266865015071575880651673303024-896626634567202629-3973824334111789408802067695056816302054735445092431823136865285427666359493-58023804727241052996905402070429354265-4375252574367817516-7243298822642518815-2125159013359710027-53868273159179049302974706781241914372-41232474418348581034794452273715899114-4080242544842497134223246842837994459-6598188437199621734551763076811897001534398395038838103604404453172856958641-2034645283838495439-4652948815102249686-5176707467742265740-6135278762527379555-43423786945530220717569248098286910076026532733943712448-4021675831347664061-13839456383449038271470231095469740733-7866905609764197711-91616324642387145961374059894507911026-843650296309480433-425458504850825433035923854340590905711753982806121238429-875626975566018339-665211930601524861944285080249618423495335111311786529427799120313719412607384631423553090401891661101987104498525-80435943350704115653572356738018736412-55190792299225417906641485388936134993371132862139756772-6597971659485448829-7707122014974671293-3645867622584752785-7134241574121196420-2750253996811258012-5845365503403519309-2052146672475430252-241796785347409151940461284661010632526383876467937572076-72719328047699969972996472598591174885-5270358078237845207512951553471418128035849202237582338-3219947368750667218015015702331902723730364443820219796-820120563086724428-5192094348209241803-7679870751370372887822882412461032357-1193758241417328907-827265738065949982731070551188017139817207598114930752004-65665056297987556492643098470856715155-3901191875636154323-563175023983409593033244776600119796809124201921753198390-12052297130013134911445197854128460850-2404005507926423982-8526255095563922897-2558919304214119491-4790908473848786039-74353138092654979482060572321262579390801955882184071624110572745229591562811689194277922849530960401121724495008-6679344303880571062-69293431181876308116875574267534953938651848514302618946841996244989316117-3956555483215890724540317690786904390521047415104595233067190950934814655868684935571550876445420051627479834549811656316175947979625-2043870489941177598-49878168745422204447994366859931621607081315117216444188-2174127200218033291-8681676996500633881-79639551360701324961952855078270405763-2589184750142578204-1525996078-3035477635310127076-716951303932484775056954956395986790683903097868117163587-4519820537800878267-693019694717118091-6668692085959600120-203178043555181225936387624137854042967269788246008030306552533537581554877829517627928420650608048567440939591080-7181705399910920922252593239774917110346460618519637325684772084111459909480-321170690730928265233086298613266812027923646027654729229339597383312226546-3333421213018531033-4965454008996699967-8771705147701039074-8359060660060040481-66582308094961628086206444236462440448-45414564067952741731325210071875284950-749815479753010241081401073019888076376098222197872335419-8333354272496132890329147268100519028730442467355015070423660931726177763061-8541036952435566581-2810577045155306996-44775908345559123197178482531175756451-4515636939078405400-391660361426691452745440803528003896584831748321654586557-155730802064394239-4437108634226049062-7364796349800781112409196580649229644378219470684076932645187174352346844524-735859197586315367529344388400528376417048404091358947001-57573038881269907081856579905749732736-1274552137397719970-2635897709557671302-8207637926964430386-6910086239979666778-4023697285195740710-14068595500198817456446233607014977936318094160934690100827332778144071102706737669181012320720-7037750656072528177-578286472053220904-281830666861335077729575832338164718973771450323180139292-396714161266657804488075006803690842135628485765468962081-36694966746658019427264945448351093968-366949663996920597270840963830029229592264561337840701328577401385408061494627293754984809470503735068288016002587-39825312560684878022666527073941464152-75913553740139191390805442600750473746637162286404733808-52130613266928507306286899842312301210668486698384133737341304272909762284067981725187593061929-5683952608406310634-8839386949466998240-6222141508998867018-5626844914698326118874608548703478555687278944607785682112618376864683137907-8821195923210780895291080598650767429335483149885745109017908961134613086504-1413650404075128766102754681439619868-2884612169130874665-3674782572556734428-458132337884983856-8570464418427644132-78302193659170985927857945461549236257-3252440553084189214-5234075855590945825-5038863812503903654-825379320759257024160729412188425723386655053521244289843-577177557815291680-3394546762668311010-6255877529041816426-8552273392171426787-57046391255864525964198765959890670289-37111646077208711333073954286494461351-2999649891948001958451417533655920859445258395048994483507194024328511519888-7237578662108811328-22233746569579659827826953789954043373098668302056050266430889140571265618-570464094513264787157817612480277920644508037899125166490567226248658030351581102104055897681297013001442972983123-159424347215952779139061564737404763598278268965405706928-22233659828089734-7237579234602644833719402403359045414314345202476004145508550156463554200665-7670381267339215927-34950137307578034417667367618245775893-23301048162657227435188066065624043467-296670439362138203143732943502749703233456915979151267833-1001266383669959208-8895167797984724402-7438359144146465571-530332696065380335733447866281245344884314185392486779726-173839930974223364981011921176220141336448595910967229658-5632287036852893840-2280237633043641692-2303711855119035847-8752795494251161142154756135608944138-180402517796697351724109251737220524727396622028415579550-3333825881623888501-6158548229838823896-176863822700069263931019793963095407612812254686513093246-15592275373005412768762332745831003473-2611233374601175613196905969243398129-2482431331295635842-292792441461375510323997672304946084601598600439644182823153137560261980289-59183229682195317936818621609795822525-3884465495851147321884288524079621069-1366544142676916416710546103673867753583385357569255388822331373111673037669-6658230809496162798-17014683408699008435965864940979985448-40299608227823787573189319794986921620455774679055211334745998119014430028813166056298299613310-7571657719168808752-75345797814504881862625681161785027816-870595183713620388554320186934733431743186078393418545313-8359060660060041766-8771705147701039064-2515189526871677385852066050016478325133959737794351742147720841114612202058048567440939509155-71817053999110028473014744856580499527-646909495897373320772697882460080303914544752299633384974-4866277730678672981-23521490071737288-6668692086295144445-20317804355518173843638762415127581581-4313722248467368635-1518852177289516928-693019694717118076-4519820537800873142-2526980938240737877-693206641796218522-73647963498001257477821947068407692619-443710863389050473745440803528003896684831748321655897282-8201685006476504368-3916603614266914512-4515636939078404115-73935556522994475372224671552417733441-2810577045155306981-44775908372402668847178482531175756366-7429189352617188988-854103695243556662630442467355015063973660931726009990896-13788855565719377628296296424379741556736064233297153537032914726810051909326098222197872355904-8333354272496131605-749815479753014337581401073019874969121325210071875286235843482721239717366173966220284155798756350798284581906381996655276010968592410925173722134397-4127127390574901813-1804025177966973842-2465970604508704089-2303711855119035682154756135608942853-87527954942511611328608676348624137008881214332146714996-298577389795978414293333940427718732987567477470556089635796989219167853995770549675997330466-1358979662825235698-370422568353326600280662634064100490868307973939553292195-30462347467413298826771879507365573776-8636065996644550998-4845297310004774885218008606068247614-8500695516163834343-29018430241331847671177805804815435830-342730347896704140528096930365830691828142738091074011380-8789246303259861697-1763920391147123947-3520095705333537674-151748765064788558167132976652127145057722215138570448222-3281537431820122565-86019702557733461048799338991376374081-76888745966259430386771872737040863882-5911203831163099997-4241286257166168436-1150503864732357606-54475669854943318282243660330286555998-7190073336464191253-5192054309786832590-1030606986822531793-18602196883088440447667584264502437230-68944198386575130251655202644936269836-83996128211006595783422673402514364495-3704194404602394948-4043920680767265844-7972304014786459250-1750048072274500217-8010387545547281558-80626297827729978291610896181350727305-2902245842709360599-6910086239979011413-8207637926964430551-1406859550019881420-402369728519574070078963101924597345921856579895012314491-1274552137397883815-8395908726055591217-5757303888126990718-81262763588412788372934438840052836996-2269763192408375159-1322906815574988758-1899598815819581511-3613551578840303615-13665441426769189817105461036738677620833853575692557984788428851334220282468186216097958225503153137560261980264-29279244146137551282399767230494611025159860043964420847-5429152979531151567-10152453412935454609147264332990683764-668205655209802023933591523673204820573196905966559043564-5351712480984760014-1559227537300541301-65064994797568522773101979394967363476-1768638227000364954-6158548229838741971-3333825881623560816901474773491904486023708681373220186533416543102569682170101489320456090594-76043780718458862899109157866543429965-2156027579191978857-1562594467463247754800141154114149475710141277570898054821045846196603043984239140747015687901-1562594467421304709-41191261032500182921014127757089805492-7418484590630376829-1525996079145289504873115507591091578665434274003942482235845780406";
+				XCHAMMER_DEPS_HASH = "version:0.1.7:-6288358196755028991-1528741234-625159552080923365-8127581152973408225-60382488214343808365756812780883331840-4134277424566218741-33471522196820527261494421402726165876-8839739632762004211-3935263738151507838-12529439719501099551299719477725641299-85193012119446840954353427595767363882-78103355334899461277791444040232288752-91726274820630955822459605020710812557-4395783669294421523671055742255511353-8822673737589657742523858672589095422184843977743635452434652312105692804628-7104213273274908219-679758369357832177774856805636566944918728930450344164141-6364728089032654954-37141080762521604717102645385897174716-81707277196853556924606631192293875317-5992982697423040041-8503096995296581571-5693332235794888449-3739679205833104590-5716230757708248057-5693332235794885884-7737114960902499877-5716230757708245492-1732183231285476262-56864347441565759853405109534272837352-5001526426879369789-8714641112548879863-15260030761653423645369305858-15260030761535272661249519582-1231456848849360626-8817116352631290858-36685524108807757306871601550350133619-1660401336883226802-10751367000041273135609641346650520204412609616195565490461807385810137608646180738581000641062869019523553946014-3150152898142868814-758833836900320754144124855096254243098994248409200432061-640852832733112164-3660228457884885351-37940045754428571794413993649482312166817687830895753030463087453622734908942518354807250625054-35832094876687772714122486084028201955-81725562811829785908723483767102732987-5509955735824431380605651250255462328642453609645804892718736311004822068933-7911379599757626890861814268814732118-541563006182789555844139936496852085266895369639536811830642613850307539377280517594734901758289163415439253565236-6791071612180950727-47499881102777279064701900514049240134-22087499345364872392832779069942261149279653861633057628450388512715606404503067917672245375856-4490755223333312164-54777546916441753924522846082039178979-1377999300503704183-8352863455740276520-7265374971314436328606344796120491980989862848830671688278635119860005799164-3156972200500211178-4493159448240012765-69131764098912094768368280218004325673-1292022443148885165-3304070505721311237-9104941123779470997862440537597727494340911856049021524504917806429534330-8298398878721488180-9072952628057915309720125349985307316565498659862126372976439946659928569726-1304025089714858154-63348993169125690149127853244747763338-75896003231532701288626367840418750907-2543721056211164657-5400898642633017152637432928446907742-47935626744626292172591680521115146342567522416347926615926512144663207289428178307958062628175-6468027630610319028-24274113546014331534538352151123026577-1606305425425100434-3378163957947613866-32675788494881577566868730365892065291-1526003076-9278278889258167827812566175111307445-3388684295977440382-467454110316041951268893238645299588751410324345331634547-65518513432487852601955092935153676901-127107518028814312945444905855249199003851830458968974476515522585727202066822505909922428546254810439674437739922-6009988230364387241-5530889120317796390515522585592984338338518304589689744864954272239225251404-6009988230364387266-53915641762257413468120114134405404565-6053821571507700452-15260030764991462368640860393-1526003076-6535893435448276227-7549966625382093590-7549966625382093600-864675401283116154944385674070531325259868862224566973562551257469915666158721958841837778039767321946876941677036064951070679673554434796172552000035764102606912655296726860257567108315047330502488487087512-51199860848237072084735710110545979212-5121459089157315136-5119986084823707043-8019589190449692488-5121459089157314971-2943110492078492025-511954238653118418486175646611307595964702320203394361545-1493776466535590959-5786574452792301155-8193766277298226014-7372569299459468694613401205547220211512655729595570523316551544805842737354596929215555455716559690104099946444655594785526635334326646793480659812552736762066623385500186551537049181670093-4082528341162969899-4584897314664415541-697721589413323834-515758622529230778629511889041549217333954367703552417477-87449488076115256607730087201848753486-791826700871607171392023070781433963457348366877321640952-303949132564988907165052298528417761298323510707194550374671607470464566480056783238092400219942299337771898097735-6218426627557843349-2142975147178256778297842119271503999385713212815202832323828387268151704065-19254712518070027655710838486732434529-1312661305193337751-38121431069173323337904110709232165900652677249264547734255925204982213198615590255469807305396-232847168952895043-6128270926062666841813627502981808093-8255568557670335926-3110406363332343134-5885884301849734180-17702799406753401991327143278253392019-2426301133938682948-17605455274075522996096886364394299575-9130031900143787567-3634511927604692285-2547487143021962340-77894130125660470041428113427913782253-8139139091374531323-8788292607868676777-3536551646188057639-5495793161182187571-4839495152964052892-1766875904516558259223092050874357732050241649474135257383798857740177320715310651746146655037-5099991733499811856380084100999441365-84795810900725735947480126719217394896-2646263051364931312-6553012701856755620-8148026740222166766-3877569293499869223-6740491435518123343-6843729515811553360483471999817582618110634294523412750265401167873245196411-3581858263665924974502581146052373343-5246314261841494417-6971485427664312224-2492181068180577426-6272770664104426303-3458436744370090110685073043780896537-2683429451122438016-80492147277249894492378868911304670439-3532658024982605066-480990759049690748249905294733503774578210355282521841931-5444233158795058188-43572083742123282438258327158363157783-16212486351755729301613999331611416448-6284912160447001145-5150004768672759937-35172559553004190039133129064392374691-1818347041014484598-8271036204017983677-8045810691566207509-25944656568100315584133539807507962803929830206370206044759003682818229339-81493537965891670395108318206660716665-78429075671085670592890694604298872771-7421062955816903248-648268335646231646122134470019866346982213438154152153033-2610806757536177900-2610811181487170285-7694039359625333515-6310197009568247227-6310197559852805815-2610833301242132210-3522019436007647199-542064694272627824-7694039374775523592-8474226909220024064-7309776704094514855-8111374297628993354821978319853532376563039625497418051316835015287969738065429176999834868582-7362205280966450237256170680221278981155935718221191645761110143800563465822-4858077158909826693-8492987856046367286-24100286959201428651688981508573441181-82869700787217278658976807282019227458-79221780915896233819021224226522360184855354868402289927-69146104409732824595910938465956068880-524144191079761359232497833882361565798713389432766028737183947079129660212-3699089071454493504111019698872830984253799976542656500817898661046773997236733538305730352048510802385169512846996581767030127137418-23446731408255419914321642933617249167-3521904517777048536-2610837725193124595-2610842149144116980-2610824453340147440-2610828877291139825-26108200293891550558555452417355842313-2610815605438162670-2938822436793690161-1232413468740098129-9135079840563352670-5482526698923264350719586268854206016364695106565051439962274313002832105037-8393787989959356178-16885366532351566091746975511865627126807542795537168648-58251264939399509481956047681886922091-6966748678664356642-765544592097642657660176597029632869011262160510426388191063250000745609258-15260030766155837777447791185555180580880402987961306462437014925523792103567000533931-35794562027322895977899856359537626651-405845017607979129-15260030767376824730530108946-15260030762141334976549772774032517707741090651-4233624876059059156-15260030761526724274310261010-7705606381917502926311924942741305459-3303403580083128353-1401392915548016578-1526003076-4640083926643311264-1526003076-7167310544517755913-3316872733268048282-2668102879498243495-664410252426410991610198059207230991775762501857920134745695603996541480416-15804293884346022471697734091693268603696962731817779273712251549250807186542268319702637163130-8133296424509437734-23419927703472351036839031271405954017-152600307636443575754559281241886184408902292833572995912405592613928898098684645666101545678329232201323900674989980358531816614207252015835298398670188157077426473839883826916265520896612127145770477308095928619283807580639712350944267-129552346130861408435462566494140444113791493290785673680-3113082661175420430-752112867173593273548180549681873431194984058908126699501-5642191498403160420-42765478873000687525427933236270554864-719581521975744232163636048431725347262385408550854413300-8549361376419041361-689372826271862954-7832057291281250321478598462420017430257106903880620427-90316216614184603025680420442155517370-5802799747169749908-34313714234312231328324149825656375221-4157034761695768357-45813488770335126265083617786186329315-816146917602113489290435416493488488883119889522755866645-152404704165266564-8018059094158124527-88933772053968241685930654023487599300-1470305967770704319816173866538981706723057264362530467521941257820937696134-7966503142036655973-8186879483480321576-245112927284386498970090366387613466788055045448335830937-269423830264515204436199529985541009-57546285782371287227865521963022381768139746612049277764-1388079287242474083-2025467090525392655-2542361022372236877-856735154416247845-73142352787238482113884905246360781714343621198860804247-13164294875514461547156173040526735466-39552854090526584367750854517315209896-3558641751975588251-5307793940765268648-5796475101255899363-15260030766387044576134307705-3485449558707374494-6126100305044383500-2444744535384534045-46909909151583635512128532207145735214-87211691994778592055415113031084758205460804251727766172-241967167414164755-3676008832771799094-8990617093888060255-5297356217388820075-40745482773221536836011112225283823097-39144061772924761098950047545965747566-7015353696821060680-1579301499827916139-6413151576581837856-35485240421127288516849031811278465648-3064615879736349805176908159358548186529366318458330011569477899761402113883880711270529188492-2708080657353942040-1410722059457395103-157084949046356119168459032928027751625939837956867378818519554173062751367424278191108217666875841360244493395880-392187327751438698863280246876434770871671793224851524891-1669610491412207910-1778780224350574478921985491080305686-6030169184083256257-1635371613213251644385508353664111379-2276897842253992548-875091218057005008453420783053029545746841353373555654079-88974720570347094031960525005642892228-10437746484191304546899747735441604015021977251994593724-6927344446959083812-296124874273086486231913519200555018595568768902497164670-1173678623890283459531927443983515257-5822033789854788956-12038502526192760318073618972548190059-3352750878535187145-8923540001637630438-43007052939834261545611524726921317207-6896431049687450580-4317934488736766973-5893873044751362001-7704705721171217913-179654088986104428772847863863115833983259891880731193657227512743134386866-6209193207895986590-9188556577077433606947004906043926540-1993350364200522510-11880320480377782533057920468480903929679534660323266005-5076917254627924371-82774216565313773258733551190231226107-8895871284016191026451841227937266037-52171793776686923385385943019454172803-8019814682953850220-73400584296079757985700573827528268674-8008864640877665075-159070591036284715384770914844941766738140414324908999250-6732028858017753634-88566507269653756057379297498523217449-620553260615532224443719295194668317073274229143885165688-6821530191601417588-4845417309374295134-628669444307311506185620041632768463883788060588556392641-697289421152423575851865240563483979-281452600067992742942808963382399254548691486668433783059-8747829503930845748-13827412628222951488767991288218703684-69781443842047776604004899083114571213-5227130954526229024747898033952934414761201275354845044574801444093347979140-3678437330460054427-4148559062256021758-4237219235271458093-168473074510757286-659271926917205019636347453833172549865154280816800775607-4153106297453231996-4699621326843683556-8840135289005628215-6614052580508916645-3714072650663389391489197319920024748-88401352890056285402445822445969515804-3059819806956708943-1526003076-367651417536274514652978464690012906491570271255273625290-90508664226033576046541374480621629046-1526003076-8495077373402898375-7158351082335208479-1526003076-4281405130236941053-1247917881884048830-23586488972818944028793801566945969261-4926124019704711310-516969096345500119960315296318748353331175793694254356330-3337262563397200767-88392372722003355237396472256889830577-3570124156817500637-26727143729482778011746638970359548279-779555999714973585-3803898622829410383-6253402244944497348-58482862531945420982752647107835212628-1650750338012684784-7405417351542802688-4196715802433962758883516146679463748128261779232741037663600975661636535417-6409119042869162750-2331876988663372174-48901896218876547258607564926471855562822936233212702306652761779294653713346067273396248792443-8460245407341213094-8784977012973368003255457605804662363-1821098838944477813817413682076660702419096326314421075694401153039050997490606727339591324811852761779294652894092283807083293135489-1821098838944457328255457605804703328-8460245407341218219-878497701163119071819096326314421485348174136820766607014-4769125909986744838-7089411941337306861-1482278719767534408-13879718724105986978500498416650184647-4730396681227033416-34666060187450514265782004295749229887592534963366664913733668326896137017187546082815954945665-7728251334121590463776152710382900280333370530391011912417370354282556040507-28057986324603352825733148137726783808-647913010554090743745268656733795945657034953454014679118-7994178997434863040-52405420766156640483280832349823300162-31924158696330469271652425007508807513-7092128994452957331-10117687892159397196628703684387339185-978924658430755964-6814424480501123310-428500297394963693753680732731535994865061922473371401594-775219604413685410635197989192209018173279903404400494775324020955351607823609094715711074677-6420595460832702265-81705260889416332097979883999726146511-7658332669860033457-7527786287270510380787146444951694907624103136369554518655238289236063704153-5778029752892243500-1280964652117995692-9051092036890502186180914886264953531826457492904018005142043189999572686062-13732344322756171044335158747632751988-1187337684368004705-3764858474401804361-82116294091253688621580898021197091384527658396219463332-1818789359085383238-7949714289438322898-4852496667562251914-49330014766263951665889211618073531318-1526003076-796698872077264795-1526003076-9705690220589269214894475122324269683-1134802210541538244-6981328987040365716-3761028139933987244599610089539580712-2335175417995500276-7825050461549711416-4190327535115935436-5224225365818131410-695310636263247159937783147299798738289267060533725875976610885368846609149-1145725280989078071-8331088544884050051-47073307720292397997482902163776257269-51543058188856340017630987525852641074553871026313709650869619230614339331493993821553587047365-8784910000677868388-42394731512372507823033071542972004757-8906932480921727047-21342637900629975501767597606508428790-6297180371633691519-2435692012266303023-81157518549531440771124877710314046893-2185874182097205458-2493809555682829118723530668948626402312825230460559288331066760166897520798-85401125260060689331374695540483144458-22780466765244210833190716878713886697328288937314110232229749539995554786626276504865909496445658444023949512010532703582412105962735620341621538218831-60264547054174536153388909567958875526-3681831097160434328-3825673016599373018-362038276754229057847910017371247864726492267745067904480-6383333960957439677-505207853501188168-38931055807486979291783505921171904038-1117833916971200837-710678880438284705848960986276193744326334622409326022540329204699559799870138052726182407048013651651794195345426-37869279876550222884957546957237518182475225670818043574290594145668374470524214750079921792109-77499385959976405786120311778853240688-4417989449255371425377831472997987382435710440331184744-6368823670957377827679496471087770455-80770474512936943894445027262682731084-4941421946963987101-194720502399117992719888456442691776595627137871089238366226579386925720408530846831014965430718084334424535979078146306076646178546321662421663083303375431591389028275282-2749938126786598549-4138688844168568479-522747398434249721848244047682938197443565155604958783054885414626564913748829448263756839378631084166433269544550242989290628210248-956425109723390313-2252140799583057280-80737601256801804816150487541201987838419511270404986154459409472819923382435558760739261283116-612302088774376839341644041463963408634081368468737051325681727140279122642-2475939619058811992-42258036252217919726202195774299064068207590181924755594-3248139340991688318-61596041144185443583335988715141230219-1396431592173809361-7629794126152141378-20493206733217627727087227858069801285-956054997040117908-8031520077650822904948861400660369852-25376367290126234646258739680571891916-51211463866599433229084102088106898188197512632790680259-3132144599918905887-6349868605803841123-294336752141612712386187687392667880951788968703341843580-365672157178991430639828274884758080156893070955585607512577460713172325752-242057754228751994962455446241351541942851851314011213384-1815539201523113347-5440571645688278963-84280052588953959723450816954283867668863942548652000572189240974340584555177486074495789338887249241495753847910-2475939619058811947-1121670015686922814-8312572403905222273-3057990127772671874-4760663122245964105898304023302542698-25376367397500417091444580081107484972-81964178377097427728859023305497089540-4700079979463845974-2922752271709623641-622766075745936341-7629794126152141353-383275316815624095-3560599915257403304834995625705456424521357289150235939178238030736751008143880278428263086739-422360132388858314-35643138251131329824286108716968703249-5638518492402163506-1210458290321899040-4317784823175390936197512634132857544-146396473886458636866095342403302349593702366119596222270-542699011557158948135309001640809287284202563305331138122783755365303432833-7727153335992152264-5147636565884801150234923782235186148771838776343510838427388705766054149557-5251102098307496386689307095558560776-8268432357580995279-8242415928239843003-383275316815624095768579975401281857-49292671792139049328377855220943777643-433589210379710431383781651793674137206517715242925410729-1385587311556693283-62560646674672679616739506027368347365-6631847261576796971-4819967658118989137-232236568116642575457134080565997708776244422481184492783-5349335554349965019-793789065559052559286452801125796420687134260618390311564-63753977149370812418887196445534816291-20062022828119874698781747288799986714-79378906552549812677134260623759020689-12481407919191348118645280109895287503-5715938921756588203-453826424638266473931141660782921230679149486959577439271793318455059610473861486619584928949811270809287876861343785399047269400097-6827640233400367351-803548438005299195654670574257348150655303976015542186802-7329035232613196696-652921852511752981443735454979812234636488742889849078382-27515224415587985525303976015877731127-8853827456403007628-7329035235297551261-4899542165720367545677201468636457042-8718637113309757071616748972592429731761779114499820525872454438601534579496-414753801771366765-47761256332218572616112510257972573286-56506370599155184821075507973400796189-527697267655882601213817212841006084794432873544769820729-3463398475174406645363457827493890105-377380452828307662-3576712009430851538-28751945045309080297676473101380465256-2046290019668225379-2044847011721766957-2586747201859103924496045819375785809-2834409725670062551556778747359356958-556142774201423509075137505798447849313077890917403635090-1934455437485110875692159179162814988580134672606633490636741683406090929104695648167124305420-2613936363181450758636891760207466969173335216756648208183101770413255601284-8747694897020393319-9044045487838555760896493232373482113-468168173449263395841980199264015086775204398177347571604-9079423103187971832-7914365130613526057-2161305099059717292-6881507665145303421125465987847273358934136075210837350933049929642648430674-6086182942847453352-79151382290148458356008141613074661144-8539093572240009966-1471377448348504661115138708192653618872701121801659062467813391160768779693309006681396163437-8176887294210299528-3187414774956826235-14097729885598808965981941226029992265-4210367345068762426-2005289398849250087-676211606060863145781468850420823335944281173655498665400-5182002791343488684-4194705972447136740-3087479124259976392-316862878396732553-1136163601765758374-3394435455270461177-8753763127249139155-11139204834187901-8902501216086666906-518315659964919314025096356924677422279855117440019763786894422349044473807-36951272019531002037287544762683465481-5169250964253841592-895069337183609468649720969796310265987246435784668698021-459542983181964665617782749238038358011805798600681899613-174529502478264952046748174294343777933198188370418870922-3892074700216424717-50107783746536494677632735796393743205-9184590275627758538-1933604428369329255-2132431483438464960-4097893930779672652-8317667152951061421-8212891282038274847-177981802027109634760669590734648473342433508380788769877-60573679895741308867311023945053348411-7067143704493272960-544389227494426691061563134373995685056377030719274067120-5898058651976115520-659559807688989539816657332197579667695575505883293818809-1802668167165076527-8491105828757425142-3341232965002024060-25822137990489100341011050961120084925-8577410666130197131-176530929071345311833822812235273495061105355693358873102-62843760032514585464133339305079997843-53781778847673809775710378855343154874-661284435205144056092070049297286619312942924024171453781130346421586413440777032975222720752657914825941018893214-339624676403354735131580606116742358403274716637676675931-45426619553725244183593526948187400416-7877796003287710063-84742623437248225562408252047810758816-52940718149050335692835329850097754668-270961683254164430410624132812476947695307487593622156123-9064801347735411090-25359223904984151891525240527319828837-75790594034630166034604076767023126228-274995838780632132225918181117081134951821327664221711191-8837035345947275893-7414344868247230091-6165225340869716025-3078878278168535299-5829871064434219095-307348737599347256-2053078631430210142-225792610789366642-3789191180834355794-4468664412698789925-6229389359367994440-5460644930889091694-1820226575366482416-5573366829382614831-26265617814103096765933289971719634064960709126412218700-6205603455155531845-4243704448529556532823810542351631234382581734847029032483940238870328980430-5522260092838658363-171706353693440383280382597315432398624576440848861309251-644522185878028136839464769835835238765575505987278203309-82056129026594002436679239721899280307250153808669790427-280826729832133390112968069048073409683438361088646894565-72957878487359753863923198511947394696-1503842792422343715561061114868528351890331319288134335297468858970196430091-42262585803711774485767184731584216991-7599115033518445073-100781923161547993249353132049547197142307127630215586469-501902008888689262349394948191629446786379528637582071411217583037964858282160217696816962918706423003791250816757-3223371535339445124-3127135808500121966-2901994304945086137-49885317861984911119964001945432188957683605686430710402-401693023802682824931662634035034969733546218473837268331530000919095425544187002701608283592813443945910834607110-1091048355475292934045701469602030601430815936674340509157590955782073770374110190893232214876522525865532224748-4852523154984809169-70718095985075663798812948801769003369-1526638894741725860646502009357437980-4726768779329668485095151908418333511-19957731731786434874474910567404422694-689550462957005544614214623266641433387652590408139119650-31873746830631747602217329615139190510520417320871753470-8527897472928073793-3596554501154075776-35176863685813184556615201382845956654658619235282262685-4388364184419427017-2468094558179903037-2222634759248221485-2918033024608143503-1546085490897988135-512167485709632371834740260997164482671795508156564397824-5051274922166090834-33450118452945996614312735637225355000-345150458064632478568239690213948552-70986664510769432286317154337942495606-848742215927515011460975615218769663-6730167001796923238-52820576065816381383947262113824803323-2661182248811255-3357994968678479832-5118389374596138463699918911829966200588144810616297866443916804426418544366-73388165254640875281096274672067789202-59841872266865015071575880651673303024-896626634567202629-3973824334111789408802067695056816302054735445092431823136865285427666359493-58023804727241052996905402070429354265-4375252574367817516-7243298822642518815-2125159013359710027-53868273159179049302974706781241914372-41232474418348581034794452273715899114-4080242544842497134223246842837994459-6598188437199621734551763076811897001534398395038838103604404453172856958641-2034645283838495439-4652948815102249686-5176707467742265740-6135278762527379555-43423786945530220717569248098286910076026532733943712448-4021675831347664061-13839456383449038271470231095469740733-7866905609764197711-91616324642387145961374059894507911026-843650296309480433-425458504850825433035923854340590905711753982806121238429-875626975566018339-665211930601524861944285080249618423495335111311786529427799120313719412607384631423553090401891661101987104498525-80435943350704115653572356738018736412-55190792299225417906641485388936134993371132862139756772-6597971659485448829-7707122014974671293-3645867622584752785-7134241574121196420-2750253996811258012-5845365503403519309-2052146672475430252-241796785347409151940461284661010632526383876467937572076-72719328047699969972996472598591174885-5270358078237845207512951553471418128035849202237582338-3219947368750667218015015702331902723730364443820219796-820120563086724428-5192094348209241803-7679870751370372887822882412461032357-1193758241417328907-827265738065949982731070551188017139817207598114930752004-65665056297987556492643098470856715155-3901191875636154323-563175023983409593033244776600119796809124201921753198390-12052297130013134911445197854128460850-2404005507926423982-8526255095563922897-2558919304214119491-4790908473848786039-74353138092654979482060572321262579390801955882184071624110572745229591562811689194277922849530960401121724495008-6679344303880571062-69293431181876308116875574267534953938651848514302618946841996244989316117-3956555483215890724540317690786904390521047415104595233067190950934814655868684935571550876445420051627479834549811656316175947979625-2043870489941177598-49878168745422204447994366859931621607081315117216444188-2174127200218033291-8681676996500633881-79639551360701324961952855078270405763-2589184750142578204-1526003076-3035477635310127076-716951303932484775056954956395986790683903097868117163587-4519820537800878267-693019694717118091-6668692085959600120-203178043555181225936387624137854042967269788246008030306552533537581554877829517627928420650608048567440939591080-7181705399910920922252593239774917110346460618519637325684772084111459909480-321170690730928265233086298613266812027923646027654729229339597383312226546-3333421213018531033-4965454008996699967-8771705147701039074-8359060660060040481-66582308094961628086206444236462440448-45414564067952741731325210071875284950-749815479753010241081401073019888076376098222197872335419-8333354272496132890329147268100519028730442467355015070423660931726177763061-8541036952435566581-2810577045155306996-44775908345559123197178482531175756451-4515636939078405400-391660361426691452745440803528003896584831748321654586557-155730802064394239-4437108634226049062-7364796349800781112409196580649229644378219470684076932645187174352346844524-735859197586315367529344388400528376417048404091358947001-57573038881269907081856579905749732736-1274552137397719970-2635897709557671302-8207637926964430386-6910086239979666778-4023697285195740710-14068595500198817456446233607014977936318094160934690100827332778144071102706737669181012320720-7037750656072528177-578286472053220904-281830666861335077729575832338164718973771450323180139292-396714161266657804488075006803690842135628485765468962081-36694966746658019427264945448351093968-366949663996920597270840963830029229592264561337840701328577401385408061494627293754984809470503735068288016002587-39825312560684878022666527073941464152-75913553740139191390805442600750473746637162286404733808-52130613266928507306286899842312301210668486698384133737341304272909762284067981725187593061929-5683952608406310634-8839386949466998240-6222141508998867018-5626844914698326118874608548703478555687278944607785682112618376864683137907-8821195923210780895291080598650767429335483149885745109017908961134613086504-1413650404075128766102754681439619868-2884612169130874665-3674782572556734428-458132337884983856-8570464418427644132-78302193659170985927857945461549236257-3252440553084189214-5234075855590945825-5038863812503903654-825379320759257024160729412188425723386655053521244289843-577177557815291680-3394546762668311010-6255877529041816426-8552273392171426787-57046391255864525964198765959890670289-37111646077208711333073954286494461351-2999649891948001958451417533655920859445258395048994483507194024328511519888-7237578662108811328-22233746569579659827826953789954043373098668302056050266430889140571265618-570464094513264787157817612480277920644508037899125166490567226248658030351581102104055897681297013001442972983123-159424347215952779139061564737404763598278268965405706928-22233659828089734-7237579234602644833719402403359045414314345202476004145508550156463554200665-7670381267339215927-34950137307578034417667367618245775893-23301048162657227435188066065624043467-296670439362138203143732943502749703233456915979151267833-1001266383669959208-8895167797984724402-7438359144146465571-530332696065380335733447866281245344884314185392486779726-173839930974223364981011921176220141336448595910967229658-5632287036852893840-2280237633043641692-2303711855119035847-8752795494251161142154756135608944138-180402517796697351724109251737220524727396622028415579550-3333825881623888501-6158548229838823896-176863822700069263931019793963095407612812254686513093246-15592275373005412768762332745831003473-2611233374601175613196905969243398129-2482431331295635842-292792441461375510323997672304946084601598600439644182823153137560261980289-59183229682195317936818621609795822525-3884465495851147321884288524079621069-1366544142676916416710546103673867753583385357569255388822331373111673037669-6658230809496162798-17014683408699008435965864940979985448-40299608227823787573189319794986921620455774679055211334745998119014430028813166056298299613310-7571657719168808752-75345797814504881862625681161785027816-870595183713620388554320186934733431743186078393418545313-8359060660060041766-8771705147701039064-2515189526871677385852066050016478325133959737794351742147720841114612202058048567440939509155-71817053999110028473014744856580499527-646909495897373320772697882460080303914544752299633384974-4866277730678672981-23521490071737288-6668692086295144445-20317804355518173843638762415127581581-4313722248467368635-1518852177289516928-693019694717118076-4519820537800873142-2526980938240737877-693206641796218522-73647963498001257477821947068407692619-443710863389050473745440803528003896684831748321655897282-8201685006476504368-3916603614266914512-4515636939078404115-73935556522994475372224671552417733441-2810577045155306981-44775908372402668847178482531175756366-7429189352617188988-854103695243556662630442467355015063973660931726009990896-13788855565719377628296296424379741556736064233297153537032914726810051909326098222197872355904-8333354272496131605-749815479753014337581401073019874969121325210071875286235843482721239717366173966220284155798756350798284581906381996655276010968592410925173722134397-4127127390574901813-1804025177966973842-2465970604508704089-2303711855119035682154756135608942853-87527954942511611328608676348624137008881214332146714996-298577389795978414293333940427718732987567477470556089635796989219167853995770549675997330466-1358979662825235698-370422568353326600280662634064100490868307973939553292195-30462347467413298826771879507365573776-8636065996644550998-4845297310004774885218008606068247614-8500695516163834343-29018430241331847671177805804815435830-342730347896704140528096930365830691828142738091074011380-8789246303259861697-1763920391147123947-3520095705333537674-151748765064788558167132976652127145057722215138570448222-3281537431820122565-86019702557733461048799338991376374081-76888745966259430386771872737040863882-5911203831163099997-4241286257166168436-1150503864732357606-54475669854943318282243660330286555998-7190073336464191253-5192054309786832590-1030606986822531793-18602196883088440447667584264502437230-68944198386575130251655202644936269836-83996128211006595783422673402514364495-3704194404602394948-4043920680767265844-7972304014786459250-1750048072274500217-8010387545547281558-80626297827729978291610896181350727305-2902245842709360599-6910086239979011413-8207637926964430551-1406859550019881420-402369728519574070078963101924597345921856579895012314491-1274552137397883815-8395908726055591217-5757303888126990718-81262763588412788372934438840052836996-2269763192408375159-1322906815574988758-1899598815819581511-3613551578840303615-13665441426769189817105461036738677620833853575692557984788428851334220282468186216097958225503153137560261980264-29279244146137551282399767230494611025159860043964420847-5429152979531151567-10152453412935454609147264332990683764-668205655209802023933591523673204820573196905966559043564-5351712480984760014-1559227537300541301-65064994797568522773101979394967363476-1768638227000364954-6158548229838741971-3333825881623560816901474773491904486023708681373220186533416543102569682170101489320456090594-76043780718458862899109157866543429965-2156027579191978857-1562594467463247754800141154114149475710141277570898054821045846196603043984239140747015687901-1562594467421304709-8383746017562828375-4119126103250018292-11720430940967520901014127757089805492-7418484590630376829-1528742058145289504873115507591091578665434274003942482235845780406";
 			};
 			name = Debug;
 		};
@@ -4236,16 +4592,117 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
 				PRODUCT_NAME = UnitTestsWithHost;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4266,16 +4723,53 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -fobjc-arc-exceptions -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-fobjc-arc-exceptions",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4296,16 +4790,117 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
 				PRODUCT_NAME = UnitTests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4334,16 +4929,46 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/",
+					"-fmodule-name=PINOperation_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4362,16 +4987,52 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4390,16 +5051,46 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/",
+					"-fmodule-name=PINOperation_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4420,16 +5111,117 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-lWeChatSDK -ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework WebKit -framework PassKit -framework Contacts -framework CoreText -framework SafariServices -framework CoreTelephony -framework SystemConfiguration -weak_framework UIKit -lc++ -lsqlite3 -lz";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-lWeChatSDK",
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					CoreTelephony,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-lc++",
+					"-lsqlite3",
+					"-lz",
+				);
 				PRODUCT_NAME = UnitTests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -4450,16 +5242,69 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4478,16 +5323,52 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4506,16 +5387,28 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ios-app/ShareExtension/ShareExtension-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
 				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-share-extension_entitlements.entitlements";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-sectcreate",
+					__TEXT,
+					__entitlements,
+					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-share-extension_entitlements.entitlements",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.ShareExtension;
 				PRODUCT_NAME = "share-extension";
 				SDKROOT = iphoneos;
@@ -4537,16 +5430,69 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4563,6 +5509,15 @@
 			};
 			name = Release;
 		};
+		BC_823899891620 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 		BC_824394874758 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -4574,15 +5529,66 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wno-everything -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wno-everything",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/",
+					"-fmodule-name=Stripe_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4601,16 +5607,52 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4629,15 +5671,66 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wno-everything -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wno-everything",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/",
+					"-fmodule-name=Stripe_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4656,16 +5749,46 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/",
+					"-fmodule-name=PINOperation_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4683,7 +5806,10 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -4711,6 +5837,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -4718,6 +5845,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -4756,16 +5884,46 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module";
-				OTHER_LDFLAGS = "-framework Foundation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/",
+					"-fmodule-name=PINOperation_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4785,14 +5943,34 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Weixin/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Weixin/Weixin_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = Vendor/Weixin/SDK1.6.2;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"-DEXAMPLE_DEF=1",
+				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -4803,6 +5981,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		CL_100178272237 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_823899891620 /* Debug */,
+				BC_229340051279 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
 		CL_173102942353 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
@@ -43,6 +43,20 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = ""
+               BuildableName = ""
+               BlueprintName = "ResetLLDBInit"
+               ReferencedContainer = "container:UrlGet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = ""
                BuildableName = "ios-app.app"
                BlueprintName = "ios-app"
                ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -43,6 +43,20 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = ""
+               BuildableName = ""
+               BlueprintName = "ResetLLDBInit"
+               ReferencedContainer = "container:UrlGet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = ""
                BuildableName = "UnitTests.xctest"
                BlueprintName = "UnitTests"
                ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
@@ -43,6 +43,20 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = ""
+               BuildableName = ""
+               BlueprintName = "ResetLLDBInit"
+               ReferencedContainer = "container:UrlGet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = ""
                BuildableName = "ios-app.app"
                BlueprintName = "ios-app"
                ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
@@ -43,6 +43,20 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = ""
+               BuildableName = ""
+               BlueprintName = "ResetLLDBInit"
+               ReferencedContainer = "container:UrlGet.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = ""
                BuildableName = "ios-app.app"
                BlueprintName = "ios-app"
                ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/ios-app/BUILD
+++ b/sample/UrlGet/ios-app/BUILD
@@ -90,11 +90,13 @@ objc_library(
     name = "UrlGetClasses",
     srcs = glob(["UrlGet/*.m"], exclude= [
         "UrlGet/NoArc.m",
-    ]),
+    ]) + [
+        "UrlGet/Some.cc",
+    ],
     non_arc_srcs = [
         "UrlGet/NoArc.m",
     ],
-    hdrs = glob(["UrlGet/*.h"]),
+    hdrs = glob(["UrlGet/*.h", "UrlGet/*.hpp"]),
 
     # Not added
     xibs = ["UrlGet/UrlGetViewController.xib"],

--- a/sample/UrlGet/ios-app/UrlGet/AppDelegate.m
+++ b/sample/UrlGet/ios-app/UrlGet/AppDelegate.m
@@ -15,12 +15,14 @@
 #import "AppDelegate.h"
 #import "UrlGetViewController.h"
 #import <GoogleAppIndexing/GoogleAppIndexing.h>
+#import "Some.hpp"
 
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   NSLog(@"%@", [GSDAppIndexing class]);
+  NSLog(@"%d", SomeCC);
   UITabBarController *bar = [[UITabBarController alloc] init];
   [bar setViewControllers:
       @[[[UrlGetViewController alloc] init]]];

--- a/sample/UrlGet/ios-app/UrlGet/Some.cc
+++ b/sample/UrlGet/ios-app/UrlGet/Some.cc
@@ -1,0 +1,2 @@
+
+int SomeCC = 1;

--- a/sample/UrlGet/ios-app/UrlGet/Some.hpp
+++ b/sample/UrlGet/ios-app/UrlGet/Some.hpp
@@ -1,0 +1,3 @@
+
+extern int SomeCC;
+


### PR DESCRIPTION
Add a test case and fix for CC usage.

XcodeGen was missing the "cc" extension for supported files.

This patch includes part 1 of the XcodeGen update: which includes my
large rename change. I'll submit a followup to address renaming all of
the data types in XCHammer.