### PR TITLE
Remove ProjectSpec naming hack

### DIFF
--- a/Sources/XCHammer/ProjectWriter.swift
+++ b/Sources/XCHammer/ProjectWriter.swift
@@ -34,7 +34,7 @@ enum ProjectWriter {
         }
     }
 
-    static func write(project xcodeGenSpec: XCGProject, genOptions: XCHammerGenerateOptions,
+    static func write(project xcodeGenSpec: ProjectSpec.Project, genOptions: XCHammerGenerateOptions,
             xcodeProjPath: Path) throws {
         let profiler = XCHammerProfiler("xcode_gen")
         defer {

--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -293,7 +293,7 @@ extension XCBuildSettings: Monoid {
 
 /// Mark - XcodeGen support
 
-func makeXcodeGenSettings(from settings: XCBuildSettings) -> XCGSettings {
+func makeXcodeGenSettings(from settings: XCBuildSettings) -> ProjectSpec.Settings {
     return Settings(dictionary: settings.getJSON())
 }
 

--- a/Sources/XCHammer/XcodeGenProjectSpecExtensions.swift
+++ b/Sources/XCHammer/XcodeGenProjectSpecExtensions.swift
@@ -9,28 +9,13 @@
 import Foundation
 import ProjectSpec
 
-/// XcodeGen ProjectSpec type workaround
-/// XcodeGen uses a name of a struct as their module name, so we can't
-/// correctly use namespaced imports.
-/// We should fix this in XcodeGen, so we can use ProjectSpec.__TYPE__
-/// TODO: (jerry) Fix this when realted PR's land
-
-public typealias XCGProject = ProjectSpec.Project
-public typealias XCGTargetSource = TargetSource
-public typealias XCGSettings = Settings
-public typealias XCGDependency = Dependency
-public typealias XCGTarget = Target
-public typealias XCGBuildScript = BuildScript
-public typealias XCGOptions = SpecOptions
-public typealias XCGLegacyTarget = LegacyTarget
-
-extension XCGDependency : Hashable {
+extension ProjectSpec.Dependency : Hashable {
     public var hashValue: Int {
         return reference.hashValue
     }
 }
 
-extension XCGTargetSource : Hashable {
+extension ProjectSpec.TargetSource : Hashable {
     init(path: String, compilerFlags: [String]? = []) {
         self.init(path: path, name: nil, compilerFlags: compilerFlags
                 ?? [])
@@ -40,7 +25,7 @@ extension XCGTargetSource : Hashable {
     }
 }
 
-extension XCGBuildScript {
+extension ProjectSpec.BuildScript {
     init(path: String?, script: String, name: String? = nil) {
         self.init(script: .script(script), name: name, inputFiles: [],
                 outputFiles: [], shell: nil, runOnlyWhenInstalling: false)


### PR DESCRIPTION
Now that XcodeGen is updated, we don't need this hack.