### PR TITLE
Replace use of &&& with flatMap()

### DIFF
--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -910,7 +910,7 @@ enum Generator {
         }
         return results.reduce(.success()) {
              result, element in
-             return result.fanout(element)
+             return result.flatMap { in _ element }
         }
     }
 }

--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -911,6 +911,6 @@ enum Generator {
         return results.reduce(.success()) {
              result, element in
              return result.fanout(element)
-        })
+        }
     }
 }

--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -908,10 +908,9 @@ enum Generator {
                  fatalError("Can't write genStatus")
             }
         }
-        let result: Result<(), GenerateError> = .success()
-        return results.reduce(into: result, {
+        return results.reduce(.success()) {
              result, element in
-             return result &&& element
+             return result.fanout(element)
         })
     }
 }

--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -910,7 +910,7 @@ enum Generator {
         }
         return results.reduce(.success()) {
              result, element in
-             return result.flatMap { in _ element }
+             return result.flatMap { _ in element }
         }
     }
 }


### PR DESCRIPTION
In order to build XCHammer with newer dependencies, the use of the deprecated `&&&` operator needs to be replaced. See https://github.com/antitypical/Result/pull/220

This `reduce()` appears to have not been working, because it wasn't modifying the `inout` state.

EDIT: It seems that `flatMap()` is the correct operation here, not `fanout()` as I originally had.