### PR TITLE
Handle has_swift_{info,dependency} attributes

### DIFF
--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -536,6 +536,8 @@ public class XcodeTarget: Hashable, Equatable {
                 break // These attrs are not related to XCConfigs
             case .binary:
                 break // Explicitly not handled since it is a implicit target we don't intend to handle
+            case .has_swift_info, .has_swift_dependency:
+                break
             default:
                 print("TODO: Unimplemented attribute \(attr) \(value)")
             }


### PR DESCRIPTION
This change silences a debug log printed when `generate`ing a project that contains swift. 

> TODO: Unimplemented attribute has_swift_info 1
> TODO: Unimplemented attribute has_swift_dependency 1

Is silencing these the right change, or do these boolean values need to be acted upon by XCHammer?