### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: generic
+os:
+  - osx
+osx_image: xcode10
+script: make ci

--- a/Makefile
+++ b/Makefile
@@ -120,3 +120,6 @@ run_force: build
 	    --bazel $(ROOT_DIR)/sample/UrlGet/tools/bazelwrapper \
 	    $(GENERATE_BAZEL_TARGETS_FLAG) \
 	    --force
+
+
+ci: test


### PR DESCRIPTION
This PR adds Travis CI, using the same pattern as PodToBUILD.

Currently, it runs `make ci` / `make test`