### PR TITLE
Generate bazel targets by default

### DIFF
--- a/IntegrationTests/run_tests.sh
+++ b/IntegrationTests/run_tests.sh
@@ -38,7 +38,7 @@ function testBuild() {
 }
 
 function testBazelBuild() {
-    $ROOT_DIR/.build/debug/$PRODUCT generate $SANDBOX/UrlGet/XCHammer.yaml --bazel $BAZEL --generate_bazel_targets --force
+    $ROOT_DIR/.build/debug/$PRODUCT generate $SANDBOX/UrlGet/XCHammer.yaml --bazel $BAZEL --force
     xcodebuild -scheme ios-app-Bazel -project $TEST_PROJ -sdk iphonesimulator
     assertExitCode "Xcode built bazel targets successfully"
 }

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,6 @@ debug: build
 	# r
 	lldb $(ROOT_DIR)/.build/debug/XCHammer
 
-GENERATE_BAZEL_TARGETS_FLAG=--generate_bazel_targets
-
 
 # Run a debug build of XCHammer
 # Development hack: don't actually install, just symlink the debug build
@@ -110,13 +108,11 @@ run: build
 	$(ROOT_DIR)/.build/debug/$(PRODUCT) generate \
 	    $(ROOT_DIR)/sample/UrlGet/XCHammer.yaml \
 	    --workspace_root $(ROOT_DIR)/sample/UrlGet \
-	    --bazel $(ROOT_DIR)/sample/UrlGet/tools/bazelwrapper \
-	    $(GENERATE_BAZEL_TARGETS_FLAG)
+	    --bazel $(ROOT_DIR)/sample/UrlGet/tools/bazelwrapper
 
 run_force: build
 	$(ROOT_DIR)/.build/debug/$(PRODUCT) generate \
 	    $(ROOT_DIR)/sample/UrlGet/XCHammer.yaml \
 	    --workspace_root $(ROOT_DIR)/sample/UrlGet \
 	    --bazel $(ROOT_DIR)/sample/UrlGet/tools/bazelwrapper \
-	    $(GENERATE_BAZEL_TARGETS_FLAG) \
 	    --force

--- a/Sources/XCHammer/main.swift
+++ b/Sources/XCHammer/main.swift
@@ -94,7 +94,7 @@ struct GenerateOptions: OptionsProtocol {
                  usage: "Path to the bazel binary")
             <*> m <| Option(key: "force", defaultValue: false,
                  usage: "Force run the generator")
-            <*> m <| Option(key: "generate_bazel_targets", defaultValue: false,
+            <*> m <| Option(key: "generate_bazel_targets", defaultValue: true,
                  usage: "Experimental generate bazel targets")
             <*> m <| Option(key: "xcworkspace", defaultValue: nil,
                  usage: "Path to the xcworkspace")


### PR DESCRIPTION
This change makes XCHammer generate Bazel targets by default, without needing to pass `--generate_bazel_targets`. A quick look at Commandant shows that this can be disabled with `--no-generate_bazel_targets`.