### PR TITLE
Allow source files to be missing at gen time

### DIFF
--- a/Sources/XCHammer/ProjectWriter.swift
+++ b/Sources/XCHammer/ProjectWriter.swift
@@ -49,7 +49,7 @@ enum ProjectWriter {
 
         // generate the project from the spec
         let generator = ProjectGenerator(project: xcodeGenSpec)
-        let xcproj = try generator.generateXcodeProject()
+        let xcproj = try generator.generateXcodeProject(validate: false)
         try xcproj.write(path: xcodeProjPath)
 
 

--- a/XCHammerAssets/Hammer.bzl
+++ b/XCHammerAssets/Hammer.bzl
@@ -75,5 +75,6 @@ def export_entitlements(name,
     entitlements_writer(
         name=name,
         entitlements=":" + name + "_exported",
-        visibility=["//visibility:public"]
+        visibility=["//visibility:public"],
+        tags=["xchammer"]
     )

--- a/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/BUILD
+++ b/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/BUILD
@@ -1,12 +1,5 @@
 load("//UrlGet.xcodeproj/XCHammerAssets:Hammer.bzl", "export_entitlements")
 export_entitlements(
-  name = "ios-app-siri-extension_entitlements",
-  entitlements = None,
-  provisioning_profile = None,
-  bundle_id = "Google.UrlGet.SiriExtension",
-  platform_type = "ios"
-)
-export_entitlements(
   name = "ios-app-share-extension_entitlements",
   entitlements = None,
   provisioning_profile = None,
@@ -14,16 +7,23 @@ export_entitlements(
   platform_type = "ios"
 )
 export_entitlements(
-  name = "ios-app-ios-app_entitlements",
-  entitlements = None,
-  provisioning_profile = None,
-  bundle_id = "Google.UrlGet",
-  platform_type = "ios"
-)
-export_entitlements(
   name = "ios-app-strings-extension_entitlements",
   entitlements = None,
   provisioning_profile = None,
   bundle_id = "Google.UrlGet.StringsExtension",
+  platform_type = "ios"
+)
+export_entitlements(
+  name = "ios-app-siri-extension_entitlements",
+  entitlements = None,
+  provisioning_profile = None,
+  bundle_id = "Google.UrlGet.SiriExtension",
+  platform_type = "ios"
+)
+export_entitlements(
+  name = "ios-app-ios-app_entitlements",
+  entitlements = None,
+  provisioning_profile = None,
+  bundle_id = "Google.UrlGet",
   platform_type = "ios"
 )

--- a/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/bazel_build_settings.py
+++ b/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/bazel_build_settings.py
@@ -130,8 +130,8 @@ class BazelBuildSettings(object):
 BUILD_SETTINGS = None
 
 BUILD_SETTINGS = BazelBuildSettings(
-    '/Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet/tools/bazelwrapper',
-    '/private/var/tmp/_bazel_mzuccarino/516059ac3683698c9bbc9bdebe7f41c6/execroot/__main__',
+    '/Users/jerry/Projects/xchammer-github/sample/UrlGet/tools/bazelwrapper',
+    '/private/var/tmp/_bazel_jerry/02ea23f0453c053e153f98f04fdb461a/execroot/__main__',
     'iphone',
     {
         'ios_x86_64': [
@@ -150,119 +150,11 @@ BUILD_SETTINGS = BazelBuildSettings(
     [],
     BazelFlagsSet(),
     {
-        '//ios-app:UrlGetClasses': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
-        '//ios-app:siri-extension': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
-        '//Vendor/Stripe:Stripe': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
-        '//ios-app:share-extension': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
-        '//Vendor/Stripe:Stripe_Bundle_Stripe': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
-        '//ios-app:strings-extension': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
-        '//Vendor/PINCache:Core': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
-        '//ios-app:strings-ext-bin': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
-        '//Vendor/PINOperation:PINOperation': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
-        '//ios-app:ios-app-bin': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
-        '//ios-app:ios-ext-bin': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
-        '//ios-app:siri-ext-bin': BazelFlagsSet(
-            flags = BazelFlags(
-                startup = [],
-                build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
-                    '--build_event_publish_all_actions=true',
-                ],
-            ),
-        ),
         '//ios-app/HeaderLib:HeaderLib': BazelFlagsSet(
             flags = BazelFlags(
                 startup = [],
                 build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
                     '--build_event_publish_all_actions=true',
                 ],
             ),
@@ -271,7 +163,88 @@ BUILD_SETTINGS = BazelBuildSettings(
             flags = BazelFlags(
                 startup = [],
                 build = [
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//ios-app:UrlGetClasses': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//ios-app:siri-ext-bin': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//Vendor/PINCache:Core': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//ios-app:ios-app-bin': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//ios-app:strings-ext-bin': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//ios-app:share-extension': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//ios-app:ios-ext-bin': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//ios-app:siri-extension': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//Vendor/PINOperation:PINOperation': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
                     '--build_event_publish_all_actions=true',
                 ],
             ),
@@ -282,7 +255,34 @@ BUILD_SETTINGS = BazelBuildSettings(
                 build = [
                     '--action_env=X=Y',
                     '--action_env=CLI_SDK=$(SDKROOT)',
-                    '--override_repository=tulsi=/Users/mzuccarino/code/mikezucc/xchammer/.build/debug',
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//ios-app:strings-extension': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//Vendor/Stripe:Stripe': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
+                    '--build_event_publish_all_actions=true',
+                ],
+            ),
+        ),
+        '//Vendor/Stripe:Stripe_Bundle_Stripe': BazelFlagsSet(
+            flags = BazelFlags(
+                startup = [],
+                build = [
+                    '--override_repository=tulsi=/Users/jerry/Projects/xchammer-github/.build/debug',
                     '--build_event_publish_all_actions=true',
                 ],
             ),

--- a/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/updateXcodeProj.sh
+++ b/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/updateXcodeProj.sh
@@ -1,7 +1,7 @@
 # This file is governed by XCHammer
 set -e
 
-if [[ "0.1.7" != "/Users/mzuccarino/code/mikezucc/xchammer/.build/debug/XCHammer --version" ]]; then 
+if [[ "0.1.7" != "/Users/jerry/Projects/xchammer-github/.build/debug/XCHammer --version" ]]; then 
     echo "warning: XCHammer version mismatch"
 fi
 
@@ -9,9 +9,9 @@ if [[ $ACTION == "clean" ]]; then
     exit 0
 fi
 
-PREV_STAT=`/usr/bin/stat -f %c "/Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/genStatus"`
-/Users/mzuccarino/code/mikezucc/xchammer/.build/debug/XCHammer generate /Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet/XCHammer.yaml --workspace_root /Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet --bazel /Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet/tools/bazelwrapper --generate_bazel_targets
-STAT=`/usr/bin/stat -f %c "/Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/genStatus"`
+PREV_STAT=`/usr/bin/stat -f %c "/Users/jerry/Projects/xchammer-github/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/genStatus"`
+/Users/jerry/Projects/xchammer-github/.build/debug/XCHammer generate /Users/jerry/Projects/xchammer-github/sample/UrlGet/XCHammer.yaml --workspace_root /Users/jerry/Projects/xchammer-github/sample/UrlGet --bazel /Users/jerry/Projects/xchammer-github/sample/UrlGet/tools/bazelwrapper
+STAT=`/usr/bin/stat -f %c "/Users/jerry/Projects/xchammer-github/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/genStatus"`
 if [[ "$PREV_STAT" != "$STAT" ]]; then
     echo "error: Xcode project was out-of-date so we updated it for you! Please build again."
     exit 1

--- a/sample/UrlGet/UrlGet.xcodeproj/project.pbxproj
+++ b/sample/UrlGet/UrlGet.xcodeproj/project.pbxproj
@@ -7,2571 +7,3535 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BF_101090596531 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_319111102880-1" /* NSBundle+Stripe_AppName.m */; };
-		BF_101852689553 /* STPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_729837640388 /* STPAPIClient.m */; };
-		BF_103019698139 /* stp_card_applepay@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_866423752002 /* stp_card_applepay@3x.png */; };
-		BF_103647375732 /* STPEphemeralKey.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_118429332705 /* STPEphemeralKey.m */; };
-		BF_106143354257 /* NSDecimalNumber+Stripe_Currency.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_485300186977 /* NSDecimalNumber+Stripe_Currency.m */; };
-		BF_110846874273 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_417020094137 /* STPURLCallbackHandler.m */; };
-		BF_113208380786 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_490229470460-1" /* NSURLComponents+Stripe.m */; };
-		BF_116171698724 /* STPPaymentCardTextFieldViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_352992722793 /* STPPaymentCardTextFieldViewModel.m */; };
-		BF_117078049933 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_451065136063 /* UIViewController+Stripe_NavigationItemProxy.m */; };
-		BF_117209957966 /* stp_card_form_front.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_597218262530 /* stp_card_form_front.png */; };
-		BF_118399563058 /* STPPaymentMethodTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_318471428702 /* STPPaymentMethodTuple.m */; };
-		BF_119119096972 /* stp_card_visa_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_535609714789 /* stp_card_visa_template.png */; };
-		BF_120539862880 /* stp_card_error_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_684957154701 /* stp_card_error_amex@2x.png */; };
-		BF_122454680258 /* NSString+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_383186939534-1" /* NSString+Stripe.m */; };
-		BF_123619201349 /* Some.cc in Sources */ = {isa = PBXBuildFile; fileRef = FR_282022996649 /* Some.cc */; };
-		BF_123692580182 /* stp_card_visa_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_161686194489 /* stp_card_visa_template@3x.png */; };
-		BF_124234759863 /* STPFile.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_227675484416 /* STPFile.m */; };
-		BF_125879088495 /* stp_card_applepay@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_458974510861 /* stp_card_applepay@2x.png */; };
-		BF_128560851764 /* ShareExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_914453841196 /* ShareExtension-Info.plist */; };
-		BF_129573605972 /* STPPaymentConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_454291026560 /* STPPaymentConfiguration.m */; };
-		BF_129899263403 /* stp_card_jcb_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_584192437806 /* stp_card_jcb_template.png */; };
-		BF_131628923074 /* stp_card_unionpay_template_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_438548292773 /* stp_card_unionpay_template_zh@3x.png */; };
-		BF_135181373888 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_549793573278 /* Localizable.strings */; };
-		BF_135378480492 /* stp_card_unknown@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_313827850627 /* stp_card_unknown@3x.png */; };
-		BF_135530049807 /* stp_card_form_front@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_767601582739 /* stp_card_form_front@3x.png */; };
-		BF_136123455694 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_863295555018 /* STPDispatchFunctions.m */; };
-		BF_138461404074 /* stp_card_amex_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_766928612639 /* stp_card_amex_template@3x.png */; };
-		BF_144207460583 /* stp_card_jcb_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_348062610832 /* stp_card_jcb_template@3x.png */; };
-		BF_149555850306 /* stp_card_discover_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_732161840902 /* stp_card_discover_template.png */; };
-		BF_150885512820 /* stp_card_cvc.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_275604636587 /* stp_card_cvc.png */; };
-		BF_151721930308 /* STPTelemetryClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_836284080868 /* STPTelemetryClient.m */; };
-		BF_151757672103 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_549793573278 /* Localizable.strings */; };
-		BF_152533994136 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_784978928035 /* UIViewController+Stripe_KeyboardAvoiding.m */; };
-		BF_154672173585 /* stp_card_diners@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_499280427849 /* stp_card_diners@2x.png */; };
-		BF_157414689128 /* STPSourceOwner.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_761061955139 /* STPSourceOwner.m */; };
-		BF_158572982416 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_447194245190 /* Tests2.m */; };
-		BF_161334189326 /* STPEmailAddressValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_820602908988 /* STPEmailAddressValidator.m */; };
-		BF_164244000470 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_353990188355 /* GoogleAppIndexing.framework */; };
-		BF_164275633159 /* stp_card_amex_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_766928612639 /* stp_card_amex_template@3x.png */; };
-		BF_167823982318 /* stp_card_diners@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_786618818576 /* stp_card_diners@3x.png */; };
-		BF_169258158277 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_171962769898-1" /* UIImage+Stripe.m */; };
-		BF_170318754028 /* STPLegalEntityParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_863581397541 /* STPLegalEntityParams.m */; };
-		BF_170396008124 /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_616218057689 /* stp_card_visa@3x.png */; };
-		BF_172554538252 /* NSMutableURLRequest+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_829657687628 /* NSMutableURLRequest+Stripe.m */; };
-		BF_176492720158 /* libios-app-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_610748361952 /* libios-app-bin.a */; };
-		BF_177540651906 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_426141564192 /* STPPaymentMethodTableViewCell.m */; };
-		BF_182151248631 /* stp_card_unionpay_template_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_607555391478 /* stp_card_unionpay_template_en.png */; };
-		BF_184627840073 /* libPINOperation-ios-11.3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_578888125127 /* libPINOperation-ios-11.3.a */; };
-		BF_187128133490 /* stp_card_visa_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_535609714789 /* stp_card_visa_template.png */; };
-		BF_191206565194 /* stp_card_amex_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_766919050802 /* stp_card_amex_template@2x.png */; };
-		BF_194808752686 /* UIToolbar+Stripe_InputAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_851062106151 /* UIToolbar+Stripe_InputAccessory.m */; };
-		BF_195019623962 /* stp_card_unionpay_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_127100525052 /* stp_card_unionpay_zh@3x.png */; };
-		BF_196243295751 /* StripeError.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_276366160308 /* StripeError.m */; };
-		BF_197519452180 /* UIToolbar+Stripe_InputAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_851062106151 /* UIToolbar+Stripe_InputAccessory.m */; };
-		BF_198135154768 /* stp_shipping_form@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_587518550104 /* stp_shipping_form@3x.png */; };
-		BF_202421252734 /* stp_card_form_back@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_471192665951 /* stp_card_form_back@2x.png */; };
-		BF_202713209090 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_742895067730 /* libPINOperation-ios-9.0.a */; };
-		BF_204553293200 /* STPSourceSEPADebitDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_639248881296 /* STPSourceSEPADebitDetails.m */; };
-		BF_205442017048 /* StripeError.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_276366160308 /* StripeError.m */; };
-		BF_208370307566 /* stp_card_unionpay_template_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_607555391478 /* stp_card_unionpay_template_en.png */; };
-		BF_210290178530 /* stp_card_unionpay_template_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_436922295096 /* stp_card_unionpay_template_en@3x.png */; };
-		BF_211705597766 /* stp_icon_add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_644827855298 /* stp_icon_add@3x.png */; };
-		BF_211849370502 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_577405838685 /* GoogleSymbolUtilities.framework */; };
-		BF_212485280648 /* stp_card_error_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_684957151634 /* stp_card_error_amex@3x.png */; };
-		BF_214005761075 /* STPCardIOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_803655950633-1" /* STPCardIOProxy.m */; };
-		BF_214401364839 /* stp_card_error_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_728079807747 /* stp_card_error_amex.png */; };
-		BF_214591006498 /* STPSourceCardDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_689735932342 /* STPSourceCardDetails.m */; };
-		BF_217006239142 /* STPShippingMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_190239098214 /* STPShippingMethodsViewController.m */; };
-		BF_218428149371 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_104204687231 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_218677791532 /* stp_card_discover_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_732161840902 /* stp_card_discover_template.png */; };
-		BF_221014046589 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_149668560898 /* STPPaymentResult.m */; };
-		BF_221385638621 /* stp_card_cvc_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_916856507218 /* stp_card_cvc_amex@3x.png */; };
-		BF_223339887562 /* STPEphemeralKeyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_170908667679 /* STPEphemeralKeyManager.m */; };
-		BF_224019183693 /* stp_test_upload_image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = FR_791168379253 /* stp_test_upload_image.jpeg */; };
-		BF_225946189938 /* stp_card_error@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_550565498786 /* stp_card_error@3x.png */; };
-		BF_227610620572 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = VG_167175369874 /* AppIntentVocabulary.plist */; };
-		BF_229174307200 /* STPSourceReceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_793128565775 /* STPSourceReceiver.m */; };
-		BF_230346920582 /* stp_card_visa_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_161685209527 /* stp_card_visa_template@2x.png */; };
-		BF_234494727001 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
-		BF_236406319029 /* Some.cc in Sources */ = {isa = PBXBuildFile; fileRef = FR_282022996649 /* Some.cc */; };
-		BF_238970309620 /* stp_icon_checkmark@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_454974753213 /* stp_icon_checkmark@3x.png */; };
-		BF_243636708199 /* stp_card_cvc_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_441695822925 /* stp_card_cvc_amex@2x.png */; };
-		BF_244355728562 /* stp_card_diners.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_315436813377 /* stp_card_diners.png */; };
-		BF_248271752273 /* UIView+Stripe_FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_270060349354-1" /* UIView+Stripe_FirstResponder.m */; };
-		BF_249342805273 /* STPPaymentMethodTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_318471428702 /* STPPaymentMethodTuple.m */; };
-		BF_250175477903 /* stp_card_form_back.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_581387210768 /* stp_card_form_back.png */; };
-		BF_255445591562 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_577405838685 /* GoogleSymbolUtilities.framework */; };
-		BF_260333157646 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_388157799616 /* main.m */; };
-		BF_261510315068 /* stp_card_visa.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_620185860855 /* stp_card_visa.png */; };
-		BF_263148238203 /* stp_card_discover@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_867716578881 /* stp_card_discover@2x.png */; };
-		BF_263324905251 /* STPColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_573822806939 /* STPColorUtils.m */; };
-		BF_264785220441 /* stp_card_form_front@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_767601579243 /* stp_card_form_front@2x.png */; };
-		BF_275397151973 /* STPPaymentConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_454291026560 /* STPPaymentConfiguration.m */; };
-		BF_276095752437 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_888449823097-1" /* STPSectionHeaderView.m */; };
-		BF_278663538510 /* stp_card_mastercard.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_819492685632 /* stp_card_mastercard.png */; };
-		BF_279020500217 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_161131115028-1" /* NSDictionary+Stripe.m */; };
-		BF_279596883188 /* empty-main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_838972687587 /* empty-main.m */; };
-		BF_283769270364 /* stp_card_discover_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_162583091328 /* stp_card_discover_template@2x.png */; };
-		BF_285927550174 /* STPApplePayPaymentMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_543365396645 /* STPApplePayPaymentMethod.m */; };
-		BF_289584464573 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_417020094137 /* STPURLCallbackHandler.m */; };
-		BF_290778906678 /* stp_card_unionpay_template_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_607867791021 /* stp_card_unionpay_template_zh.png */; };
-		BF_293411348661 /* PINOperationGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_100956106934 /* PINOperationGroup.m */; };
-		BF_296262923336 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_691812537693 /* stp_card_amex@2x.png */; };
-		BF_296805053083 /* stp_card_error_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_684957151634 /* stp_card_error_amex@3x.png */; };
-		BF_297270047166 /* stp_card_unionpay_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_351629510243 /* stp_card_unionpay_zh.png */; };
-		BF_298426479289 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_353990188355 /* GoogleAppIndexing.framework */; };
-		BF_300982148222 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_536943478702 /* GoogleNetworkingUtilities.framework */; };
-		BF_304667849339 /* stp_card_jcb_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_348062610832 /* stp_card_jcb_template@3x.png */; };
-		BF_305816078570 /* stp_card_applepay@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_458974510861 /* stp_card_applepay@2x.png */; };
-		BF_306186377385 /* STPCardValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_716273040248 /* STPCardValidator.m */; };
-		BF_307222715199 /* stp_card_error.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_550412986688 /* stp_card_error.png */; };
-		BF_309045885116 /* strings-extension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_910389829219 /* strings-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BF_309156400099 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_235441027813 /* STPSource.m */; };
-		BF_309570989202 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_390212303514 /* stp_card_amex.png */; };
-		BF_310147481663 /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_153681520641 /* stp_card_applepay.png */; };
-		BF_310592570415 /* stp_card_error@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_849166683791 /* stp_card_error@2x.png */; };
-		BF_312420450925 /* stp_card_error.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_550412986688 /* stp_card_error.png */; };
-		BF_314158884179 /* stp_card_diners_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_329418993821 /* stp_card_diners_template@2x.png */; };
-		BF_316466910586 /* STPCategoryLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_383188188562-1" /* STPCategoryLoader.m */; };
-		BF_317591589294 /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_221232691707 /* STPAddressFieldTableViewCell.m */; };
-		BF_317838552798 /* stp_icon_checkmark.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_213958106393 /* stp_icon_checkmark.png */; };
-		BF_320837076228 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_838405705884 /* stp_card_amex@3x.png */; };
-		BF_321486603389 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_171962769898-1" /* UIImage+Stripe.m */; };
-		BF_332238646659 /* STPPhoneNumberValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_845699426889 /* STPPhoneNumberValidator.m */; };
-		BF_333370963763 /* STPPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_177669650679-1" /* STPPromise.m */; };
-		BF_333697809308 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_595618312739 /* libPINCache-Core-ios-9.0.a */; };
-		BF_339948089738 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_536943478702 /* GoogleNetworkingUtilities.framework */; };
-		BF_340672610509 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_353990188355 /* GoogleAppIndexing.framework */; };
-		BF_340860741059 /* STPPaymentMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_394482207665 /* STPPaymentMethodsViewController.m */; };
-		BF_341351208907 /* stp_card_jcb@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_554896677909 /* stp_card_jcb@3x.png */; };
-		BF_341904587881 /* stp_card_unionpay_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_256481006549 /* stp_card_unionpay_en.png */; };
-		BF_342698057840 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_577405838685 /* GoogleSymbolUtilities.framework */; };
-		BF_343082518654 /* STPPaymentCardTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_786851096829 /* STPPaymentCardTextFieldCell.m */; };
-		BF_343953132595 /* stp_card_unionpay_template_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_438548292773 /* stp_card_unionpay_template_zh@3x.png */; };
-		BF_344516029993 /* stp_card_jcb.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_739797562620 /* stp_card_jcb.png */; };
-		BF_344635626378 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_536943478702 /* GoogleNetworkingUtilities.framework */; };
-		BF_349880824923 /* STPAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_744571361438-1" /* STPAPIRequest.m */; };
-		BF_353317260207 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_827262883523 /* InfoPlist.strings */; };
-		BF_357314905437 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_838405705884 /* stp_card_amex@3x.png */; };
-		BF_357489808821 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_393824443136 /* STPPaymentContextAmountModel.m */; };
-		BF_358123724804 /* stp_card_unionpay_template_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_607867791021 /* stp_card_unionpay_template_zh.png */; };
-		BF_359877986903 /* STPFormTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_118015691316-1" /* STPFormTextField.m */; };
-		BF_360825627851 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_827262883523 /* InfoPlist.strings */; };
-		BF_362461023323 /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_201151680337-1" /* PINCache.m */; };
-		BF_362750078846 /* STPCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_764679247202 /* STPCustomerContext.m */; };
-		BF_363066368412 /* stp_card_discover@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_460546061817 /* stp_card_discover@3x.png */; };
-		BF_363607041405 /* stp_card_discover_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_162624925573 /* stp_card_discover_template@3x.png */; };
-		BF_364718393009 /* stp_icon_add.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_446151064510 /* stp_icon_add.png */; };
-		BF_365572872399 /* STPMultipartFormDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_344043994903 /* STPMultipartFormDataEncoder.m */; };
-		BF_365968776464 /* stp_icon_add@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_701860410388 /* stp_icon_add@2x.png */; };
-		BF_367284426572 /* STPAddCardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_670019473135 /* STPAddCardViewController.m */; };
-		BF_369875356536 /* AppJerry.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_720345196462-1" /* AppJerry.m */; };
-		BF_370608658701 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_983798454349 /* STPCardParams.m */; };
-		BF_371536116472 /* stp_card_visa.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_620185860855 /* stp_card_visa.png */; };
-		BF_372859359289 /* StringsExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_575999326641 /* StringsExtension-Info.plist */; };
-		BF_376657278382 /* stp_card_discover@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_867716578881 /* stp_card_discover@2x.png */; };
-		BF_378840913279 /* STPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_729837640388 /* STPAPIClient.m */; };
-		BF_379613470386 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
-		BF_380829518120 /* stp_card_discover_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_162583091328 /* stp_card_discover_template@2x.png */; };
-		BF_381871517932 /* STPFormEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_375651978668 /* STPFormEncoder.m */; };
-		BF_381896389344 /* stp_card_mastercard@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_160191336416 /* stp_card_mastercard@3x.png */; };
-		BF_382005665511 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_114615500587 /* PKPayment+Stripe.m */; };
-		BF_382809687329 /* stp_card_unionpay_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_119347389557 /* stp_card_unionpay_en@3x.png */; };
-		BF_383261352520 /* STPAddressViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_650044337253-1" /* STPAddressViewModel.m */; };
-		BF_388766661431 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_611231413868 /* PINDiskCache.m */; };
-		BF_389902562892 /* share-extension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_243789410170 /* share-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BF_391600535834 /* stp_card_diners_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_341722897024 /* stp_card_diners_template.png */; };
-		BF_396367102140 /* stp_card_cvc@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_150617010141 /* stp_card_cvc@3x.png */; };
-		BF_397345146558 /* stp_icon_add.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_446151064510 /* stp_icon_add.png */; };
-		BF_399571997734 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_841504889387 /* AppDelegate.m */; };
-		BF_405126167311 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_518266894407 /* libStripe-ios-9.0.a */; };
-		BF_408232004094 /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_720396073744 /* stp_shipping_form.png */; };
-		BF_412227068955 /* stp_card_unionpay_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_127100545188 /* stp_card_unionpay_zh@2x.png */; };
-		BF_412364227267 /* stp_icon_add@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_701860410388 /* stp_icon_add@2x.png */; };
-		BF_413861440512 /* UIBarButtonItem+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_266252253452-1" /* UIBarButtonItem+Stripe.m */; };
-		BF_418274553626 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166622418620 /* Tests.m */; };
-		BF_423050148924 /* NSError+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_136387137481-1" /* NSError+Stripe.m */; };
-		BF_424540904917 /* STPCoreViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_547792905644 /* STPCoreViewController.m */; };
-		BF_424698683183 /* STPSourceParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_748997447722 /* STPSourceParams.m */; };
-		BF_431247232736 /* stp_card_unionpay_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_119347408405 /* stp_card_unionpay_en@2x.png */; };
-		BF_433098327180 /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_308451946297 /* STPAPIClient+ApplePay.m */; };
-		BF_436043688776 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_390212303514 /* stp_card_amex.png */; };
-		BF_437340004481 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_149668560898 /* STPPaymentResult.m */; };
-		BF_444049534671 /* STPSourceParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_748997447722 /* STPSourceParams.m */; };
-		BF_445949043870 /* STPEphemeralKey.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_118429332705 /* STPEphemeralKey.m */; };
-		BF_447084161359 /* stp_card_form_front@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_767601582739 /* stp_card_form_front@3x.png */; };
-		BF_447601669755 /* STPShippingAddressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_744666232521 /* STPShippingAddressViewController.m */; };
-		BF_448507476666 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_401789639718-1" /* STPStringUtils.m */; };
-		BF_449892321630 /* STPShippingMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_190239098214 /* STPShippingMethodsViewController.m */; };
-		BF_452758362099 /* STPAnalyticsClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_140569352166 /* STPAnalyticsClient.m */; };
-		BF_453568682923 /* STPSourceVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_431507780270 /* STPSourceVerification.m */; };
-		BF_453613883928 /* stp_card_unknown@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_313827850627 /* stp_card_unknown@3x.png */; };
-		BF_454318076844 /* STPCoreScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_651201787786 /* STPCoreScrollViewController.m */; };
-		BF_455180069893 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_426141564192 /* STPPaymentMethodTableViewCell.m */; };
-		BF_456142095854 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_691812537693 /* stp_card_amex@2x.png */; };
-		BF_457382615413 /* STPCustomer+SourceTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_180708382140 /* STPCustomer+SourceTuple.m */; };
-		BF_457943934341 /* stp_card_unionpay_template_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_438213232580 /* stp_card_unionpay_template_zh@2x.png */; };
-		BF_461338526634 /* STPAddCardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_670019473135 /* STPAddCardViewController.m */; };
-		BF_462455659113 /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_153681520641 /* stp_card_applepay.png */; };
-		BF_465924387016 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_577405838685 /* GoogleSymbolUtilities.framework */; };
-		BF_467013923609 /* UIView+Stripe_FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_270060349354-1" /* UIView+Stripe_FirstResponder.m */; };
-		BF_468726244056 /* STPAnalyticsClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_140569352166 /* STPAnalyticsClient.m */; };
-		BF_470929899408 /* STPCustomer.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_775444959222 /* STPCustomer.m */; };
-		BF_471167991953 /* libUrlGetClasses-ios-11.3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_262777658410 /* libUrlGetClasses-ios-11.3.a */; };
-		BF_471380831706 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
-		BF_473725115787 /* stp_shipping_form@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_587518550104 /* stp_shipping_form@3x.png */; };
-		BF_474140462599 /* STPFormTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_118015691316-1" /* STPFormTextField.m */; };
-		BF_474989706909 /* stp_card_diners_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_341722897024 /* stp_card_diners_template.png */; };
-		BF_475917700354 /* stp_card_amex_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_222214992417 /* stp_card_amex_template.png */; };
-		BF_477621904475 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_401789639718-1" /* STPStringUtils.m */; };
-		BF_484844982921 /* STPSwitchTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_793362014210-1" /* STPSwitchTableViewCell.m */; };
-		BF_485817685451 /* stp_card_unionpay_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_127100525052 /* stp_card_unionpay_zh@3x.png */; };
-		BF_486194470271 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_104204687231 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_489322762158 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_522111507539 /* STPRedirectContext.m */; };
-		BF_489787044526 /* STPMultipartFormDataPart.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_430199726738 /* STPMultipartFormDataPart.m */; };
-		BF_490736564052 /* stp_icon_checkmark.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_213958106393 /* stp_icon_checkmark.png */; };
-		BF_492261497607 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_888449823097-1" /* STPSectionHeaderView.m */; };
-		BF_492945389948 /* UIView+Stripe_SafeAreaBounds.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_394531061746-1" /* UIView+Stripe_SafeAreaBounds.m */; };
-		BF_492946219688 /* stp_card_unionpay_template_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_440272897295 /* stp_card_unionpay_template_en@2x.png */; };
-		BF_498128473604 /* STPLocalizationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_374398035813 /* STPLocalizationUtils.m */; };
-		BF_503400796960 /* STPDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_240384147848 /* STPDelegateProxy.m */; };
-		BF_504461851187 /* NSMutableURLRequest+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_829657687628 /* NSMutableURLRequest+Stripe.m */; };
-		BF_506403901135 /* STPLegalEntityParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_863581397541 /* STPLegalEntityParams.m */; };
-		BF_512885476152 /* stp_card_diners_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_329419374230 /* stp_card_diners_template@3x.png */; };
-		BF_513577914721 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_841504889387 /* AppDelegate.m */; };
-		BF_513813635076 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_863295555018 /* STPDispatchFunctions.m */; };
-		BF_515478026660 /* STPEmailAddressValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_820602908988 /* STPEmailAddressValidator.m */; };
-		BF_522340134300 /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_181346025846 /* STPPostalCodeValidator.m */; };
-		BF_522935875969 /* STPFile.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_227675484416 /* STPFile.m */; };
-		BF_523457148489 /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_720396073744 /* stp_shipping_form.png */; };
-		BF_524688171203 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
-		BF_525198602071 /* NoArc.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_454823234837 /* NoArc.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		BF_527046135878 /* PINOperationGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_100956106934 /* PINOperationGroup.m */; };
-		BF_527047701434 /* UIBarButtonItem+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_266252253452-1" /* UIBarButtonItem+Stripe.m */; };
-		BF_529356427113 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_479483572541-1" /* PINMemoryCache.m */; };
-		BF_529924854363 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
-		BF_532444640647 /* STPCardValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_716273040248 /* STPCardValidator.m */; };
-		BF_534245496321 /* STPSourceSEPADebitDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_639248881296 /* STPSourceSEPADebitDetails.m */; };
-		BF_536302022069 /* stp_card_error@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_849166683791 /* stp_card_error@2x.png */; };
-		BF_540163603984 /* stp_card_jcb_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_348062819194 /* stp_card_jcb_template@2x.png */; };
-		BF_540876532481 /* STPCategoryLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_383188188562-1" /* STPCategoryLoader.m */; };
-		BF_541601624736 /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_397431763487-1" /* STPValidatedTextField.m */; };
-		BF_541822299127 /* STPMultipartFormDataPart.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_430199726738 /* STPMultipartFormDataPart.m */; };
-		BF_542584147501 /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_397431763487-1" /* STPValidatedTextField.m */; };
-		BF_542676579977 /* UIViewController+Stripe_ParentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_866814615747 /* UIViewController+Stripe_ParentViewController.m */; };
-		BF_545260635462 /* STPBankAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_520364995872 /* STPBankAccount.m */; };
-		BF_545657128345 /* stp_card_diners@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_499280427849 /* stp_card_diners@2x.png */; };
-		BF_547740684006 /* UINavigationController+Stripe_Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_746622613527 /* UINavigationController+Stripe_Completion.m */; };
-		BF_550396607124 /* STPMultipartFormDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_344043994903 /* STPMultipartFormDataEncoder.m */; };
-		BF_550931196942 /* stp_icon_checkmark@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_454974753213 /* stp_icon_checkmark@3x.png */; };
-		BF_551106090485 /* stp_card_mastercard@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_160191336416 /* stp_card_mastercard@3x.png */; };
-		BF_551145990127 /* stp_card_mastercard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_160191367084 /* stp_card_mastercard@2x.png */; };
-		BF_555361758086 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_747790741358-1" /* STPSourcePoller.m */; };
-		BF_556944891381 /* STPCoreTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_175464452737 /* STPCoreTableViewController.m */; };
-		BF_557157962944 /* STPSourceRedirect.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_770817608373 /* STPSourceRedirect.m */; };
-		BF_558507126140 /* stp_card_unknown@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_653524283850 /* stp_card_unknown@2x.png */; };
-		BF_559836411561 /* STPShippingMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_805980394107 /* STPShippingMethodTableViewCell.m */; };
-		BF_559895246776 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_388157799616 /* main.m */; };
-		BF_563013784716 /* STPCoreScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_651201787786 /* STPCoreScrollViewController.m */; };
-		BF_563626665274 /* STPPaymentMethodsInternalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_303088826339 /* STPPaymentMethodsInternalViewController.m */; };
-		BF_564964647160 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
-		BF_565142811584 /* stp_card_unionpay_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_351629510243 /* stp_card_unionpay_zh.png */; };
-		BF_565454288660 /* stp_card_amex_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_766919050802 /* stp_card_amex_template@2x.png */; };
-		BF_566176482817 /* STPTelemetryClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_836284080868 /* STPTelemetryClient.m */; };
-		BF_566891501383 /* stp_card_unionpay_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_119347408405 /* stp_card_unionpay_en@2x.png */; };
-		BF_568508761573 /* UINavigationBar+Stripe_Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_486615080111 /* UINavigationBar+Stripe_Theme.m */; };
-		BF_570367328430 /* stp_card_discover_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_162624925573 /* stp_card_discover_template@3x.png */; };
-		BF_571681387310 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_595618312739 /* libPINCache-Core-ios-9.0.a */; };
-		BF_574162666878 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166622418620 /* Tests.m */; };
-		BF_574178145405 /* STPAspects.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_225093974291 /* STPAspects.m */; };
-		BF_575244002306 /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_464213115625 /* stp_card_visa@2x.png */; };
-		BF_575343219227 /* stp_card_jcb_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_348062819194 /* stp_card_jcb_template@2x.png */; };
-		BF_578541352057 /* STPApplePayPaymentMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_543365396645 /* STPApplePayPaymentMethod.m */; };
-		BF_579672973360 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_983798454349 /* STPCardParams.m */; };
-		BF_580343450772 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_358060139028 /* GoogleAuthUtilities.framework */; };
-		BF_582530802914 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_351883541716 /* GoogleAppIndexingResources.bundle */; };
-		BF_583178766090 /* stp_card_form_back@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_435082555494 /* stp_card_form_back@3x.png */; };
-		BF_585378562575 /* STPSwitchTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_793362014210-1" /* STPSwitchTableViewCell.m */; };
-		BF_588141243996 /* stp_card_diners@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_786618818576 /* stp_card_diners@3x.png */; };
-		BF_589173441158 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_161131115028-1" /* NSDictionary+Stripe.m */; };
-		BF_590384333602 /* stp_card_unionpay_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_127100545188 /* stp_card_unionpay_zh@2x.png */; };
-		BF_591718251943 /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_181346025846 /* STPPostalCodeValidator.m */; };
-		BF_591758609732 /* libios-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_107900841834 /* libios-ext-bin.a */; };
-		BF_592286488997 /* stp_card_applepay@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_866423752002 /* stp_card_applepay@3x.png */; };
-		BF_594617974909 /* STPCoreViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_547792905644 /* STPCoreViewController.m */; };
-		BF_597354886609 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_887010092861 /* UrlGetViewController.xib */; };
-		BF_601678502290 /* stp_card_mastercard_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_914734393950 /* stp_card_mastercard_template@3x.png */; };
-		BF_606449406959 /* STPUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_634891479805 /* STPUserInformation.m */; };
-		BF_608151538300 /* STPCard.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_371561332475 /* STPCard.m */; };
-		BF_613056099577 /* NSArray+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_857114782727 /* NSArray+Stripe.m */; };
-		BF_614157202241 /* libPINCache-Arc-exception-safe-ios-11.3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_413373192620 /* libPINCache-Arc-exception-safe-ios-11.3.a */; };
-		BF_619165246202 /* STPPaymentActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_847087900331 /* STPPaymentActivityIndicatorView.m */; };
-		BF_619760599042 /* STPSourceOwner.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_761061955139 /* STPSourceOwner.m */; };
-		BF_622220407417 /* NSError+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_136387137481-1" /* NSError+Stripe.m */; };
-		BF_624140904670 /* stp_card_unknown.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_458081448840 /* stp_card_unknown.png */; };
-		BF_624388286307 /* STPTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_218958582687 /* STPTheme.m */; };
-		BF_624533472251 /* stp_card_jcb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_498036443375 /* stp_card_jcb@2x.png */; };
-		BF_625777932861 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_887010092861 /* UrlGetViewController.xib */; };
-		BF_625910032218 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_747790741358-1" /* STPSourcePoller.m */; };
-		BF_626697178248 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_353990188355 /* GoogleAppIndexing.framework */; };
-		BF_627749579000 /* stp_card_mastercard_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_914737022420 /* stp_card_mastercard_template@2x.png */; };
-		BF_628380396410 /* UIViewController+Stripe_Promises.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_904866835747 /* UIViewController+Stripe_Promises.m */; };
-		BF_632117953374 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_447194245190 /* Tests2.m */; };
-		BF_632167503271 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_887010092861 /* UrlGetViewController.xib */; };
-		BF_633647804116 /* STPSourceRedirect.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_770817608373 /* STPSourceRedirect.m */; };
-		BF_638181999525 /* NSDecimalNumber+Stripe_Currency.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_485300186977 /* NSDecimalNumber+Stripe_Currency.m */; };
-		BF_638318951126 /* STPCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_764679247202 /* STPCustomerContext.m */; };
-		BF_641847747226 /* STPAddressViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_650044337253-1" /* STPAddressViewModel.m */; };
-		BF_643237519141 /* StringsExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_575999326641 /* StringsExtension-Info.plist */; };
-		BF_644423025658 /* libStripe-ios-11.3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_334313231181 /* libStripe-ios-11.3.a */; };
-		BF_644483827733 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_235441027813 /* STPSource.m */; };
-		BF_647200911547 /* STPAspects.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_225093974291 /* STPAspects.m */; };
-		BF_647333681922 /* STPCardIOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_803655950633-1" /* STPCardIOProxy.m */; };
-		BF_648083042725 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_490229470460-1" /* NSURLComponents+Stripe.m */; };
-		BF_650211204451 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_205813692671 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
-		BF_651974698404 /* stp_card_form_front@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_767601579243 /* stp_card_form_front@2x.png */; };
-		BF_657456269763 /* stp_card_unknown@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_653524283850 /* stp_card_unknown@2x.png */; };
-		BF_657639625002 /* NoArc.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_454823234837 /* NoArc.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		BF_660644608808 /* STPColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_573822806939 /* STPColorUtils.m */; };
-		BF_662578892143 /* STPPaymentActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_847087900331 /* STPPaymentActivityIndicatorView.m */; };
-		BF_668909179812 /* SiriExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_609723908966 /* SiriExtension-Info.plist */; };
-		BF_670384869498 /* STPConnectAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_795421255062 /* STPConnectAccountParams.m */; };
-		BF_671889331007 /* UrlGetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_761662219184-1" /* UrlGetViewController.m */; };
-		BF_672812697537 /* STPPhoneNumberValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_845699426889 /* STPPhoneNumberValidator.m */; };
-		BF_673363358977 /* STPCustomer+SourceTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_180708382140 /* STPCustomer+SourceTuple.m */; };
-		BF_673487248208 /* ShareExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_914453841196 /* ShareExtension-Info.plist */; };
-		BF_676108111271 /* STPUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_634891479805 /* STPUserInformation.m */; };
-		BF_677961554122 /* STPImageLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_314016843022 /* STPImageLibrary.m */; };
-		BF_680096215864 /* stp_card_error_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_728079807747 /* stp_card_error_amex.png */; };
-		BF_682536272872 /* UIView+Stripe_SafeAreaBounds.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_394531061746-1" /* UIView+Stripe_SafeAreaBounds.m */; };
-		BF_682900860588 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_447194245190 /* Tests2.m */; };
-		BF_691269567943 /* stp_card_jcb_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_584192437806 /* stp_card_jcb_template.png */; };
-		BF_691914571811 /* SiriExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_609723908966 /* SiriExtension-Info.plist */; };
-		BF_693418203202 /* STPBINRange.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_670697261324 /* STPBINRange.m */; };
-		BF_693631994031 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_358060139028 /* GoogleAuthUtilities.framework */; };
-		BF_695166312425 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_205813692671 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
-		BF_696239529970 /* stp_card_mastercard_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_719224241995 /* stp_card_mastercard_template.png */; };
-		BF_696341792458 /* STPAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_744571361438-1" /* STPAPIRequest.m */; };
-		BF_702488203596 /* STPPaymentCardTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_438132085983 /* STPPaymentCardTextField.m */; };
-		BF_703680853725 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_784978928035 /* UIViewController+Stripe_KeyboardAvoiding.m */; };
-		BF_703994405433 /* STPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_538535395111 /* STPToken.m */; };
-		BF_704390356650 /* STPBINRange.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_670697261324 /* STPBINRange.m */; };
-		BF_707044678539 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = VG_167175369874 /* AppIntentVocabulary.plist */; };
-		BF_707958902606 /* stp_test_upload_image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = FR_791168379253 /* stp_test_upload_image.jpeg */; };
-		BF_709812349499 /* stp_icon_checkmark@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_462265337593 /* stp_icon_checkmark@2x.png */; };
-		BF_709965398842 /* stp_shipping_form@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_166108154819 /* stp_shipping_form@2x.png */; };
-		BF_710724944264 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_319111102880-1" /* NSBundle+Stripe_AppName.m */; };
-		BF_712602684753 /* stp_card_diners_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_329418993821 /* stp_card_diners_template@2x.png */; };
-		BF_716143536218 /* STPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_538535395111 /* STPToken.m */; };
-		BF_716920207658 /* stp_card_diners_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_329419374230 /* stp_card_diners_template@3x.png */; };
-		BF_718842850114 /* AppIntent.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_501274904079 /* AppIntent.m */; };
-		BF_719520352570 /* stp_card_error@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_550565498786 /* stp_card_error@3x.png */; };
-		BF_721271532741 /* STPFormEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_375651978668 /* STPFormEncoder.m */; };
-		BF_722312868055 /* libstrings-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_666369934619 /* libstrings-ext-bin.a */; };
-		BF_724018934696 /* stp_card_visa_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_161686194489 /* stp_card_visa_template@3x.png */; };
-		BF_726182205540 /* STPShippingMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_805980394107 /* STPShippingMethodTableViewCell.m */; };
-		BF_726887199051 /* stp_card_unknown.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_458081448840 /* stp_card_unknown.png */; };
-		BF_729565343289 /* PINOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_898827650356-1" /* PINOperationQueue.m */; };
-		BF_729766328605 /* STPPaymentCardTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_438132085983 /* STPPaymentCardTextField.m */; };
-		BF_730365141006 /* STPPaymentCardTextFieldViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_352992722793 /* STPPaymentCardTextFieldViewModel.m */; };
-		BF_730930168105 /* UrlGetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_761662219184-1" /* UrlGetViewController.m */; };
-		BF_730994754938 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_518266894407 /* libStripe-ios-9.0.a */; };
-		BF_734763667839 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_104204687231 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_735260424658 /* STPPaymentMethodsInternalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_303088826339 /* STPPaymentMethodsInternalViewController.m */; };
-		BF_737308335445 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_740003049424 /* STPBankAccountParams.m */; };
-		BF_737678661541 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_114615500587 /* PKPayment+Stripe.m */; };
-		BF_737682176383 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_358060139028 /* GoogleAuthUtilities.framework */; };
-		BF_741290718883 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_595618312739 /* libPINCache-Core-ios-9.0.a */; };
-		BF_743198081299 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_104204687231 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_743467796528 /* stp_card_mastercard_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_914734393950 /* stp_card_mastercard_template@3x.png */; };
-		BF_746261684005 /* STPSourceCardDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_689735932342 /* STPSourceCardDetails.m */; };
-		BF_749423264532 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_344823093939 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */; };
-		BF_750570579564 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_611231413868 /* PINDiskCache.m */; };
-		BF_750850029603 /* UINavigationController+Stripe_Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_746622613527 /* UINavigationController+Stripe_Completion.m */; };
-		BF_751036638648 /* STPCard.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_371561332475 /* STPCard.m */; };
-		BF_751727897601 /* stp_card_discover.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_485714325221 /* stp_card_discover.png */; };
-		BF_752333850625 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_104204687231 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_754436355955 /* stp_card_mastercard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_160191367084 /* stp_card_mastercard@2x.png */; };
-		BF_755282272245 /* UIViewController+Stripe_ParentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_866814615747 /* UIViewController+Stripe_ParentViewController.m */; };
-		BF_756048036715 /* libsiri-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_169594879022 /* libsiri-ext-bin.a */; };
-		BF_759141593816 /* stp_card_visa_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_161685209527 /* stp_card_visa_template@2x.png */; };
-		BF_759468879883 /* stp_card_jcb@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_554896677909 /* stp_card_jcb@3x.png */; };
-		BF_761040028655 /* STPSourceVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_431507780270 /* STPSourceVerification.m */; };
-		BF_764139746955 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_518266894407 /* libStripe-ios-9.0.a */; };
-		BF_764589198900 /* STPCoreTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_175464452737 /* STPCoreTableViewController.m */; };
-		BF_765177499875 /* stp_card_discover@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_460546061817 /* stp_card_discover@3x.png */; };
-		BF_765712413593 /* STPBankAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_520364995872 /* STPBankAccount.m */; };
-		BF_768185306849 /* stp_card_form_back@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_471192665951 /* stp_card_form_back@2x.png */; };
-		BF_768471797584 /* stp_icon_add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_644827855298 /* stp_icon_add@3x.png */; };
-		BF_769011939867 /* STPCustomer.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_775444959222 /* STPCustomer.m */; };
-		BF_770908080194 /* STPBundleLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_433875149495 /* STPBundleLocator.m */; };
-		BF_771252936417 /* STPBundleLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_433875149495 /* STPBundleLocator.m */; };
-		BF_775869817833 /* stp_card_mastercard.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_819492685632 /* stp_card_mastercard.png */; };
-		BF_776995690719 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_104204687231 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_777042903596 /* NSArray+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_857114782727 /* NSArray+Stripe.m */; };
-		BF_778389135851 /* UITableViewCell+Stripe_Borders.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_882551670747 /* UITableViewCell+Stripe_Borders.m */; };
-		BF_778975644784 /* stp_card_form_back.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_581387210768 /* stp_card_form_back.png */; };
-		BF_780353267060 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_205813692671 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
-		BF_785144964550 /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_616218057689 /* stp_card_visa@3x.png */; };
-		BF_786464893976 /* stp_card_jcb.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_739797562620 /* stp_card_jcb.png */; };
-		BF_788247927438 /* NSString+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_383186939534-1" /* NSString+Stripe.m */; };
-		BF_788315800256 /* stp_card_cvc_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_916856507218 /* stp_card_cvc_amex@3x.png */; };
-		BF_789294932168 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_147245088243 /* libUrlGetClasses-ios-9.0.a */; };
-		BF_790723168256 /* STPPaymentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_466427502225 /* STPPaymentContext.m */; };
-		BF_790802022403 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_388157799616 /* main.m */; };
-		BF_792540141787 /* stp_card_discover.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_485714325221 /* stp_card_discover.png */; };
-		BF_794704307481 /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_308451946297 /* STPAPIClient+ApplePay.m */; };
-		BF_794972634449 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_147245088243 /* libUrlGetClasses-ios-9.0.a */; };
-		BF_795798416899 /* stp_icon_checkmark@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_462265337593 /* stp_icon_checkmark@2x.png */; };
-		BF_796039839460 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166622418620 /* Tests.m */; };
-		BF_797689592140 /* stp_card_mastercard_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_719224241995 /* stp_card_mastercard_template.png */; };
-		BF_798749616868 /* STPConnectAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_795421255062 /* STPConnectAccountParams.m */; };
-		BF_799643590551 /* stp_card_error_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_684957154701 /* stp_card_error_amex@2x.png */; };
-		BF_799923208158 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_451065136063 /* UIViewController+Stripe_NavigationItemProxy.m */; };
-		BF_801105503627 /* STPDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_240384147848 /* STPDelegateProxy.m */; };
-		BF_801730223798 /* NSCharacterSet+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_856763993418 /* NSCharacterSet+Stripe.m */; };
-		BF_801846914366 /* UITableViewCell+Stripe_Borders.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_882551670747 /* UITableViewCell+Stripe_Borders.m */; };
-		BF_803250566133 /* stp_card_amex_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_222214992417 /* stp_card_amex_template.png */; };
-		BF_803562003601 /* siri-extension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_361814418977 /* siri-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BF_805521780698 /* UIViewController+Stripe_Promises.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_904866835747 /* UIViewController+Stripe_Promises.m */; };
-		BF_807240198227 /* stp_card_form_front.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_597218262530 /* stp_card_form_front.png */; };
-		BF_809361463000 /* stp_card_cvc.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_275604636587 /* stp_card_cvc.png */; };
-		BF_811880897715 /* STPPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_177669650679-1" /* STPPromise.m */; };
-		BF_819923078927 /* STPShippingAddressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_744666232521 /* STPShippingAddressViewController.m */; };
-		BF_822557121935 /* STPTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_218958582687 /* STPTheme.m */; };
-		BF_831697474059 /* libPINCache-Core-ios-11.3.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_683369487726 /* libPINCache-Core-ios-11.3.a */; };
-		BF_834502484694 /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_464213115625 /* stp_card_visa@2x.png */; };
-		BF_837589283931 /* UINavigationBar+Stripe_Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_486615080111 /* UINavigationBar+Stripe_Theme.m */; };
-		BF_839039646076 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_393824443136 /* STPPaymentContextAmountModel.m */; };
-		BF_842714463720 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_207298251625 /* STPAddress.m */; };
-		BF_843119778099 /* STPPaymentCardTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_786851096829 /* STPPaymentCardTextFieldCell.m */; };
-		BF_843248890798 /* stp_card_form_back@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_435082555494 /* stp_card_form_back@3x.png */; };
-		BF_849479514763 /* NSCharacterSet+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_856763993418 /* NSCharacterSet+Stripe.m */; };
-		BF_851253922391 /* stp_card_cvc_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_648806668237 /* stp_card_cvc_amex.png */; };
-		BF_854999455782 /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_201151680337-1" /* PINCache.m */; };
-		BF_859207755337 /* stp_card_mastercard_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_914737022420 /* stp_card_mastercard_template@2x.png */; };
-		BF_861336833852 /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_221232691707 /* STPAddressFieldTableViewCell.m */; };
-		BF_865102949522 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_344823093939 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */; };
-		BF_868282965233 /* stp_card_unionpay_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_256481006549 /* stp_card_unionpay_en.png */; };
-		BF_869586500948 /* stp_card_cvc_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_441695822925 /* stp_card_cvc_amex@2x.png */; };
-		BF_875649997485 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_742895067730 /* libPINOperation-ios-9.0.a */; };
-		BF_876890323199 /* stp_card_cvc@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_202016520148 /* stp_card_cvc@2x.png */; };
-		BF_878073784080 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_742895067730 /* libPINOperation-ios-9.0.a */; };
-		BF_881459130844 /* STPSourceReceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_793128565775 /* STPSourceReceiver.m */; };
-		BF_884995049144 /* STPEphemeralKeyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_170908667679 /* STPEphemeralKeyManager.m */; };
-		BF_885742776305 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_358060139028 /* GoogleAuthUtilities.framework */; };
-		BF_885899011351 /* stp_card_diners.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_315436813377 /* stp_card_diners.png */; };
-		BF_887553915782 /* stp_card_jcb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_498036443375 /* stp_card_jcb@2x.png */; };
-		BF_888620683913 /* stp_card_unionpay_template_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_440272897295 /* stp_card_unionpay_template_en@2x.png */; };
-		BF_891178962083 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_536943478702 /* GoogleNetworkingUtilities.framework */; };
-		BF_892241538456 /* stp_card_cvc@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_202016520148 /* stp_card_cvc@2x.png */; };
-		BF_892762272109 /* stp_card_cvc@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_150617010141 /* stp_card_cvc@3x.png */; };
-		BF_892886647641 /* stp_card_unionpay_template_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_438213232580 /* stp_card_unionpay_template_zh@2x.png */; };
-		BF_896932005981 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_522111507539 /* STPRedirectContext.m */; };
-		BF_903449840898 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_147245088243 /* libUrlGetClasses-ios-9.0.a */; };
-		BF_903899752134 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_740003049424 /* STPBankAccountParams.m */; };
-		BF_905507208473 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_479483572541-1" /* PINMemoryCache.m */; };
-		BF_908168907899 /* STPImageLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_314016843022 /* STPImageLibrary.m */; };
-		BF_910614995151 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_207298251625 /* STPAddress.m */; };
-		BF_912080281901 /* stp_card_cvc_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_648806668237 /* stp_card_cvc_amex.png */; };
-		BF_914150910917 /* STPPaymentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_466427502225 /* STPPaymentContext.m */; };
-		BF_914665933472 /* stp_shipping_form@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_166108154819 /* stp_shipping_form@2x.png */; };
-		BF_916682364312 /* STPPaymentMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_394482207665 /* STPPaymentMethodsViewController.m */; };
-		BF_917099122644 /* PINOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = "FR_898827650356-1" /* PINOperationQueue.m */; };
-		BF_920165268680 /* STPLocalizationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_374398035813 /* STPLocalizationUtils.m */; };
-		BF_949644424763 /* stp_card_unionpay_template_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_436922295096 /* stp_card_unionpay_template_en@3x.png */; };
-		BF_951074971939 /* UrlGet-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_100219285940 /* UrlGet-Info.plist */; };
-		BF_969469422979 /* stp_card_unionpay_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_119347389557 /* stp_card_unionpay_en@3x.png */; };
+		BF_100146255098 /* Fabric+FABKits.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_227516787760 /* Fabric+FABKits.h */; };
+		BF_100603453597 /* STPCoreScrollViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_165114611545 /* STPCoreScrollViewController+Private.h */; };
+		BF_101090340568 /* UIBarButtonItem+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_660486720752 /* UIBarButtonItem+Stripe.m */; };
+		BF_101230637733 /* STPSource.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_204424633043 /* STPSource.h */; };
+		BF_102169882211 /* STPPaymentContextAmountModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_463415628327 /* STPPaymentContextAmountModel.h */; };
+		BF_102221489346 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_314953714155 /* STPPaymentResult.m */; };
+		BF_103914288281 /* STPSourceCardDetails.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_462403503968 /* STPSourceCardDetails.h */; };
+		BF_104714549948 /* STPSourceParams+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_872295844282 /* STPSourceParams+Private.h */; };
+		BF_104746139472 /* STPPaymentConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_920849002660 /* STPPaymentConfiguration.m */; };
+		BF_104922805231 /* STPBankAccountParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_831107356712 /* STPBankAccountParams.h */; };
+		BF_106827386674 /* PINCacheMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_703899038574 /* PINCacheMacros.h */; };
+		BF_106880923726 /* stp_card_discover_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_142523824475 /* stp_card_discover_template@2x.png */; };
+		BF_107059998957 /* NSDictionary+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_240832335761 /* NSDictionary+Stripe.h */; };
+		BF_107316023987 /* stp_card_mastercard@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_127475428263 /* stp_card_mastercard@3x.png */; };
+		BF_108843500906 /* STPBankAccountParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_831107356712 /* STPBankAccountParams.h */; };
+		BF_110567999400 /* STPPaymentMethodTuple.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_489307065831 /* STPPaymentMethodTuple.h */; };
+		BF_110879963190 /* stp_card_error_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_453324145384 /* stp_card_error_amex.png */; };
+		BF_111108499174 /* STPFormEncodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_150902497411 /* STPFormEncodable.h */; };
+		BF_112047178936 /* STPAddressViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_439275709173 /* STPAddressViewModel.m */; };
+		BF_113443738270 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_668440300851 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_114085359031 /* STPCardParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_380855240261 /* STPCardParams.h */; };
+		BF_115916247363 /* stp_card_form_front@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_324426164016 /* stp_card_form_front@3x.png */; };
+		BF_117152966090 /* UITableViewCell+Stripe_Borders.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_503123501592 /* UITableViewCell+Stripe_Borders.m */; };
+		BF_117355793113 /* NSCharacterSet+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_275560902555 /* NSCharacterSet+Stripe.m */; };
+		BF_117584520624 /* STPSourceParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_737093675579 /* STPSourceParams.h */; };
+		BF_119653876866 /* STPPaymentConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_920849002660 /* STPPaymentConfiguration.m */; };
+		BF_120744269678 /* stp_card_cvc_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_134719527222 /* stp_card_cvc_amex.png */; };
+		BF_120847667496 /* STPShippingMethodsViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_289951473723 /* STPShippingMethodsViewController.h */; };
+		BF_123137700688 /* STPAPIClient+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_701197038044 /* STPAPIClient+Private.h */; };
+		BF_123790181276 /* STPCoreScrollViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_214570034228 /* STPCoreScrollViewController.h */; };
+		BF_124956471100 /* STPToken.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_768476324412 /* STPToken.h */; };
+		BF_127014736755 /* STPMultipartFormDataEncoder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_464681328909 /* STPMultipartFormDataEncoder.h */; };
+		BF_127812358508 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_668440300851 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_129442605958 /* Some.hpp in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_180206282362 /* Some.hpp */; };
+		BF_130098066142 /* STPEphemeralKey.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_897166241393 /* STPEphemeralKey.h */; };
+		BF_131266585648 /* PINOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_373510968019 /* PINOperationQueue.m */; };
+		BF_131709469819 /* stp_card_unionpay_template_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_393687196501 /* stp_card_unionpay_template_en.png */; };
+		BF_132059510992 /* STPUserInformation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_195508064871 /* STPUserInformation.h */; };
+		BF_132160679787 /* STPPaymentConfiguration+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_868093412922 /* STPPaymentConfiguration+Private.h */; };
+		BF_133395627932 /* STPRedirectContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_160259185428 /* STPRedirectContext.h */; };
+		BF_133579846289 /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_807603038020 /* stp_card_visa@2x.png */; };
+		BF_133887420812 /* STPSource.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_865857012183 /* STPSource.h */; };
+		BF_134834117932 /* STPEphemeralKey.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_401046103149 /* STPEphemeralKey.m */; };
+		BF_135071580354 /* stp_card_visa_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_772315109974 /* stp_card_visa_template@3x.png */; };
+		BF_135641607626 /* PINMemoryCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_888484860318 /* PINMemoryCache.h */; };
+		BF_136155763923 /* STPLegalEntityParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_431919160946 /* STPLegalEntityParams.h */; };
+		BF_136341807913 /* stp_card_unionpay_template_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_737821215910 /* stp_card_unionpay_template_zh@3x.png */; };
+		BF_137179509720 /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_479371064013 /* STPAddressFieldTableViewCell.m */; };
+		BF_137228820791 /* STPConnectAccountParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_773846360911 /* STPConnectAccountParams.h */; };
+		BF_137377739778 /* STPFile+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_547023080128 /* STPFile+Private.h */; };
+		BF_137837529643 /* NSArray+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_270361851280 /* NSArray+Stripe.m */; };
+		BF_138090297162 /* STPFormTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_185670732342 /* STPFormTextField.m */; };
+		BF_138472644633 /* STPTelemetryClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_222347419161 /* STPTelemetryClient.h */; };
+		BF_138908459130 /* UIViewController+Stripe_NavigationItemProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_675363467066 /* UIViewController+Stripe_NavigationItemProxy.h */; };
+		BF_139000354086 /* StripeError.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_800273678048 /* StripeError.m */; };
+		BF_139035489647 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_916661342534 /* UIViewController+Stripe_NavigationItemProxy.m */; };
+		BF_142092478818 /* PINCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_227724747281 /* PINCache.h */; };
+		BF_143196074828 /* STPSourceVerification+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_702731086180 /* STPSourceVerification+Private.h */; };
+		BF_144071511099 /* STPCardValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_308536515212 /* STPCardValidator.h */; };
+		BF_144351754131 /* STPSectionHeaderView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_284420664639 /* STPSectionHeaderView.h */; };
+		BF_145804100375 /* STPCardValidationState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_498316524810 /* STPCardValidationState.h */; };
+		BF_146371965091 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_115569304376 /* libStripe-ios-9.0.a */; };
+		BF_147754211592 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_437723492681 /* GoogleAppIndexing.framework */; };
+		BF_148813291472 /* NSArray+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_787984517909 /* NSArray+Stripe.h */; };
+		BF_148824861067 /* NSString+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_470744425341 /* NSString+Stripe.h */; };
+		BF_148892726201 /* STPSourceProtocol.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_368887152771 /* STPSourceProtocol.h */; };
+		BF_149470713379 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_310086671711 /* PINMemoryCache.m */; };
+		BF_150275074078 /* PINMemoryCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_600019716014 /* PINMemoryCache.h */; };
+		BF_150553243167 /* PINOperationGroup.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_152553107307 /* PINOperationGroup.h */; };
+		BF_152880658474 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_437723492681 /* GoogleAppIndexing.framework */; };
+		BF_153172028372 /* STPCategoryLoader.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_124543526378 /* STPCategoryLoader.h */; };
+		BF_154257750868 /* STPBankAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_687805612898 /* STPBankAccount.m */; };
+		BF_155717795722 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_623895726528 /* STPAddress.m */; };
+		BF_156073223996 /* STPShippingAddressViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_715819450244 /* STPShippingAddressViewController.h */; };
+		BF_157677532165 /* STPSourceSEPADebitDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_827299014426 /* STPSourceSEPADebitDetails.m */; };
+		BF_157760965950 /* PINOperation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_814877671763 /* PINOperation.h */; };
+		BF_158017278741 /* PKPayment+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_591392785580 /* PKPayment+Stripe.h */; };
+		BF_158442569045 /* STPSourceParams+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_872295844282 /* STPSourceParams+Private.h */; };
+		BF_161201956257 /* stp_card_error_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_456109311282 /* stp_card_error_amex@3x.png */; };
+		BF_164445430449 /* STPPaymentContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_443179884003 /* STPPaymentContext.h */; };
+		BF_165842399401 /* STPDelegateProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_721129734544 /* STPDelegateProxy.h */; };
+		BF_166860047134 /* STPFile.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_392574313117 /* STPFile.h */; };
+		BF_166990927798 /* STPTheme.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_100918364096 /* STPTheme.h */; };
+		BF_167857380704 /* stp_card_form_back@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_810335568173 /* stp_card_form_back@2x.png */; };
+		BF_168061390722 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_469267514516 /* PKPayment+Stripe.m */; };
+		BF_170328062118 /* stp_shipping_form@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_596924801474 /* stp_shipping_form@2x.png */; };
+		BF_171809984581 /* STPPromise.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_353249173463 /* STPPromise.h */; };
+		BF_174244889509 /* STPAPIClient+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_701197038044 /* STPAPIClient+Private.h */; };
+		BF_174303735628 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_711629859574 /* STPPaymentMethodTableViewCell.m */; };
+		BF_174348858309 /* STPPaymentResult.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_633919745139 /* STPPaymentResult.h */; };
+		BF_174386052051 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_860483718504 /* GoogleAppIndexingResources.bundle */; };
+		BF_174486510611 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_668440300851 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_175137485039 /* STPPaymentResult.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_374236941753 /* STPPaymentResult.h */; };
+		BF_176578096799 /* StripeError.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_527811563431 /* StripeError.h */; };
+		BF_178740885781 /* UrlGetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_734554573488 /* UrlGetViewController.m */; };
+		BF_179371215461 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_599031596757 /* NSBundle+Stripe_AppName.m */; };
+		BF_180634520283 /* STPShippingMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166620028473 /* STPShippingMethodTableViewCell.m */; };
+		BF_180979737359 /* STPCoreTableViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_622146132147 /* STPCoreTableViewController.h */; };
+		BF_182653551571 /* STPTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_678946834674 /* STPTheme.m */; };
+		BF_183151058556 /* stp_card_unionpay_template_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_781843868845 /* stp_card_unionpay_template_zh@2x.png */; };
+		BF_183934373416 /* STPBundleLocator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_637247309669 /* STPBundleLocator.h */; };
+		BF_185028476423 /* STPSourceReceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_477141207452 /* STPSourceReceiver.m */; };
+		BF_185419460814 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_411547927351 /* Tests.m */; };
+		BF_185796462300 /* STPShippingMethodsViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_164344606297 /* STPShippingMethodsViewController.h */; };
+		BF_186075171313 /* UIBarButtonItem+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_657975526681 /* UIBarButtonItem+Stripe.h */; };
+		BF_186163370017 /* STPShippingMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166620028473 /* STPShippingMethodTableViewCell.m */; };
+		BF_186470418346 /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_479371064013 /* STPAddressFieldTableViewCell.m */; };
+		BF_186704525098 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_416711012558 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */; };
+		BF_186780588036 /* stp_card_discover_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_705928698620 /* stp_card_discover_template@3x.png */; };
+		BF_190125344918 /* STPCardValidationState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_647615708741 /* STPCardValidationState.h */; };
+		BF_190332253133 /* UIViewController+Stripe_ParentViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_737907561380 /* UIViewController+Stripe_ParentViewController.h */; };
+		BF_191691531945 /* stp_card_unionpay_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_362535988676 /* stp_card_unionpay_en@3x.png */; };
+		BF_192470649449 /* NSURLComponents+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_480653613414 /* NSURLComponents+Stripe.h */; };
+		BF_192939647191 /* STPPromise.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_706359988177 /* STPPromise.h */; };
+		BF_193712619951 /* UIViewController+Stripe_Promises.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_879635869993 /* UIViewController+Stripe_Promises.m */; };
+		BF_194493693132 /* STPAPIClient+ApplePay.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_807037820303 /* STPAPIClient+ApplePay.h */; };
+		BF_194725058635 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_879680789012 /* Localizable.strings */; };
+		BF_195212030478 /* STPFile.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_859214955617 /* STPFile.m */; };
+		BF_196387551046 /* NSMutableURLRequest+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_469496801272 /* NSMutableURLRequest+Stripe.h */; };
+		BF_196835437059 /* STPMultipartFormDataPart.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_500693267193 /* STPMultipartFormDataPart.h */; };
+		BF_197009564453 /* STPFormTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_468517384487 /* STPFormTextField.h */; };
+		BF_198210767515 /* STPPaymentMethodTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_410962885406 /* STPPaymentMethodTableViewCell.h */; };
+		BF_198878007932 /* siri-extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FR_287747118355 /* siri-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		BF_199378233254 /* STPTelemetryClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_826898134611 /* STPTelemetryClient.h */; };
+		BF_200106439412 /* UIView+Stripe_FirstResponder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_170596598734 /* UIView+Stripe_FirstResponder.h */; };
+		BF_200762616227 /* STPAPIRequest.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_853966787131 /* STPAPIRequest.h */; };
+		BF_200803442114 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_508900331586 /* NSURLComponents+Stripe.m */; };
+		BF_201216735639 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_189036277762 /* STPSource.m */; };
+		BF_201941927316 /* NSCharacterSet+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_426656857393 /* NSCharacterSet+Stripe.h */; };
+		BF_201977440511 /* STPSourceRedirect.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_808247114849 /* STPSourceRedirect.h */; };
+		BF_201997171984 /* stp_icon_checkmark@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_649006375359 /* stp_icon_checkmark@3x.png */; };
+		BF_202675181349 /* PINCacheObjectSubscripting.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_106153810107 /* PINCacheObjectSubscripting.h */; };
+		BF_202768383446 /* STPPaymentActivityIndicatorView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_809108791963 /* STPPaymentActivityIndicatorView.h */; };
+		BF_203808042422 /* STPSourceRedirect.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_808247114849 /* STPSourceRedirect.h */; };
+		BF_204309584836 /* STPPaymentMethodTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_370123180763 /* STPPaymentMethodTuple.m */; };
+		BF_204376260226 /* stp_card_form_front@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_484208255089 /* stp_card_form_front@2x.png */; };
+		BF_205465445125 /* stp_card_unionpay_template_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_781843868845 /* stp_card_unionpay_template_zh@2x.png */; };
+		BF_205626696615 /* stp_card_jcb_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_921522766901 /* stp_card_jcb_template@3x.png */; };
+		BF_206231436836 /* HeaderLib.hpp in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_379671331039 /* HeaderLib.hpp */; };
+		BF_206864577886 /* STPPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_218112984498 /* STPPromise.m */; };
+		BF_207133615015 /* libStripe-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_458251636042 /* libStripe-ios-12.0.a */; };
+		BF_207703320722 /* STPBINRange.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_900054750708 /* STPBINRange.h */; };
+		BF_207911305607 /* STPSourcePoller.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_328352920299 /* STPSourcePoller.h */; };
+		BF_209206423450 /* STPWeakStrongMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_805065086362 /* STPWeakStrongMacros.h */; };
+		BF_209931254852 /* PINCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_138502338795 /* PINCache.h */; };
+		BF_210015723451 /* STPPaymentCardTextFieldViewModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_157587722902 /* STPPaymentCardTextFieldViewModel.h */; };
+		BF_210645786994 /* STPCoreTableViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_618638349731 /* STPCoreTableViewController+Private.h */; };
+		BF_213327728178 /* PINDiskCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_530544298450 /* PINDiskCache.h */; };
+		BF_213494327648 /* STPCustomer+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_597436128584 /* STPCustomer+Private.h */; };
+		BF_214675800404 /* stp_card_form_back@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_325521637118 /* stp_card_form_back@3x.png */; };
+		BF_215861264855 /* STPCoreScrollViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_214570034228 /* STPCoreScrollViewController.h */; };
+		BF_217248561129 /* STPValidatedTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_285793989872 /* STPValidatedTextField.h */; };
+		BF_217425227990 /* STPBankAccountParams+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_859246040826 /* STPBankAccountParams+Private.h */; };
+		BF_219567242214 /* STPSourceParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_737093675579 /* STPSourceParams.h */; };
+		BF_219570105028 /* STPCategoryLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_494301659888 /* STPCategoryLoader.m */; };
+		BF_220632397395 /* STPFormEncoder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_287240998336 /* STPFormEncoder.h */; };
+		BF_223032729056 /* STPFormEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166695994825 /* STPFormEncoder.m */; };
+		BF_223123858378 /* STPPaymentMethodTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_410962885406 /* STPPaymentMethodTableViewCell.h */; };
+		BF_223235247875 /* STPPaymentCardTextFieldViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_583395561891 /* STPPaymentCardTextFieldViewModel.m */; };
+		BF_223700651165 /* PINOperationQueue.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_960264344136 /* PINOperationQueue.h */; };
+		BF_225363930007 /* StripeError.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_527811563431 /* StripeError.h */; };
+		BF_225737491335 /* STPSourceRedirect+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_724259384552 /* STPSourceRedirect+Private.h */; };
+		BF_226783325786 /* PINOperationMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_603110710953 /* PINOperationMacros.h */; };
+		BF_227467098705 /* STPAddressFieldTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_276281345727 /* STPAddressFieldTableViewCell.h */; };
+		BF_227521460820 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_604030021498 /* GoogleNetworkingUtilities.framework */; };
+		BF_227579742807 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_753120224409 /* UrlGetViewController.xib */; };
+		BF_227693182834 /* STPWeakStrongMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_233085860418 /* STPWeakStrongMacros.h */; };
+		BF_228687791291 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_508923610275 /* STPSourcePoller.m */; };
+		BF_228710689171 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_753120224409 /* UrlGetViewController.xib */; };
+		BF_229030472669 /* stp_card_cvc@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_324415420402 /* stp_card_cvc@2x.png */; };
+		BF_229523316496 /* STPImageLibrary+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_182438507920 /* STPImageLibrary+Private.h */; };
+		BF_230146524333 /* STPTelemetryClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_222347419161 /* STPTelemetryClient.h */; };
+		BF_231653111479 /* Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_727217733032 /* Stripe.h */; };
+		BF_231739405054 /* STPCoreScrollViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_711918819728 /* STPCoreScrollViewController.h */; };
+		BF_232882297758 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_353316542796 /* libPINOperation-ios-9.0.a */; };
+		BF_232886281401 /* STPDispatchFunctions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_680182050104 /* STPDispatchFunctions.h */; };
+		BF_233165390610 /* NSMutableURLRequest+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_670837697807 /* NSMutableURLRequest+Stripe.h */; };
+		BF_233235282272 /* STPPaymentMethod.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_654192010378 /* STPPaymentMethod.h */; };
+		BF_233631577233 /* UIViewController+Stripe_KeyboardAvoiding.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_933371169343 /* UIViewController+Stripe_KeyboardAvoiding.h */; };
+		BF_233834259796 /* stp_card_diners.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_524791267555 /* stp_card_diners.png */; };
+		BF_234221106414 /* STPSwitchTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_589726050819 /* STPSwitchTableViewCell.h */; };
+		BF_234524631364 /* STPDispatchFunctions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_651847570475 /* STPDispatchFunctions.h */; };
+		BF_234885104089 /* stp_card_unionpay_template_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_393687196501 /* stp_card_unionpay_template_en.png */; };
+		BF_235691758803 /* stp_card_mastercard_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_232572251428 /* stp_card_mastercard_template@2x.png */; };
+		BF_235752708584 /* PINCacheMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_495367858217 /* PINCacheMacros.h */; };
+		BF_236310643340 /* STPAPIClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_320799198594 /* STPAPIClient.h */; };
+		BF_238336665490 /* STPInternalAPIResponseDecodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_583778395098 /* STPInternalAPIResponseDecodable.h */; };
+		BF_239251576981 /* PINMemoryCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_888484860318 /* PINMemoryCache.h */; };
+		BF_240712445821 /* PINOperationGroup.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_218663833597 /* PINOperationGroup.h */; };
+		BF_241021670094 /* STPSourceReceiver.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_821033470551 /* STPSourceReceiver.h */; };
+		BF_241035691797 /* STPFormEncoder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_287240998336 /* STPFormEncoder.h */; };
+		BF_242007217085 /* PINCacheMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_703899038574 /* PINCacheMacros.h */; };
+		BF_242731081458 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_183755575988 /* UIImage+Stripe.m */; };
+		BF_243171785764 /* STPEphemeralKey.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_864958197976 /* STPEphemeralKey.h */; };
+		BF_243777181681 /* STPBlocks.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_871480364449 /* STPBlocks.h */; };
+		BF_244856205536 /* STPCoreTableViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_622146132147 /* STPCoreTableViewController.h */; };
+		BF_246151654463 /* STPAspects.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_592944512740 /* STPAspects.h */; };
+		BF_246871801942 /* UINavigationBar+Stripe_Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_509452004334 /* UINavigationBar+Stripe_Theme.m */; };
+		BF_246968793155 /* STPPaymentContext+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_651211894634 /* STPPaymentContext+Private.h */; };
+		BF_247686977314 /* UINavigationController+Stripe_Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_664471815887 /* UINavigationController+Stripe_Completion.m */; };
+		BF_248839685356 /* stp_card_unknown@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_183338914811 /* stp_card_unknown@3x.png */; };
+		BF_249856706881 /* STPImageLibrary.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_386885018930 /* STPImageLibrary.h */; };
+		BF_250725326080 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_437723492681 /* GoogleAppIndexing.framework */; };
+		BF_253368692998 /* STPFile+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_547023080128 /* STPFile+Private.h */; };
+		BF_253644441454 /* PINDiskCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_170769962236 /* PINDiskCache.h */; };
+		BF_253963778803 /* STPAnalyticsClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_622439046503 /* STPAnalyticsClient.h */; };
+		BF_254250253346 /* STPAddressViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_439275709173 /* STPAddressViewModel.m */; };
+		BF_255637005666 /* STPCardValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_828376497251 /* STPCardValidator.m */; };
+		BF_255666967363 /* STPAddressFieldTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_328254709834 /* STPAddressFieldTableViewCell.h */; };
+		BF_256572517200 /* STPAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_119461237896 /* STPAPIRequest.m */; };
+		BF_256602909817 /* STPCoreViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_809630086871 /* STPCoreViewController+Private.h */; };
+		BF_257558791404 /* STPCustomer+SourceTuple.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_443953828808 /* STPCustomer+SourceTuple.h */; };
+		BF_259137754468 /* STPSourceCardDetails.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_254186187103 /* STPSourceCardDetails.h */; };
+		BF_259187615236 /* UIBarButtonItem+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_657975526681 /* UIBarButtonItem+Stripe.h */; };
+		BF_262014197977 /* PINOperationGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_279289880954 /* PINOperationGroup.m */; };
+		BF_264598445944 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_604030021498 /* GoogleNetworkingUtilities.framework */; };
+		BF_265834091794 /* STPSourceSEPADebitDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_827299014426 /* STPSourceSEPADebitDetails.m */; };
+		BF_266910441885 /* STPTelemetryClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_855134969525 /* STPTelemetryClient.m */; };
+		BF_268374256153 /* AppJerry.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_614447531043 /* AppJerry.h */; };
+		BF_271492252716 /* STPSourceCardDetails.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_462403503968 /* STPSourceCardDetails.h */; };
+		BF_271545812902 /* stp_card_form_back@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_325521637118 /* stp_card_form_back@3x.png */; };
+		BF_271795342133 /* STPEmailAddressValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_688739162706 /* STPEmailAddressValidator.h */; };
+		BF_271887872074 /* STPSourceParams+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_201763267702 /* STPSourceParams+Private.h */; };
+		BF_271910114791 /* STPUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_793899192763 /* STPUserInformation.m */; };
+		BF_272070534199 /* STPRedirectContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_666150738023 /* STPRedirectContext.h */; };
+		BF_272694535622 /* Fancy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_684008688115 /* Fancy.m */; };
+		BF_273428119225 /* STPCustomer+SourceTuple.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_567993355124 /* STPCustomer+SourceTuple.h */; };
+		BF_273878717745 /* stp_card_applepay@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_196593282791 /* stp_card_applepay@2x.png */; };
+		BF_274055105852 /* UINavigationBar+Stripe_Theme.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_310141525667 /* UINavigationBar+Stripe_Theme.h */; };
+		BF_274107263036 /* STPPaymentCardTextFieldCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_801026079927 /* STPPaymentCardTextFieldCell.h */; };
+		BF_275773117433 /* UIViewController+Stripe_NavigationItemProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_675363467066 /* UIViewController+Stripe_NavigationItemProxy.h */; };
+		BF_276707441897 /* stp_card_jcb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_492175780721 /* stp_card_jcb@2x.png */; };
+		BF_277915633922 /* STPAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_119461237896 /* STPAPIRequest.m */; };
+		BF_278333102912 /* STPUserInformation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_195508064871 /* STPUserInformation.h */; };
+		BF_278829573744 /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_709946777976 /* STPPostalCodeValidator.m */; };
+		BF_279850284898 /* STPAddressFieldTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_276281345727 /* STPAddressFieldTableViewCell.h */; };
+		BF_280277985629 /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_200668121419 /* stp_card_applepay.png */; };
+		BF_280480574053 /* NSBundle+Stripe_AppName.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_749553059542 /* NSBundle+Stripe_AppName.h */; };
+		BF_280516295555 /* STPShippingAddressViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_715819450244 /* STPShippingAddressViewController.h */; };
+		BF_280938055037 /* STPImageLibrary+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_182438507920 /* STPImageLibrary+Private.h */; };
+		BF_282310191556 /* STPPaymentActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_352033123735 /* STPPaymentActivityIndicatorView.m */; };
+		BF_282469902247 /* UIViewController+Stripe_Promises.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_879635869993 /* UIViewController+Stripe_Promises.m */; };
+		BF_284630288850 /* STPSource+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_715088161304 /* STPSource+Private.h */; };
+		BF_285352739005 /* STPPaymentMethodsInternalViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_360464332296 /* STPPaymentMethodsInternalViewController.h */; };
+		BF_286432145384 /* STPPaymentMethodTuple.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_169041491584 /* STPPaymentMethodTuple.h */; };
+		BF_286736495414 /* Fabric.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_704198783520 /* Fabric.h */; };
+		BF_286835721677 /* STPPaymentCardTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_401159209257 /* STPPaymentCardTextField.h */; };
+		BF_287688546313 /* STPAPIClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_465632152352 /* STPAPIClient.h */; };
+		BF_291205570528 /* STPCustomer+SourceTuple.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_443953828808 /* STPCustomer+SourceTuple.h */; };
+		BF_293638183421 /* PINCacheObjectSubscripting.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_106153810107 /* PINCacheObjectSubscripting.h */; };
+		BF_296366995311 /* UIToolbar+Stripe_InputAccessory.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_563361406910 /* UIToolbar+Stripe_InputAccessory.h */; };
+		BF_297095191265 /* UIViewController+Stripe_Promises.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_335537886290 /* UIViewController+Stripe_Promises.h */; };
+		BF_299666730550 /* STPEphemeralKeyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_110318688237 /* STPEphemeralKeyManager.m */; };
+		BF_301160263931 /* STPBundleLocator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_637247309669 /* STPBundleLocator.h */; };
+		BF_301307915522 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_310086671711 /* PINMemoryCache.m */; };
+		BF_301449658397 /* NSCharacterSet+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_623324372480 /* NSCharacterSet+Stripe.h */; };
+		BF_301542515092 /* STPFile.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_392574313117 /* STPFile.h */; };
+		BF_301587847104 /* STPPaymentContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_906691198581 /* STPPaymentContext.h */; };
+		BF_302356280384 /* STPCoreViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_174620530590 /* STPCoreViewController.m */; };
+		BF_302695802166 /* stp_card_unionpay_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_362535988676 /* stp_card_unionpay_en@3x.png */; };
+		BF_302723009548 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166918657392 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */; };
+		BF_304341542293 /* UINavigationController+Stripe_Completion.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_170614256090 /* UINavigationController+Stripe_Completion.h */; };
+		BF_304474317661 /* STPPaymentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_427454786804 /* STPPaymentContext.m */; };
+		BF_307754168989 /* STPCardBrand.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_676661417209 /* STPCardBrand.h */; };
+		BF_308351168005 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_556956092926 /* stp_card_amex@2x.png */; };
+		BF_308592078285 /* STPShippingMethodTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_184535322115 /* STPShippingMethodTableViewCell.h */; };
+		BF_308754239008 /* STPSourceOwner.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_457060453990 /* STPSourceOwner.m */; };
+		BF_310201476180 /* StripeError.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_213034861182 /* StripeError.h */; };
+		BF_310549301087 /* Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_727217733032 /* Stripe.h */; };
+		BF_310644130665 /* UIImage+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_499312825618 /* UIImage+Stripe.h */; };
+		BF_311301233982 /* stp_card_jcb@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_453447722637 /* stp_card_jcb@3x.png */; };
+		BF_311686438440 /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_807603038020 /* stp_card_visa@2x.png */; };
+		BF_312874409667 /* STPCardIOProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_407411144964 /* STPCardIOProxy.h */; };
+		BF_313673711928 /* STPMultipartFormDataPart.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_915238346456 /* STPMultipartFormDataPart.h */; };
+		BF_316400397438 /* PINCacheObjectSubscripting.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_106153810107 /* PINCacheObjectSubscripting.h */; };
+		BF_318193899835 /* STPPaymentCardTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_887939645205 /* STPPaymentCardTextFieldCell.m */; };
+		BF_319135685673 /* STPSourceEnums.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_565065630971 /* STPSourceEnums.h */; };
+		BF_319277470730 /* Fabric.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_776459644262 /* Fabric.h */; };
+		BF_319427141132 /* STPConnectAccountParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_773846360911 /* STPConnectAccountParams.h */; };
+		BF_319684961598 /* UIViewController+Stripe_Promises.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_193926384296 /* UIViewController+Stripe_Promises.h */; };
+		BF_320315038553 /* STPPaymentCardTextFieldCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_903513735268 /* STPPaymentCardTextFieldCell.h */; };
+		BF_320484224139 /* NSBundle+Stripe_AppName.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_408343592509 /* NSBundle+Stripe_AppName.h */; };
+		BF_321275598237 /* STPStringUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_217618539785 /* STPStringUtils.h */; };
+		BF_321663130447 /* UINavigationBar+Stripe_Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_509452004334 /* UINavigationBar+Stripe_Theme.m */; };
+		BF_322266225629 /* stp_card_unionpay_template_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_737821215910 /* stp_card_unionpay_template_zh@3x.png */; };
+		BF_322336096484 /* STPCategoryLoader.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_124543526378 /* STPCategoryLoader.h */; };
+		BF_323275224816 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_143673724944 /* PINDiskCache.m */; };
+		BF_323560998381 /* STPAnalyticsClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_249006138549 /* STPAnalyticsClient.m */; };
+		BF_324442077506 /* STPSourceCardDetails+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_637121338601 /* STPSourceCardDetails+Private.h */; };
+		BF_324947308668 /* STPAPIResponseDecodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_679084602979 /* STPAPIResponseDecodable.h */; };
+		BF_325133916291 /* PINCacheMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_495367858217 /* PINCacheMacros.h */; };
+		BF_325270855464 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_505294580563 /* STPPaymentContextAmountModel.m */; };
+		BF_325335508110 /* AppJerry.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_890897390711 /* AppJerry.m */; };
+		BF_327076790512 /* STPSourceOwner.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_437529102342 /* STPSourceOwner.h */; };
+		BF_327112620609 /* stp_card_form_front@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_324426164016 /* stp_card_form_front@3x.png */; };
+		BF_329201445433 /* STPSourceParams+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_201763267702 /* STPSourceParams+Private.h */; };
+		BF_329509230679 /* STPAPIRequest.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_863899671502 /* STPAPIRequest.h */; };
+		BF_329788152376 /* stp_card_discover@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_363658341124 /* stp_card_discover@3x.png */; };
+		BF_331504465853 /* UINavigationBar+Stripe_Theme.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_847858510902 /* UINavigationBar+Stripe_Theme.h */; };
+		BF_332058350591 /* STPSourcePoller.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_649967179890 /* STPSourcePoller.h */; };
+		BF_332524283285 /* STPFile.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_441979129851 /* STPFile.h */; };
+		BF_332563396093 /* STPPaymentContext+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_187663198768 /* STPPaymentContext+Private.h */; };
+		BF_332688033468 /* STPBankAccount.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_381541692670 /* STPBankAccount.h */; };
+		BF_333086167823 /* STPPaymentMethodsInternalViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_360464332296 /* STPPaymentMethodsInternalViewController.h */; };
+		BF_334152094445 /* Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_692503360915 /* Stripe.h */; };
+		BF_334327636283 /* STPUserInformation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_623044591305 /* STPUserInformation.h */; };
+		BF_334815795400 /* STPSourceVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_922234055079 /* STPSourceVerification.m */; };
+		BF_334982662971 /* AppIntent.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_578847093777 /* AppIntent.h */; };
+		BF_336768004540 /* STPCardValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_828376497251 /* STPCardValidator.m */; };
+		BF_336991966280 /* share-extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FR_205363634933 /* share-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		BF_338270222352 /* STPURLCallbackHandler.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_336262010096 /* STPURLCallbackHandler.h */; };
+		BF_339016661836 /* STPAddCardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_248304595826 /* STPAddCardViewController.m */; };
+		BF_340463658665 /* stp_card_visa_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_233098522244 /* stp_card_visa_template@2x.png */; };
+		BF_340528636515 /* HeaderLib.hpp in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_379671331039 /* HeaderLib.hpp */; };
+		BF_340560239601 /* STPTheme.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_100918364096 /* STPTheme.h */; };
+		BF_340933732939 /* STPEphemeralKeyProvider.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_529604170619 /* STPEphemeralKeyProvider.h */; };
+		BF_343340901752 /* stp_icon_add@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_857961905734 /* stp_icon_add@2x.png */; };
+		BF_344141107682 /* FauxPasAnnotations.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_310737407634 /* FauxPasAnnotations.h */; };
+		BF_344187469442 /* STPBankAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_687805612898 /* STPBankAccount.m */; };
+		BF_345158428908 /* stp_card_diners@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_886839681304 /* stp_card_diners@3x.png */; };
+		BF_345971164535 /* STPAspects.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_592944512740 /* STPAspects.h */; };
+		BF_346272866687 /* StripeError.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_213034861182 /* StripeError.h */; };
+		BF_347272708167 /* STPToken.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_848452328362 /* STPToken.h */; };
+		BF_348272881363 /* STPAddressFieldTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_328254709834 /* STPAddressFieldTableViewCell.h */; };
+		BF_348553538684 /* STPCardBrand.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_843671643897 /* STPCardBrand.h */; };
+		BF_348851446943 /* STPPhoneNumberValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_523478154706 /* STPPhoneNumberValidator.m */; };
+		BF_348910236732 /* STPCardValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_635783061927 /* STPCardValidator.h */; };
+		BF_349486581716 /* STPPaymentConfiguration.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_124520506223 /* STPPaymentConfiguration.h */; };
+		BF_349542215895 /* STPPaymentMethodsViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_799082704884 /* STPPaymentMethodsViewController.h */; };
+		BF_349909356229 /* STPApplePayPaymentMethod.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_369657259990 /* STPApplePayPaymentMethod.h */; };
+		BF_350160722692 /* STPLegalEntityParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_399283558766 /* STPLegalEntityParams.m */; };
+		BF_352002510167 /* stp_shipping_form@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_825690379672 /* stp_shipping_form@3x.png */; };
+		BF_352077015212 /* UITableViewCell+Stripe_Borders.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_734989487303 /* UITableViewCell+Stripe_Borders.h */; };
+		BF_352193689126 /* STPCoreTableViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_654509270410 /* STPCoreTableViewController.h */; };
+		BF_353203537674 /* PINCaching.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_735360084506 /* PINCaching.h */; };
+		BF_353232387432 /* PINCacheMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_495367858217 /* PINCacheMacros.h */; };
+		BF_353638367833 /* STPURLCallbackHandler.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_592260627016 /* STPURLCallbackHandler.h */; };
+		BF_354243208020 /* NSDecimalNumber+Stripe_Currency.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_747080657190 /* NSDecimalNumber+Stripe_Currency.h */; };
+		BF_357323148348 /* STPPostalCodeValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_563104549644 /* STPPostalCodeValidator.h */; };
+		BF_358266653017 /* stp_card_discover@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_363658341124 /* stp_card_discover@3x.png */; };
+		BF_359639414693 /* PINOperationTypes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_224088827831 /* PINOperationTypes.h */; };
+		BF_360817461512 /* stp_card_amex_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_140562483639 /* stp_card_amex_template.png */; };
+		BF_360876168008 /* stp_icon_add.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_739176942134 /* stp_icon_add.png */; };
+		BF_362052980185 /* stp_card_discover.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_475562073492 /* stp_card_discover.png */; };
+		BF_362145821284 /* STPValidatedTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_285793989872 /* STPValidatedTextField.h */; };
+		BF_363806556004 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_845488816582 /* main.m */; };
+		BF_364834197722 /* stp_card_error.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_721448149799 /* stp_card_error.png */; };
+		BF_365335193276 /* STPSource+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_715088161304 /* STPSource+Private.h */; };
+		BF_366356063932 /* libstrings-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_731137829020 /* libstrings-ext-bin.a */; };
+		BF_366909454330 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_411547927351 /* Tests.m */; };
+		BF_370084113100 /* STPAPIClient+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_847634122805 /* STPAPIClient+Private.h */; };
+		BF_370616232422 /* STPCoreViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_228923531634 /* STPCoreViewController.h */; };
+		BF_371070407565 /* STPAddress.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_830637254163 /* STPAddress.h */; };
+		BF_372419327804 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_508923610275 /* STPSourcePoller.m */; };
+		BF_373655580141 /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_394612788029 /* stp_card_visa@3x.png */; };
+		BF_375786299436 /* UIViewController+Stripe_ParentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_535994124885 /* UIViewController+Stripe_ParentViewController.m */; };
+		BF_377176486795 /* PINCaching.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_735360084506 /* PINCaching.h */; };
+		BF_377519697110 /* STPApplePayPaymentMethod.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_369657259990 /* STPApplePayPaymentMethod.h */; };
+		BF_377635648661 /* STPPaymentMethodTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_225976546120 /* STPPaymentMethodTableViewCell.h */; };
+		BF_377871186748 /* STPSourceCardDetails+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_637121338601 /* STPSourceCardDetails+Private.h */; };
+		BF_379564040014 /* STPSourceVerification+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_257482490656 /* STPSourceVerification+Private.h */; };
+		BF_379596458405 /* PINOperation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_814877671763 /* PINOperation.h */; };
+		BF_381194798012 /* Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_692503360915 /* Stripe.h */; };
+		BF_381216440451 /* STPColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_813264579658 /* STPColorUtils.m */; };
+		BF_381600174431 /* STPSourceProtocol.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_421045928597 /* STPSourceProtocol.h */; };
+		BF_383705307049 /* STPBINRange.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_413991883976 /* STPBINRange.m */; };
+		BF_384316649234 /* UIViewController+Stripe_KeyboardAvoiding.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_933371169343 /* UIViewController+Stripe_KeyboardAvoiding.h */; };
+		BF_384586044957 /* STPSourceRedirect.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_483144838889 /* STPSourceRedirect.m */; };
+		BF_384805256193 /* UIViewController+Stripe_Promises.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_335537886290 /* UIViewController+Stripe_Promises.h */; };
+		BF_386629431164 /* STPBlocks.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_871480364449 /* STPBlocks.h */; };
+		BF_386982105162 /* STPPaymentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_427454786804 /* STPPaymentContext.m */; };
+		BF_387460061294 /* PINCaching.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_493757317549 /* PINCaching.h */; };
+		BF_387516634905 /* STPSourceOwner.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_241491748011 /* STPSourceOwner.h */; };
+		BF_389131547685 /* stp_card_unionpay_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_340610195773 /* stp_card_unionpay_en.png */; };
+		BF_389783104759 /* stp_card_visa_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_772315109974 /* stp_card_visa_template@3x.png */; };
+		BF_390127553943 /* STPPhoneNumberValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_456708297239 /* STPPhoneNumberValidator.h */; };
+		BF_390732101066 /* UIImage+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_223874375474 /* UIImage+Stripe.h */; };
+		BF_391460386182 /* STPAddressViewModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_700370057985 /* STPAddressViewModel.h */; };
+		BF_393344152740 /* PINDiskCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_170769962236 /* PINDiskCache.h */; };
+		BF_394155200732 /* PINOperationGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_279289880954 /* PINOperationGroup.m */; };
+		BF_394612155069 /* STPCoreTableViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_732165764070 /* STPCoreTableViewController+Private.h */; };
+		BF_394659372902 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_628989537343 /* STPRedirectContext.m */; };
+		BF_394931725478 /* UIViewController+Stripe_ParentViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_690817139963 /* UIViewController+Stripe_ParentViewController.h */; };
+		BF_396132512980 /* STPCard.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_667277485416 /* STPCard.h */; };
+		BF_396206799972 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_668440300851 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_396790623337 /* ShareExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_115263350237 /* ShareExtension-Info.plist */; };
+		BF_397168673519 /* STPTelemetryClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_855134969525 /* STPTelemetryClient.m */; };
+		BF_398559820423 /* PINDiskCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_530544298450 /* PINDiskCache.h */; };
+		BF_399349584461 /* FauxPasAnnotations.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_250934899452 /* FauxPasAnnotations.h */; };
+		BF_400156068580 /* stp_card_unionpay_template_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_884447368899 /* stp_card_unionpay_template_en@3x.png */; };
+		BF_400157729166 /* stp_card_diners_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_738136358357 /* stp_card_diners_template@2x.png */; };
+		BF_400290070131 /* STPCoreScrollViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_251439661499 /* STPCoreScrollViewController+Private.h */; };
+		BF_400448975998 /* PINMemoryCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_600019716014 /* PINMemoryCache.h */; };
+		BF_400652638065 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_689122585293 /* STPStringUtils.m */; };
+		BF_400807889795 /* STPAspects.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_791769030009 /* STPAspects.h */; };
+		BF_402241053725 /* STPMultipartFormDataPart.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_792688469879 /* STPMultipartFormDataPart.m */; };
+		BF_402485226064 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_668440300851 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_403886376750 /* stp_card_error_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_453324145384 /* stp_card_error_amex.png */; };
+		BF_405210370729 /* STPCardIOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_805430750713 /* STPCardIOProxy.m */; };
+		BF_407711809898 /* stp_card_error_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_574597020760 /* stp_card_error_amex@2x.png */; };
+		BF_408465547746 /* STPSourceVerification+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_257482490656 /* STPSourceVerification+Private.h */; };
+		BF_409598630067 /* STPCoreTableViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_618638349731 /* STPCoreTableViewController+Private.h */; };
+		BF_410605641080 /* NSDecimalNumber+Stripe_Currency.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_299376274777 /* NSDecimalNumber+Stripe_Currency.m */; };
+		BF_412198890813 /* SiriExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_497557335011 /* SiriExtension-Info.plist */; };
+		BF_413008443157 /* UINavigationController+Stripe_Completion.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_170614256090 /* UINavigationController+Stripe_Completion.h */; };
+		BF_415270383479 /* STPSourceReceiver.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_821033470551 /* STPSourceReceiver.h */; };
+		BF_415609941844 /* stp_test_upload_image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = FR_265863572154 /* stp_test_upload_image.jpeg */; };
+		BF_416017100058 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_779344507530 /* GoogleSymbolUtilities.framework */; };
+		BF_416435839240 /* STPPhoneNumberValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_523478154706 /* STPPhoneNumberValidator.m */; };
+		BF_417261323696 /* STPCoreScrollViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_711918819728 /* STPCoreScrollViewController.h */; };
+		BF_418364721790 /* NSMutableURLRequest+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_670837697807 /* NSMutableURLRequest+Stripe.h */; };
+		BF_419060351838 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_189036277762 /* STPSource.m */; };
+		BF_419231674646 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_569620833385 /* UIViewController+Stripe_KeyboardAvoiding.m */; };
+		BF_419236608986 /* STPLocalizationUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_172739966665 /* STPLocalizationUtils.h */; };
+		BF_419385641509 /* STPSourceParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_300701900501 /* STPSourceParams.h */; };
+		BF_419437199489 /* STPPaymentMethod.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_654192010378 /* STPPaymentMethod.h */; };
+		BF_420301864162 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_753262157515 /* InfoPlist.strings */; };
+		BF_422184539559 /* stp_card_visa.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_336676787389 /* stp_card_visa.png */; };
+		BF_422344483627 /* STPConnectAccountParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_413807607925 /* STPConnectAccountParams.h */; };
+		BF_423182950497 /* stp_card_amex_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_758612271558 /* stp_card_amex_template@2x.png */; };
+		BF_424269191583 /* stp_card_form_back.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_363247867339 /* stp_card_form_back.png */; };
+		BF_425025203089 /* STPWeakStrongMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_233085860418 /* STPWeakStrongMacros.h */; };
+		BF_425616635833 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_860483718504 /* GoogleAppIndexingResources.bundle */; };
+		BF_426499012757 /* STPCard+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_281566021398 /* STPCard+Private.h */; };
+		BF_426709595180 /* STPFormEncodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_150902497411 /* STPFormEncodable.h */; };
+		BF_427057640073 /* STPEphemeralKeyManager.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_593739516315 /* STPEphemeralKeyManager.h */; };
+		BF_427155318619 /* stp_card_discover@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_818474340164 /* stp_card_discover@2x.png */; };
+		BF_428731482701 /* STPCard.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_376164653878 /* STPCard.m */; };
+		BF_429301656895 /* STPCard+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_609262385738 /* STPCard+Private.h */; };
+		BF_430562804116 /* stp_card_diners_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_608901290361 /* stp_card_diners_template.png */; };
+		BF_430940717273 /* STPPaymentActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_352033123735 /* STPPaymentActivityIndicatorView.m */; };
+		BF_432388821541 /* stp_icon_checkmark@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_649006375359 /* stp_icon_checkmark@3x.png */; };
+		BF_432714044264 /* UIViewController+Stripe_NavigationItemProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_861265882976 /* UIViewController+Stripe_NavigationItemProxy.h */; };
+		BF_435911882500 /* libPINCache-Core-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_618988043579 /* libPINCache-Core-ios-12.0.a */; };
+		BF_436097312406 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_860483718504 /* GoogleAppIndexingResources.bundle */; };
+		BF_436684481566 /* PINCaching.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_493757317549 /* PINCaching.h */; };
+		BF_437008572190 /* NSDecimalNumber+Stripe_Currency.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_176587841763 /* NSDecimalNumber+Stripe_Currency.h */; };
+		BF_437082473392 /* stp_card_cvc.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_454721095065 /* stp_card_cvc.png */; };
+		BF_439404861791 /* STPBlocks.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_190999170508 /* STPBlocks.h */; };
+		BF_439411478194 /* STPSourceOwner.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_241491748011 /* STPSourceOwner.h */; };
+		BF_439874366934 /* STPPaymentMethodsInternalViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_901652225192 /* STPPaymentMethodsInternalViewController.h */; };
+		BF_440806803592 /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_153688961655 /* stp_shipping_form.png */; };
+		BF_440885593334 /* UrlGetViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_738661589644 /* UrlGetViewController.h */; };
+		BF_440925310579 /* STPRedirectContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_160259185428 /* STPRedirectContext.h */; };
+		BF_441130999656 /* STPColorUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_420487677011 /* STPColorUtils.h */; };
+		BF_441143570909 /* STPBackendAPIAdapter.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_768992176715 /* STPBackendAPIAdapter.h */; };
+		BF_441239768776 /* STPCoreTableViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_732165764070 /* STPCoreTableViewController+Private.h */; };
+		BF_441606882074 /* STPCoreTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_502904508636 /* STPCoreTableViewController.m */; };
+		BF_442937624512 /* STPPaymentCardTextField+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_112556541763 /* STPPaymentCardTextField+Private.h */; };
+		BF_443299014311 /* STPColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_813264579658 /* STPColorUtils.m */; };
+		BF_443954776903 /* UITableViewCell+Stripe_Borders.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_441651685045 /* UITableViewCell+Stripe_Borders.h */; };
+		BF_445613793524 /* STPPaymentCardTextFieldViewModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_117244705373 /* STPPaymentCardTextFieldViewModel.h */; };
+		BF_445930735906 /* STPSource+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_879111094388 /* STPSource+Private.h */; };
+		BF_446113441111 /* stp_card_jcb_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_921522766901 /* stp_card_jcb_template@3x.png */; };
+		BF_446933985080 /* STPEmailAddressValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_688739162706 /* STPEmailAddressValidator.h */; };
+		BF_447117284785 /* STPCard.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_119185384321 /* STPCard.h */; };
+		BF_447256914684 /* NSBundle+Stripe_AppName.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_408343592509 /* NSBundle+Stripe_AppName.h */; };
+		BF_447991924275 /* STPFormEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166695994825 /* STPFormEncoder.m */; };
+		BF_449467972875 /* UIView+Stripe_SafeAreaBounds.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_838695088836 /* UIView+Stripe_SafeAreaBounds.m */; };
+		BF_450073368424 /* STPWeakStrongMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_805065086362 /* STPWeakStrongMacros.h */; };
+		BF_451005353506 /* STPFormEncodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_494798662852 /* STPFormEncodable.h */; };
+		BF_451265572771 /* STPBundleLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_798914995582 /* STPBundleLocator.m */; };
+		BF_452046692150 /* STPPaymentCardTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_197802340500 /* STPPaymentCardTextField.m */; };
+		BF_453090159483 /* stp_card_visa_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_171399986210 /* stp_card_visa_template.png */; };
+		BF_454182150390 /* empty-main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_858321172415 /* empty-main.m */; };
+		BF_454309773871 /* UIBarButtonItem+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_111986568000 /* UIBarButtonItem+Stripe.h */; };
+		BF_455037699108 /* STPBankAccount.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_240590486966 /* STPBankAccount.h */; };
+		BF_455227481165 /* stp_card_jcb.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_242554983927 /* stp_card_jcb.png */; };
+		BF_455904102704 /* stp_icon_add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_481907633182 /* stp_icon_add@3x.png */; };
+		BF_456907750469 /* STPShippingMethodTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_184535322115 /* STPShippingMethodTableViewCell.h */; };
+		BF_457120798592 /* STPSourceCardDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_179040801106 /* STPSourceCardDetails.m */; };
+		BF_458258120490 /* stp_card_error@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_260626407590 /* stp_card_error@2x.png */; };
+		BF_458560551921 /* STPAPIResponseDecodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_107405673473 /* STPAPIResponseDecodable.h */; };
+		BF_460147438551 /* NSArray+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_130046752603 /* NSArray+Stripe.h */; };
+		BF_462176714151 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_353316542796 /* libPINOperation-ios-9.0.a */; };
+		BF_462583713399 /* STPBankAccount.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_240590486966 /* STPBankAccount.h */; };
+		BF_463191881014 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_620301149926 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */; };
+		BF_463357683021 /* NSURLComponents+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_134445234443 /* NSURLComponents+Stripe.h */; };
+		BF_463366413936 /* STPUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_793899192763 /* STPUserInformation.m */; };
+		BF_466358947901 /* AppIntent.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_840244369229 /* AppIntent.m */; };
+		BF_468271912137 /* STPUserInformation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_623044591305 /* STPUserInformation.h */; };
+		BF_469824851714 /* STPEmailAddressValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_388659491173 /* STPEmailAddressValidator.h */; };
+		BF_470288652110 /* STPAnalyticsClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_622439046503 /* STPAnalyticsClient.h */; };
+		BF_471993719881 /* STPBankAccount.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_381541692670 /* STPBankAccount.h */; };
+		BF_472021374075 /* stp_icon_checkmark.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_918038203573 /* stp_icon_checkmark.png */; };
+		BF_474599747974 /* STPImageLibrary+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_591183502734 /* STPImageLibrary+Private.h */; };
+		BF_474960562947 /* STPCoreViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_591666596335 /* STPCoreViewController+Private.h */; };
+		BF_475143180585 /* stp_card_form_front.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_387226535794 /* stp_card_form_front.png */; };
+		BF_476701351716 /* STPValidatedTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_729185093187 /* STPValidatedTextField.h */; };
+		BF_477766101315 /* STPPaymentConfiguration.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_306688222964 /* STPPaymentConfiguration.h */; };
+		BF_478765691567 /* NSCharacterSet+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_275560902555 /* NSCharacterSet+Stripe.m */; };
+		BF_479143927617 /* UITableViewCell+Stripe_Borders.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_734989487303 /* UITableViewCell+Stripe_Borders.h */; };
+		BF_479590952822 /* stp_card_mastercard_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_465416715992 /* stp_card_mastercard_template@3x.png */; };
+		BF_480254573427 /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_709946777976 /* STPPostalCodeValidator.m */; };
+		BF_481459157621 /* PINCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_227724747281 /* PINCache.h */; };
+		BF_482442627169 /* STPLocalizationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_529784366644 /* STPLocalizationUtils.m */; };
+		BF_482937980884 /* PINCaching.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_493757317549 /* PINCaching.h */; };
+		BF_482938234912 /* stp_card_discover_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_827618709703 /* stp_card_discover_template.png */; };
+		BF_483120801550 /* STPStringUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_217618539785 /* STPStringUtils.h */; };
+		BF_483233437923 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_743842026332 /* GoogleAuthUtilities.framework */; };
+		BF_483363410580 /* STPSourceVerification+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_702731086180 /* STPSourceVerification+Private.h */; };
+		BF_483597779937 /* PINDiskCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_530544298450 /* PINDiskCache.h */; };
+		BF_484127874607 /* STPInternalAPIResponseDecodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_145688362384 /* STPInternalAPIResponseDecodable.h */; };
+		BF_484204787292 /* STPCustomer.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_362637812812 /* STPCustomer.m */; };
+		BF_484323380262 /* STPSourceVerification.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_216387680131 /* STPSourceVerification.h */; };
+		BF_485648701398 /* stp_card_applepay@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_716391505040 /* stp_card_applepay@3x.png */; };
+		BF_485760438581 /* PINDiskCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_170769962236 /* PINDiskCache.h */; };
+		BF_487054552557 /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_153688961655 /* stp_shipping_form.png */; };
+		BF_487984092344 /* STPMultipartFormDataEncoder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_391708229706 /* STPMultipartFormDataEncoder.h */; };
+		BF_488257176070 /* PINCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_138502338795 /* PINCache.h */; };
+		BF_488527143184 /* STPAPIClient+ApplePay.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_199387754190 /* STPAPIClient+ApplePay.h */; };
+		BF_491398236520 /* stp_card_jcb_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_779248810941 /* stp_card_jcb_template.png */; };
+		BF_492061585534 /* Fabric+FABKits.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_485689218719 /* Fabric+FABKits.h */; };
+		BF_496327918804 /* NSString+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_716313626667 /* NSString+Stripe.h */; };
+		BF_496697733442 /* stp_card_diners@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_107323960575 /* stp_card_diners@2x.png */; };
+		BF_497669979549 /* STPCardIOProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_437919225479 /* STPCardIOProxy.h */; };
+		BF_498677365325 /* stp_card_diners_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_421043145734 /* stp_card_diners_template@3x.png */; };
+		BF_498764902292 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_240970093763 /* STPCardParams.m */; };
+		BF_498867406999 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_860483718504 /* GoogleAppIndexingResources.bundle */; };
+		BF_499364212407 /* stp_card_discover_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_827618709703 /* stp_card_discover_template.png */; };
+		BF_499388278079 /* STPPaymentMethodsInternalViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_901652225192 /* STPPaymentMethodsInternalViewController.h */; };
+		BF_499403324285 /* PINCacheObjectSubscripting.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_621675436412 /* PINCacheObjectSubscripting.h */; };
+		BF_500487776665 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_322145952019 /* NSDictionary+Stripe.m */; };
+		BF_500902037116 /* PINCacheObjectSubscripting.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_621675436412 /* PINCacheObjectSubscripting.h */; };
+		BF_502579502558 /* stp_icon_add@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_857961905734 /* stp_icon_add@2x.png */; };
+		BF_502665421922 /* STPAnalyticsClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_252761981132 /* STPAnalyticsClient.h */; };
+		BF_503027097537 /* STPPaymentMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_341953782072 /* STPPaymentMethodsViewController.m */; };
+		BF_503397154927 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_542306643416 /* stp_card_amex.png */; };
+		BF_504006751447 /* stp_test_upload_image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = FR_265863572154 /* stp_test_upload_image.jpeg */; };
+		BF_504315410621 /* stp_card_unknown@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_435282719354 /* stp_card_unknown@2x.png */; };
+		BF_504610670413 /* NSURLComponents+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_480653613414 /* NSURLComponents+Stripe.h */; };
+		BF_504906925819 /* NSDecimalNumber+Stripe_Currency.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_747080657190 /* NSDecimalNumber+Stripe_Currency.h */; };
+		BF_511203901761 /* STPDelegateProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_652176105039 /* STPDelegateProxy.h */; };
+		BF_511683710040 /* NSError+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_434788842793 /* NSError+Stripe.m */; };
+		BF_512702965137 /* stp_card_unionpay_template_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_443910781375 /* stp_card_unionpay_template_zh.png */; };
+		BF_514808246518 /* STPShippingAddressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_114090975619 /* STPShippingAddressViewController.m */; };
+		BF_516085003785 /* stp_card_jcb_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_755922952676 /* stp_card_jcb_template@2x.png */; };
+		BF_517120243851 /* stp_card_mastercard_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_878039505509 /* stp_card_mastercard_template.png */; };
+		BF_518725300039 /* PINOperationTypes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_684714893235 /* PINOperationTypes.h */; };
+		BF_519578738523 /* stp_card_unionpay_template_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_542047769331 /* stp_card_unionpay_template_en@2x.png */; };
+		BF_520157303909 /* PINMemoryCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_888484860318 /* PINMemoryCache.h */; };
+		BF_520486560930 /* STPPaymentMethodTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_370123180763 /* STPPaymentMethodTuple.m */; };
+		BF_521256516347 /* libUrlGetClasses-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_952027055371 /* libUrlGetClasses-ios-12.0.a */; };
+		BF_522195337332 /* UIViewController+Stripe_KeyboardAvoiding.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_555089210878 /* UIViewController+Stripe_KeyboardAvoiding.h */; };
+		BF_523854442262 /* STPShippingAddressViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_190529263507 /* STPShippingAddressViewController.h */; };
+		BF_524857575538 /* STPCustomer+SourceTuple.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_567993355124 /* STPCustomer+SourceTuple.h */; };
+		BF_525736542296 /* stp_card_unknown.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_622754080338 /* stp_card_unknown.png */; };
+		BF_526637614106 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = VG_557820679266 /* AppIntentVocabulary.plist */; };
+		BF_526770364330 /* STPPostalCodeValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_583674497367 /* STPPostalCodeValidator.h */; };
+		BF_526963054110 /* STPPaymentContextAmountModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_428794804154 /* STPPaymentContextAmountModel.h */; };
+		BF_528256391815 /* STPCardParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_600578543769 /* STPCardParams.h */; };
+		BF_529345976121 /* stp_card_diners_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_608901290361 /* stp_card_diners_template.png */; };
+		BF_531230473633 /* STPSourceVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_922234055079 /* STPSourceVerification.m */; };
+		BF_531401913033 /* Some.cc in Sources */ = {isa = PBXBuildFile; fileRef = FR_167666946058 /* Some.cc */; };
+		BF_532506937214 /* stp_shipping_form@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_596924801474 /* stp_shipping_form@2x.png */; };
+		BF_533019153936 /* STPBackendAPIAdapter.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_768992176715 /* STPBackendAPIAdapter.h */; };
+		BF_533139797846 /* STPSource+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_879111094388 /* STPSource+Private.h */; };
+		BF_533342140868 /* FABKitProtocol.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_459256248737 /* FABKitProtocol.h */; };
+		BF_533902145193 /* STPMultipartFormDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_695779107005 /* STPMultipartFormDataEncoder.m */; };
+		BF_534133201948 /* STPAPIClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_320799198594 /* STPAPIClient.h */; };
+		BF_535227545278 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_753120224409 /* UrlGetViewController.xib */; };
+		BF_536300143534 /* STPPaymentCardTextFieldViewModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_117244705373 /* STPPaymentCardTextFieldViewModel.h */; };
+		BF_536656955521 /* STPSourceParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_300701900501 /* STPSourceParams.h */; };
+		BF_537015205276 /* STPSourceEnums.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_709146189722 /* STPSourceEnums.h */; };
+		BF_537090058859 /* stp_icon_add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_481907633182 /* stp_icon_add@3x.png */; };
+		BF_537327529029 /* stp_card_visa.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_336676787389 /* stp_card_visa.png */; };
+		BF_537511256999 /* STPCustomer.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_362637812812 /* STPCustomer.m */; };
+		BF_537734704667 /* STPPaymentMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_341953782072 /* STPPaymentMethodsViewController.m */; };
+		BF_537907193664 /* STPAddCardViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_502474434784 /* STPAddCardViewController+Private.h */; };
+		BF_538380531367 /* stp_card_cvc_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_754763453812 /* stp_card_cvc_amex@2x.png */; };
+		BF_538398697795 /* UITableViewCell+Stripe_Borders.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_503123501592 /* UITableViewCell+Stripe_Borders.m */; };
+		BF_538525263717 /* PINOperationMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_210368222096 /* PINOperationMacros.h */; };
+		BF_539811780662 /* UIViewController+Stripe_Promises.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_193926384296 /* UIViewController+Stripe_Promises.h */; };
+		BF_541423578972 /* STPLocalizationUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_172739966665 /* STPLocalizationUtils.h */; };
+		BF_541984527700 /* STPCoreViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_809630086871 /* STPCoreViewController+Private.h */; };
+		BF_542733884215 /* STPPaymentContextAmountModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_463415628327 /* STPPaymentContextAmountModel.h */; };
+		BF_542911731250 /* stp_card_form_front.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_387226535794 /* stp_card_form_front.png */; };
+		BF_546913603120 /* STPSourceParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_386854374165 /* STPSourceParams.m */; };
+		BF_547467272222 /* STPCardIOProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_407411144964 /* STPCardIOProxy.h */; };
+		BF_547493121527 /* STPPaymentCardTextField+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_760476646265 /* STPPaymentCardTextField+Private.h */; };
+		BF_547821895204 /* STPMultipartFormDataPart.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_792688469879 /* STPMultipartFormDataPart.m */; };
+		BF_547903250638 /* STPCoreTableViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_654509270410 /* STPCoreTableViewController.h */; };
+		BF_548176440234 /* PINCacheObjectSubscripting.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_621675436412 /* PINCacheObjectSubscripting.h */; };
+		BF_548404306289 /* STPCardIOProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_437919225479 /* STPCardIOProxy.h */; };
+		BF_549127057796 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_551274171982 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
+		BF_549129403466 /* Fabric.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_704198783520 /* Fabric.h */; };
+		BF_549225706027 /* STPAPIRequest.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_853966787131 /* STPAPIRequest.h */; };
+		BF_550263340238 /* PINOperationGroup.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_218663833597 /* PINOperationGroup.h */; };
+		BF_550314237865 /* STPPaymentConfiguration+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_413649058186 /* STPPaymentConfiguration+Private.h */; };
+		BF_550459375374 /* PINDiskCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_530544298450 /* PINDiskCache.h */; };
+		BF_550612809375 /* STPAPIClient+ApplePay.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_199387754190 /* STPAPIClient+ApplePay.h */; };
+		BF_550890492479 /* STPInternalAPIResponseDecodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_145688362384 /* STPInternalAPIResponseDecodable.h */; };
+		BF_551983870758 /* STPPaymentConfiguration.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_306688222964 /* STPPaymentConfiguration.h */; };
+		BF_552934083707 /* STPMultipartFormDataEncoder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_391708229706 /* STPMultipartFormDataEncoder.h */; };
+		BF_553283229840 /* STPCardValidationState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_498316524810 /* STPCardValidationState.h */; };
+		BF_554008743498 /* STPLocalizationUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_387408549256 /* STPLocalizationUtils.h */; };
+		BF_554214730689 /* PKPayment+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_332315537569 /* PKPayment+Stripe.h */; };
+		BF_554251084243 /* UIToolbar+Stripe_InputAccessory.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_172958393529 /* UIToolbar+Stripe_InputAccessory.h */; };
+		BF_554873144876 /* UIView+Stripe_FirstResponder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_468805634066 /* UIView+Stripe_FirstResponder.h */; };
+		BF_555268818033 /* libsiri-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_674603271118 /* libsiri-ext-bin.a */; };
+		BF_555538071810 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_916661342534 /* UIViewController+Stripe_NavigationItemProxy.m */; };
+		BF_556264213146 /* stp_card_diners_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_421043145734 /* stp_card_diners_template@3x.png */; };
+		BF_556340857556 /* stp_card_unionpay_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_205650942905 /* stp_card_unionpay_en@2x.png */; };
+		BF_556472663789 /* STPSourceCardDetails+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_880704464323 /* STPSourceCardDetails+Private.h */; };
+		BF_556483001857 /* Fabric.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_776459644262 /* Fabric.h */; };
+		BF_556535368733 /* STPSourceReceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_477141207452 /* STPSourceReceiver.m */; };
+		BF_557021896850 /* STPBINRange.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_404009520577 /* STPBINRange.h */; };
+		BF_557434726307 /* STPAPIResponseDecodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_107405673473 /* STPAPIResponseDecodable.h */; };
+		BF_557718603905 /* STPPaymentContext+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_651211894634 /* STPPaymentContext+Private.h */; };
+		BF_558954520920 /* STPPaymentCardTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_112095401783 /* STPPaymentCardTextField.h */; };
+		BF_559238596559 /* stp_card_diners@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_107323960575 /* stp_card_diners@2x.png */; };
+		BF_559293705325 /* STPBINRange.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_413991883976 /* STPBINRange.m */; };
+		BF_559718294321 /* STPInternalAPIResponseDecodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_583778395098 /* STPInternalAPIResponseDecodable.h */; };
+		BF_559862217917 /* PINCacheMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_703899038574 /* PINCacheMacros.h */; };
+		BF_561780859195 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_481672282565 /* libPINCache-Core-ios-9.0.a */; };
+		BF_561826517078 /* libPINOperation-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_424267095963 /* libPINOperation-ios-12.0.a */; };
+		BF_562026224161 /* STPEphemeralKey.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_401046103149 /* STPEphemeralKey.m */; };
+		BF_563667443364 /* stp_card_error@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_260626407590 /* stp_card_error@2x.png */; };
+		BF_564483627286 /* NSCharacterSet+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_623324372480 /* NSCharacterSet+Stripe.h */; };
+		BF_564986401887 /* STPPaymentConfiguration+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_868093412922 /* STPPaymentConfiguration+Private.h */; };
+		BF_565384582904 /* NSArray+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_787984517909 /* NSArray+Stripe.h */; };
+		BF_565451141735 /* UIViewController+Stripe_ParentViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_690817139963 /* UIViewController+Stripe_ParentViewController.h */; };
+		BF_566061458534 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_604030021498 /* GoogleNetworkingUtilities.framework */; };
+		BF_566136145133 /* stp_card_unionpay_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_212508126291 /* stp_card_unionpay_zh@3x.png */; };
+		BF_569143270790 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_879680789012 /* Localizable.strings */; };
+		BF_569899831647 /* UIImage+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_499312825618 /* UIImage+Stripe.h */; };
+		BF_570611123316 /* STPPaymentCardTextFieldCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_903513735268 /* STPPaymentCardTextFieldCell.h */; };
+		BF_570983647477 /* STPAddress.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_856633702404 /* STPAddress.h */; };
+		BF_572579139440 /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_874886281442 /* PINCache.m */; };
+		BF_573040290455 /* STPCustomer+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_597436128584 /* STPCustomer+Private.h */; };
+		BF_574479621621 /* STPSwitchTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_589726050819 /* STPSwitchTableViewCell.h */; };
+		BF_575594069114 /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_394612788029 /* stp_card_visa@3x.png */; };
+		BF_575712853151 /* STPCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_582745043417 /* STPCustomerContext.m */; };
+		BF_576791073433 /* STPSource.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_865857012183 /* STPSource.h */; };
+		BF_578906339526 /* STPCoreViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_106165532869 /* STPCoreViewController.h */; };
+		BF_579369186123 /* STPLegalEntityParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_399283558766 /* STPLegalEntityParams.m */; };
+		BF_579705915869 /* STPSwitchTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_446067735536 /* STPSwitchTableViewCell.h */; };
+		BF_579733271806 /* stp_card_unknown@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_435282719354 /* stp_card_unknown@2x.png */; };
+		BF_579970270682 /* PINOperationGroup.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_152553107307 /* PINOperationGroup.h */; };
+		BF_580063542734 /* STPPaymentMethodTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_225976546120 /* STPPaymentMethodTableViewCell.h */; };
+		BF_580588333688 /* STPAddCardViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_296560133436 /* STPAddCardViewController.h */; };
+		BF_581636919195 /* stp_card_form_back.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_363247867339 /* stp_card_form_back.png */; };
+		BF_581808474341 /* NSMutableURLRequest+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_246982922734 /* NSMutableURLRequest+Stripe.m */; };
+		BF_583334210316 /* STPSource.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_204424633043 /* STPSource.h */; };
+		BF_583670923783 /* STPSourceSEPADebitDetails.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_314640988313 /* STPSourceSEPADebitDetails.h */; };
+		BF_583882935065 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_779344507530 /* GoogleSymbolUtilities.framework */; };
+		BF_584113318929 /* PKPayment+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_332315537569 /* PKPayment+Stripe.h */; };
+		BF_585028702972 /* STPPaymentCardTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_112095401783 /* STPPaymentCardTextField.h */; };
+		BF_586042743864 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_429071574776 /* STPBankAccountParams.m */; };
+		BF_586217066392 /* stp_card_error_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_456109311282 /* stp_card_error_amex@3x.png */; };
+		BF_586866993565 /* STPShippingMethodsViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_164344606297 /* STPShippingMethodsViewController.h */; };
+		BF_587241892406 /* STPAPIResponseDecodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_679084602979 /* STPAPIResponseDecodable.h */; };
+		BF_588001213672 /* AppDelegate.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_819768356424 /* AppDelegate.h */; };
+		BF_588369128785 /* NoArc.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_547151370574 /* NoArc.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BF_588930220508 /* STPSourceEnums.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_709146189722 /* STPSourceEnums.h */; };
+		BF_589188210696 /* PINCacheObjectSubscripting.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_106153810107 /* PINCacheObjectSubscripting.h */; };
+		BF_590301139518 /* STPSourceCardDetails.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_254186187103 /* STPSourceCardDetails.h */; };
+		BF_590596019249 /* PINOperationQueue.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_190995174488 /* PINOperationQueue.h */; };
+		BF_591354843568 /* STPAddressViewModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_768379248407 /* STPAddressViewModel.h */; };
+		BF_593076128533 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_321171250374 /* libUrlGetClasses-ios-9.0.a */; };
+		BF_593747456481 /* STPEmailAddressValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_657711760784 /* STPEmailAddressValidator.m */; };
+		BF_594223087452 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_569620833385 /* UIViewController+Stripe_KeyboardAvoiding.m */; };
+		BF_595033292052 /* UIView+Stripe_FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_235596592030 /* UIView+Stripe_FirstResponder.m */; };
+		BF_595197390143 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_166918657392 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */; };
+		BF_595198601241 /* PINOperationTypes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_684714893235 /* PINOperationTypes.h */; };
+		BF_595507140671 /* STPLegalEntityParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_459027505856 /* STPLegalEntityParams.h */; };
+		BF_595803006362 /* STPDelegateProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_652176105039 /* STPDelegateProxy.h */; };
+		BF_596643458939 /* STPEphemeralKeyManager.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_634151600220 /* STPEphemeralKeyManager.h */; };
+		BF_596981788321 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_176089150530 /* STPSectionHeaderView.m */; };
+		BF_598450610068 /* UIViewController+Stripe_ParentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_535994124885 /* UIViewController+Stripe_ParentViewController.m */; };
+		BF_598961581630 /* STPCard.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_667277485416 /* STPCard.h */; };
+		BF_599487230604 /* STPAddCardViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_395102338138 /* STPAddCardViewController+Private.h */; };
+		BF_601455989561 /* STPPaymentMethodTuple.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_169041491584 /* STPPaymentMethodTuple.h */; };
+		BF_601788139586 /* PINCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_138502338795 /* PINCache.h */; };
+		BF_602281982503 /* UIImage+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_223874375474 /* UIImage+Stripe.h */; };
+		BF_603955496550 /* STPBankAccountParams+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_720475461729 /* STPBankAccountParams+Private.h */; };
+		BF_605002578850 /* STPColorUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_701086246168 /* STPColorUtils.h */; };
+		BF_605459178514 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_556956092926 /* stp_card_amex@2x.png */; };
+		BF_606363516352 /* Some.cc in Sources */ = {isa = PBXBuildFile; fileRef = FR_167666946058 /* Some.cc */; };
+		BF_606365642930 /* NSString+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_281431888822 /* NSString+Stripe.m */; };
+		BF_606909180832 /* STPFormEncodable.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_494798662852 /* STPFormEncodable.h */; };
+		BF_607070386912 /* STPColorUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_701086246168 /* STPColorUtils.h */; };
+		BF_607164502273 /* STPCategoryLoader.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_568593882583 /* STPCategoryLoader.h */; };
+		BF_609231923885 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_753262157515 /* InfoPlist.strings */; };
+		BF_610177243136 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_845488816582 /* main.m */; };
+		BF_610466688322 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_743842026332 /* GoogleAuthUtilities.framework */; };
+		BF_611229103734 /* STPCoreScrollViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_165114611545 /* STPCoreScrollViewController+Private.h */; };
+		BF_611959448208 /* STPCoreViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_228923531634 /* STPCoreViewController.h */; };
+		BF_612411344394 /* stp_card_mastercard_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_465416715992 /* stp_card_mastercard_template@3x.png */; };
+		BF_612947230634 /* STPAPIClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_465632152352 /* STPAPIClient.h */; };
+		BF_614327253500 /* STPMultipartFormDataEncoder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_464681328909 /* STPMultipartFormDataEncoder.h */; };
+		BF_614826181880 /* NSDecimalNumber+Stripe_Currency.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_299376274777 /* NSDecimalNumber+Stripe_Currency.m */; };
+		BF_615023423365 /* STPImageLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_413023481354 /* STPImageLibrary.m */; };
+		BF_615736622874 /* STPApplePayPaymentMethod.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_171679345202 /* STPApplePayPaymentMethod.h */; };
+		BF_615795409362 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_623895726528 /* STPAddress.m */; };
+		BF_616460888190 /* STPCardValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_635783061927 /* STPCardValidator.h */; };
+		BF_616983081347 /* UITableViewCell+Stripe_Borders.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_441651685045 /* UITableViewCell+Stripe_Borders.h */; };
+		BF_617648187444 /* STPAddressViewModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_768379248407 /* STPAddressViewModel.h */; };
+		BF_618163706615 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_551274171982 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
+		BF_619170717804 /* PINMemoryCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_888484860318 /* PINMemoryCache.h */; };
+		BF_621297371033 /* PKPayment+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_591392785580 /* PKPayment+Stripe.h */; };
+		BF_624393800431 /* STPApplePayPaymentMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_321591135654 /* STPApplePayPaymentMethod.m */; };
+		BF_626857746750 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_321171250374 /* libUrlGetClasses-ios-9.0.a */; };
+		BF_626946760252 /* UINavigationController+Stripe_Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_664471815887 /* UINavigationController+Stripe_Completion.m */; };
+		BF_627155690991 /* StringsExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_102943442467 /* StringsExtension-Info.plist */; };
+		BF_627940546410 /* STPSwitchTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_493570425693 /* STPSwitchTableViewCell.m */; };
+		BF_628093969059 /* STPAnalyticsClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_249006138549 /* STPAnalyticsClient.m */; };
+		BF_629239440212 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_743842026332 /* GoogleAuthUtilities.framework */; };
+		BF_629941936974 /* FABKitProtocol.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_263771945362 /* FABKitProtocol.h */; };
+		BF_630704383611 /* STPValidatedTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_729185093187 /* STPValidatedTextField.h */; };
+		BF_630730911163 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_860483718504 /* GoogleAppIndexingResources.bundle */; };
+		BF_631160075017 /* UIView+Stripe_SafeAreaBounds.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_708327290125 /* UIView+Stripe_SafeAreaBounds.h */; };
+		BF_631286616569 /* stp_card_cvc@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_353412325098 /* stp_card_cvc@3x.png */; };
+		BF_632482032205 /* STPShippingMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_236953861390 /* STPShippingMethodsViewController.m */; };
+		BF_632696438025 /* STPSectionHeaderView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_481660996906 /* STPSectionHeaderView.h */; };
+		BF_633003488668 /* stp_card_cvc.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_454721095065 /* stp_card_cvc.png */; };
+		BF_633128707324 /* STPDelegateProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_721129734544 /* STPDelegateProxy.h */; };
+		BF_633410647955 /* STPBundleLocator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_420736451946 /* STPBundleLocator.h */; };
+		BF_633638727304 /* NSError+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_657128263749 /* NSError+Stripe.h */; };
+		BF_634068117988 /* STPShippingMethodsViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_289951473723 /* STPShippingMethodsViewController.h */; };
+		BF_636460932467 /* STPConnectAccountParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_413807607925 /* STPConnectAccountParams.h */; };
+		BF_636871656877 /* STPLegalEntityParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_431919160946 /* STPLegalEntityParams.h */; };
+		BF_637475383201 /* NSString+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_716313626667 /* NSString+Stripe.h */; };
+		BF_638527070046 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = VG_557820679266 /* AppIntentVocabulary.plist */; };
+		BF_639049821515 /* STPSourceRedirect.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_427684117497 /* STPSourceRedirect.h */; };
+		BF_639850709349 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_469267514516 /* PKPayment+Stripe.m */; };
+		BF_641558335001 /* stp_shipping_form@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_825690379672 /* stp_shipping_form@3x.png */; };
+		BF_644055395911 /* STPShippingAddressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_114090975619 /* STPShippingAddressViewController.m */; };
+		BF_644346539646 /* STPPaymentCardTextFieldViewModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_157587722902 /* STPPaymentCardTextFieldViewModel.h */; };
+		BF_644495441626 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_115569304376 /* libStripe-ios-9.0.a */; };
+		BF_645210569547 /* stp_card_form_front@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_484208255089 /* stp_card_form_front@2x.png */; };
+		BF_645844241746 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_322145952019 /* NSDictionary+Stripe.m */; };
+		BF_646424098992 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_214160927202 /* STPDispatchFunctions.m */; };
+		BF_646731671250 /* STPPaymentActivityIndicatorView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_809108791963 /* STPPaymentActivityIndicatorView.h */; };
+		BF_647324315494 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_860483718504 /* GoogleAppIndexingResources.bundle */; };
+		BF_647726860901 /* stp_icon_add.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_739176942134 /* stp_icon_add.png */; };
+		BF_648562762332 /* STPPaymentMethodsViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_753343340710 /* STPPaymentMethodsViewController+Private.h */; };
+		BF_648932273856 /* STPPaymentCardTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_197802340500 /* STPPaymentCardTextField.m */; };
+		BF_649301406038 /* Fabric+FABKits.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_227516787760 /* Fabric+FABKits.h */; };
+		BF_649733185797 /* stp_card_mastercard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_470930712391 /* stp_card_mastercard@2x.png */; };
+		BF_651489745922 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_295663962341 /* stp_card_amex@3x.png */; };
+		BF_652165739522 /* STPBlocks.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_190999170508 /* STPBlocks.h */; };
+		BF_652915475726 /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_874886281442 /* PINCache.m */; };
+		BF_653745811457 /* STPCard.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_376164653878 /* STPCard.m */; };
+		BF_654317303678 /* AppDelegate.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_819768356424 /* AppDelegate.h */; };
+		BF_656310590468 /* STPAddCardViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_502474434784 /* STPAddCardViewController+Private.h */; };
+		BF_656381699164 /* STPSourceRedirect+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_723543549131 /* STPSourceRedirect+Private.h */; };
+		BF_656814611262 /* STPPhoneNumberValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_438694548221 /* STPPhoneNumberValidator.h */; };
+		BF_656913513255 /* STPImageLibrary.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_386885018930 /* STPImageLibrary.h */; };
+		BF_657262140631 /* STPCard+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_281566021398 /* STPCard+Private.h */; };
+		BF_659708573738 /* STPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_629980649685 /* STPToken.m */; };
+		BF_659943408471 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_773149577891 /* Tests2.m */; };
+		BF_660181566425 /* UIToolbar+Stripe_InputAccessory.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_172958393529 /* UIToolbar+Stripe_InputAccessory.h */; };
+		BF_661729225758 /* stp_card_cvc@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_324415420402 /* stp_card_cvc@2x.png */; };
+		BF_662605744307 /* NSError+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_657128263749 /* NSError+Stripe.h */; };
+		BF_663116816096 /* STPBundleLocator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_420736451946 /* STPBundleLocator.h */; };
+		BF_663191289928 /* STPCoreScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_311622561615 /* STPCoreScrollViewController.m */; };
+		BF_663686741949 /* STPPaymentActivityIndicatorView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_825181478485 /* STPPaymentActivityIndicatorView.h */; };
+		BF_663796921581 /* STPEphemeralKeyProvider.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_529604170619 /* STPEphemeralKeyProvider.h */; };
+		BF_664767754488 /* stp_card_cvc_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_134719527222 /* stp_card_cvc_amex.png */; };
+		BF_664828362108 /* STPPaymentCardTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_401159209257 /* STPPaymentCardTextField.h */; };
+		BF_665107086376 /* STPPhoneNumberValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_456708297239 /* STPPhoneNumberValidator.h */; };
+		BF_666051195313 /* STPCoreViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_174620530590 /* STPCoreViewController.m */; };
+		BF_666439790854 /* PINMemoryCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_600019716014 /* PINMemoryCache.h */; };
+		BF_666488213915 /* stp_card_unionpay_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_128201504065 /* stp_card_unionpay_zh.png */; };
+		BF_666590302924 /* stp_card_unionpay_template_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_884447368899 /* stp_card_unionpay_template_en@3x.png */; };
+		BF_666902952524 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_481672282565 /* libPINCache-Core-ios-9.0.a */; };
+		BF_667707193631 /* STPEphemeralKeyProvider.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_496554446077 /* STPEphemeralKeyProvider.h */; };
+		BF_668090102880 /* STPSwitchTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_493570425693 /* STPSwitchTableViewCell.m */; };
+		BF_668302248372 /* stp_card_cvc@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_353412325098 /* stp_card_cvc@3x.png */; };
+		BF_669332903893 /* NSDictionary+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_668317149915 /* NSDictionary+Stripe.h */; };
+		BF_670172723121 /* STPBankAccountParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_359239314212 /* STPBankAccountParams.h */; };
+		BF_670611076258 /* STPSourceProtocol.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_368887152771 /* STPSourceProtocol.h */; };
+		BF_674231239736 /* STPPaymentContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_443179884003 /* STPPaymentContext.h */; };
+		BF_676957737800 /* STPSectionHeaderView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_284420664639 /* STPSectionHeaderView.h */; };
+		BF_677261258913 /* STPAddCardViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_605183289017 /* STPAddCardViewController.h */; };
+		BF_677400779752 /* STPCardValidationState.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_647615708741 /* STPCardValidationState.h */; };
+		BF_677745771921 /* STPBankAccountParams+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_720475461729 /* STPBankAccountParams+Private.h */; };
+		BF_678284120450 /* STPCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_582745043417 /* STPCustomerContext.m */; };
+		BF_678696729482 /* UIViewController+Stripe_NavigationItemProxy.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_861265882976 /* UIViewController+Stripe_NavigationItemProxy.h */; };
+		BF_680428845014 /* UIView+Stripe_FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_235596592030 /* UIView+Stripe_FirstResponder.m */; };
+		BF_681407398214 /* STPPaymentResult.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_633919745139 /* STPPaymentResult.h */; };
+		BF_683052243089 /* STPPaymentConfiguration+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_413649058186 /* STPPaymentConfiguration+Private.h */; };
+		BF_683203182624 /* STPToken.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_768476324412 /* STPToken.h */; };
+		BF_683530227445 /* NSArray+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_130046752603 /* NSArray+Stripe.h */; };
+		BF_683682685556 /* STPCustomer+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_285060110180 /* STPCustomer+Private.h */; };
+		BF_685348128266 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_115569304376 /* libStripe-ios-9.0.a */; };
+		BF_686732017306 /* stp_card_unknown@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_183338914811 /* stp_card_unknown@3x.png */; };
+		BF_686832569531 /* STPSourceRedirect.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_483144838889 /* STPSourceRedirect.m */; };
+		BF_688412023245 /* STPSourceOwner.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_457060453990 /* STPSourceOwner.m */; };
+		BF_688548530308 /* STPSourceReceiver.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_771342212418 /* STPSourceReceiver.h */; };
+		BF_688989087489 /* stp_card_unionpay_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_128201504065 /* stp_card_unionpay_zh.png */; };
+		BF_689014154181 /* STPDispatchFunctions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_680182050104 /* STPDispatchFunctions.h */; };
+		BF_689981672024 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_779344507530 /* GoogleSymbolUtilities.framework */; };
+		BF_690686155656 /* PINCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_138502338795 /* PINCache.h */; };
+		BF_691261085238 /* Some.hpp in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_180206282362 /* Some.hpp */; };
+		BF_692824832486 /* STPLocalizationUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_387408549256 /* STPLocalizationUtils.h */; };
+		BF_694096876398 /* UrlGetViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_738661589644 /* UrlGetViewController.h */; };
+		BF_694131021614 /* STPImageLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_413023481354 /* STPImageLibrary.m */; };
+		BF_695311822348 /* stp_card_cvc_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_754763453812 /* stp_card_cvc_amex@2x.png */; };
+		BF_695686603777 /* NoArc.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_547151370574 /* NoArc.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BF_695835611478 /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_763790828482 /* STPValidatedTextField.m */; };
+		BF_696851575369 /* STPCoreViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_106165532869 /* STPCoreViewController.h */; };
+		BF_697575071468 /* UINavigationBar+Stripe_Theme.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_310141525667 /* UINavigationBar+Stripe_Theme.h */; };
+		BF_697824881552 /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_769504085116 /* STPAPIClient+ApplePay.m */; };
+		BF_698473776974 /* STPCardValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_308536515212 /* STPCardValidator.h */; };
+		BF_699400014971 /* StripeError.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_800273678048 /* StripeError.m */; };
+		BF_700321127624 /* PINCaching.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_735360084506 /* PINCaching.h */; };
+		BF_700714835948 /* STPDispatchFunctions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_651847570475 /* STPDispatchFunctions.h */; };
+		BF_702518897872 /* stp_card_mastercard@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_127475428263 /* stp_card_mastercard@3x.png */; };
+		BF_703160045272 /* stp_card_unionpay_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_947823834394 /* stp_card_unionpay_zh@2x.png */; };
+		BF_705261524169 /* STPPaymentConfiguration.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_124520506223 /* STPPaymentConfiguration.h */; };
+		BF_706090148504 /* stp_card_mastercard.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_423603962795 /* stp_card_mastercard.png */; };
+		BF_706090347626 /* STPCustomer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_668070994301 /* STPCustomer.h */; };
+		BF_706148594395 /* STPPaymentMethodsInternalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_865157427735 /* STPPaymentMethodsInternalViewController.m */; };
+		BF_706833575101 /* stp_card_amex_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_468113573340 /* stp_card_amex_template@3x.png */; };
+		BF_707222492630 /* STPPaymentActivityIndicatorView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_825181478485 /* STPPaymentActivityIndicatorView.h */; };
+		BF_708261286034 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_508900331586 /* NSURLComponents+Stripe.m */; };
+		BF_708665657427 /* stp_card_unionpay_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_205650942905 /* stp_card_unionpay_en@2x.png */; };
+		BF_708687516173 /* STPShippingMethodTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_802267686739 /* STPShippingMethodTableViewCell.h */; };
+		BF_710323036496 /* STPCustomer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_668070994301 /* STPCustomer.h */; };
+		BF_710345899699 /* STPCard.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_119185384321 /* STPCard.h */; };
+		BF_710837320023 /* STPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_629980649685 /* STPToken.m */; };
+		BF_711121425182 /* STPEphemeralKeyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_110318688237 /* STPEphemeralKeyManager.m */; };
+		BF_711203980455 /* STPStringUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_574570312868 /* STPStringUtils.h */; };
+		BF_712036193580 /* STPAddCardViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_605183289017 /* STPAddCardViewController.h */; };
+		BF_712363952044 /* STPMultipartFormDataPart.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_915238346456 /* STPMultipartFormDataPart.h */; };
+		BF_712791594497 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_773149577891 /* Tests2.m */; };
+		BF_712988642500 /* stp_card_error_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_574597020760 /* stp_card_error_amex@2x.png */; };
+		BF_715699072640 /* STPPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_218112984498 /* STPPromise.m */; };
+		BF_715931941628 /* STPSourceSEPADebitDetails.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_609302522033 /* STPSourceSEPADebitDetails.h */; };
+		BF_716964868962 /* PINCaching.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_493757317549 /* PINCaching.h */; };
+		BF_717821120978 /* stp_card_unionpay_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_947823834394 /* stp_card_unionpay_zh@2x.png */; };
+		BF_717872951990 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_416711012558 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */; };
+		BF_718406769513 /* STPAddress.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_856633702404 /* STPAddress.h */; };
+		BF_720283447267 /* STPPromise.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_706359988177 /* STPPromise.h */; };
+		BF_720601400496 /* STPAnalyticsClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_252761981132 /* STPAnalyticsClient.h */; };
+		BF_722268048417 /* stp_card_unionpay_template_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_542047769331 /* stp_card_unionpay_template_en@2x.png */; };
+		BF_722838844774 /* stp_card_discover.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_475562073492 /* stp_card_discover.png */; };
+		BF_724008586335 /* PINOperationTypes.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_224088827831 /* PINOperationTypes.h */; };
+		BF_724589153213 /* STPCoreViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_591666596335 /* STPCoreViewController+Private.h */; };
+		BF_725700492600 /* STPPaymentMethod.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_748329317110 /* STPPaymentMethod.h */; };
+		BF_726160460471 /* STPShippingMethodTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_802267686739 /* STPShippingMethodTableViewCell.h */; };
+		BF_727077927178 /* NSCharacterSet+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_426656857393 /* NSCharacterSet+Stripe.h */; };
+		BF_727176482223 /* stp_card_error.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_721448149799 /* stp_card_error.png */; };
+		BF_728133248104 /* STPSourcePoller.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_328352920299 /* STPSourcePoller.h */; };
+		BF_730550012423 /* PINCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_227724747281 /* PINCache.h */; };
+		BF_732196886655 /* UINavigationController+Stripe_Completion.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_498549693882 /* UINavigationController+Stripe_Completion.h */; };
+		BF_736236657369 /* STPApplePayPaymentMethod.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_171679345202 /* STPApplePayPaymentMethod.h */; };
+		BF_736370347193 /* PINCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_227724747281 /* PINCache.h */; };
+		BF_736595894600 /* stp_card_visa_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_233098522244 /* stp_card_visa_template@2x.png */; };
+		BF_737431965053 /* STPFile.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_859214955617 /* STPFile.m */; };
+		BF_738500385646 /* stp_card_unknown.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_622754080338 /* stp_card_unknown.png */; };
+		BF_738675055335 /* PINCaching.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_735360084506 /* PINCaching.h */; };
+		BF_739943495228 /* NSDictionary+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_240832335761 /* NSDictionary+Stripe.h */; };
+		BF_740403725356 /* NSMutableURLRequest+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_246982922734 /* NSMutableURLRequest+Stripe.m */; };
+		BF_740939883811 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_437723492681 /* GoogleAppIndexing.framework */; };
+		BF_741943896980 /* STPPaymentMethodsInternalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_865157427735 /* STPPaymentMethodsInternalViewController.m */; };
+		BF_742830011938 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_214160927202 /* STPDispatchFunctions.m */; };
+		BF_744717184211 /* STPCard+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_609262385738 /* STPCard+Private.h */; };
+		BF_745257428742 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_481672282565 /* libPINCache-Core-ios-9.0.a */; };
+		BF_746330347275 /* STPURLCallbackHandler.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_592260627016 /* STPURLCallbackHandler.h */; };
+		BF_746399658810 /* STPToken.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_848452328362 /* STPToken.h */; };
+		BF_746714470153 /* STPPostalCodeValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_563104549644 /* STPPostalCodeValidator.h */; };
+		BF_747429969635 /* STPConnectAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_572796611138 /* STPConnectAccountParams.m */; };
+		BF_748382559973 /* STPTheme.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_256578496436 /* STPTheme.h */; };
+		BF_749593072306 /* UIToolbar+Stripe_InputAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_594159834513 /* UIToolbar+Stripe_InputAccessory.m */; };
+		BF_749620751106 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_845488816582 /* main.m */; };
+		BF_750512776469 /* PINOperationMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_210368222096 /* PINOperationMacros.h */; };
+		BF_750902070972 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_773149577891 /* Tests2.m */; };
+		BF_752215109014 /* STPAspects.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_791769030009 /* STPAspects.h */; };
+		BF_752256144767 /* stp_card_diners@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_886839681304 /* stp_card_diners@3x.png */; };
+		BF_752543758240 /* stp_card_jcb.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_242554983927 /* stp_card_jcb.png */; };
+		BF_752750884043 /* STPSourceRedirect+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_723543549131 /* STPSourceRedirect+Private.h */; };
+		BF_753390046774 /* STPBINRange.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_900054750708 /* STPBINRange.h */; };
+		BF_753696533019 /* UIView+Stripe_SafeAreaBounds.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_838695088836 /* UIView+Stripe_SafeAreaBounds.m */; };
+		BF_755849946898 /* FABKitProtocol.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_263771945362 /* FABKitProtocol.h */; };
+		BF_756694657825 /* NSBundle+Stripe_AppName.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_749553059542 /* NSBundle+Stripe_AppName.h */; };
+		BF_757592272989 /* STPCustomer+SourceTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_679404232338 /* STPCustomer+SourceTuple.m */; };
+		BF_758552470194 /* NSArray+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_270361851280 /* NSArray+Stripe.m */; };
+		BF_758774651870 /* STPSectionHeaderView.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_481660996906 /* STPSectionHeaderView.h */; };
+		BF_758805317529 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_689122585293 /* STPStringUtils.m */; };
+		BF_761949389858 /* stp_card_amex_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_140562483639 /* stp_card_amex_template.png */; };
+		BF_762079931330 /* STPPromise.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_353249173463 /* STPPromise.h */; };
+		BF_762148963754 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_711629859574 /* STPPaymentMethodTableViewCell.m */; };
+		BF_762592850533 /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_763790828482 /* STPValidatedTextField.m */; };
+		BF_764055906310 /* STPDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_410892256394 /* STPDelegateProxy.m */; };
+		BF_764466462314 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_293229987775 /* STPURLCallbackHandler.m */; };
+		BF_767770953726 /* stp_card_unionpay_template_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_443910781375 /* stp_card_unionpay_template_zh.png */; };
+		BF_769390461961 /* FABKitProtocol.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_459256248737 /* FABKitProtocol.h */; };
+		BF_770870274260 /* STPCategoryLoader.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_568593882583 /* STPCategoryLoader.h */; };
+		BF_772244235996 /* stp_icon_checkmark.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_918038203573 /* stp_icon_checkmark.png */; };
+		BF_772256144782 /* stp_icon_checkmark@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_851662726671 /* stp_icon_checkmark@2x.png */; };
+		BF_773012804294 /* STPAPIClient+ApplePay.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_807037820303 /* STPAPIClient+ApplePay.h */; };
+		BF_777312866759 /* STPPaymentCardTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_887939645205 /* STPPaymentCardTextFieldCell.m */; };
+		BF_777929815323 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_295663962341 /* stp_card_amex@3x.png */; };
+		BF_777934210855 /* stp_card_cvc_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_770241236915 /* stp_card_cvc_amex@3x.png */; };
+		BF_778216471773 /* STPCustomer+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_285060110180 /* STPCustomer+Private.h */; };
+		BF_778571260535 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_253734139691 /* AppDelegate.m */; };
+		BF_780445515388 /* UIView+Stripe_FirstResponder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_468805634066 /* UIView+Stripe_FirstResponder.h */; };
+		BF_780796191582 /* stp_card_jcb@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_453447722637 /* stp_card_jcb@3x.png */; };
+		BF_781128673283 /* STPAPIClient+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_847634122805 /* STPAPIClient+Private.h */; };
+		BF_781224844460 /* STPPaymentCardTextFieldCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_801026079927 /* STPPaymentCardTextFieldCell.h */; };
+		BF_781804809790 /* FauxPasAnnotations.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_250934899452 /* FauxPasAnnotations.h */; };
+		BF_781817350106 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_240970093763 /* STPCardParams.m */; };
+		BF_783900044562 /* STPAspects.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_344626064168 /* STPAspects.m */; };
+		BF_785207536242 /* libios-app-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_968277723020 /* libios-app-bin.a */; };
+		BF_791606347633 /* PINOperation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_656725481201 /* PINOperation.h */; };
+		BF_792549583398 /* STPCategoryLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_494301659888 /* STPCategoryLoader.m */; };
+		BF_792758988381 /* stp_card_discover_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_705928698620 /* stp_card_discover_template@3x.png */; };
+		BF_792879120425 /* StringsExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_102943442467 /* StringsExtension-Info.plist */; };
+		BF_793949375173 /* PINOperationQueue.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_190995174488 /* PINOperationQueue.h */; };
+		BF_794987405795 /* STPFormTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_468517384487 /* STPFormTextField.h */; };
+		BF_795516723710 /* NSDictionary+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_668317149915 /* NSDictionary+Stripe.h */; };
+		BF_795733996006 /* UIView+Stripe_SafeAreaBounds.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_703828678216 /* UIView+Stripe_SafeAreaBounds.h */; };
+		BF_795903619981 /* STPCustomerContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_639161976165 /* STPCustomerContext.h */; };
+		BF_796694256828 /* stp_card_error@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_804401515869 /* stp_card_error@3x.png */; };
+		BF_797115579488 /* STPAspects.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_344626064168 /* STPAspects.m */; };
+		BF_797161458492 /* strings-extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FR_107066082523 /* strings-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		BF_797400080911 /* STPSourceCardDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_179040801106 /* STPSourceCardDetails.m */; };
+		BF_800824306451 /* STPPaymentResult.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_374236941753 /* STPPaymentResult.h */; };
+		BF_802212837063 /* STPPhoneNumberValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_438694548221 /* STPPhoneNumberValidator.h */; };
+		BF_803011142765 /* STPEphemeralKey.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_864958197976 /* STPEphemeralKey.h */; };
+		BF_804144951548 /* STPTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_678946834674 /* STPTheme.m */; };
+		BF_804888977857 /* stp_card_diners.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_524791267555 /* stp_card_diners.png */; };
+		BF_805591497955 /* PINOperationQueue.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_960264344136 /* PINOperationQueue.h */; };
+		BF_805740141929 /* NSURLComponents+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_134445234443 /* NSURLComponents+Stripe.h */; };
+		BF_806327248992 /* PINOperationMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_603110710953 /* PINOperationMacros.h */; };
+		BF_807296877452 /* UIViewController+Stripe_KeyboardAvoiding.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_555089210878 /* UIViewController+Stripe_KeyboardAvoiding.h */; };
+		BF_807594298166 /* stp_card_mastercard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_470930712391 /* stp_card_mastercard@2x.png */; };
+		BF_808217497340 /* STPFormTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_185670732342 /* STPFormTextField.m */; };
+		BF_808246866099 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_411547927351 /* Tests.m */; };
+		BF_808784190597 /* STPCardBrand.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_676661417209 /* STPCardBrand.h */; };
+		BF_811211250455 /* STPCardIOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_805430750713 /* STPCardIOProxy.m */; };
+		BF_811394832804 /* UIBarButtonItem+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_111986568000 /* UIBarButtonItem+Stripe.h */; };
+		BF_812087440491 /* UINavigationBar+Stripe_Theme.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_847858510902 /* UINavigationBar+Stripe_Theme.h */; };
+		BF_813765486872 /* UIView+Stripe_FirstResponder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_170596598734 /* UIView+Stripe_FirstResponder.h */; };
+		BF_814006962241 /* STPAddCardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_248304595826 /* STPAddCardViewController.m */; };
+		BF_814292853267 /* STPCoreTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_502904508636 /* STPCoreTableViewController.m */; };
+		BF_814474818515 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_293229987775 /* STPURLCallbackHandler.m */; };
+		BF_815107472923 /* STPPaymentMethodsViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_501344631583 /* STPPaymentMethodsViewController+Private.h */; };
+		BF_815609127357 /* STPPaymentCardTextField+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_112556541763 /* STPPaymentCardTextField+Private.h */; };
+		BF_816470681529 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_314953714155 /* STPPaymentResult.m */; };
+		BF_817466125506 /* STPColorUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_420487677011 /* STPColorUtils.h */; };
+		BF_818300223791 /* STPFormEncoder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_187518438601 /* STPFormEncoder.h */; };
+		BF_818394404850 /* STPPaymentCardTextField+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_760476646265 /* STPPaymentCardTextField+Private.h */; };
+		BF_818590191865 /* libios-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_258616937111 /* libios-ext-bin.a */; };
+		BF_821768833841 /* STPPaymentMethodsViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_501344631583 /* STPPaymentMethodsViewController+Private.h */; };
+		BF_821964836057 /* STPSourceReceiver.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_771342212418 /* STPSourceReceiver.h */; };
+		BF_823227850974 /* STPCustomerContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_639161976165 /* STPCustomerContext.h */; };
+		BF_824099007553 /* UIView+Stripe_SafeAreaBounds.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_703828678216 /* UIView+Stripe_SafeAreaBounds.h */; };
+		BF_824224080322 /* PINCacheObjectSubscripting.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_621675436412 /* PINCacheObjectSubscripting.h */; };
+		BF_824955833590 /* STPSourceVerification.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_749349441066 /* STPSourceVerification.h */; };
+		BF_825318156586 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_860483718504 /* GoogleAppIndexingResources.bundle */; };
+		BF_826111041639 /* stp_card_amex_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_758612271558 /* stp_card_amex_template@2x.png */; };
+		BF_828073877901 /* STPPostalCodeValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_583674497367 /* STPPostalCodeValidator.h */; };
+		BF_831427525575 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_429071574776 /* STPBankAccountParams.m */; };
+		BF_831515964199 /* stp_card_form_back@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_810335568173 /* stp_card_form_back@2x.png */; };
+		BF_832200031424 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_505294580563 /* STPPaymentContextAmountModel.m */; };
+		BF_832988560206 /* STPSwitchTableViewCell.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_446067735536 /* STPSwitchTableViewCell.h */; };
+		BF_834104184485 /* STPCustomerContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_455055307449 /* STPCustomerContext.h */; };
+		BF_836435373461 /* STPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_908317792274 /* STPAPIClient.m */; };
+		BF_839205472018 /* STPFile+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_358655835312 /* STPFile+Private.h */; };
+		BF_840158473028 /* STPFormTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_153226209751 /* STPFormTextField.h */; };
+		BF_840224660358 /* NSDecimalNumber+Stripe_Currency.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_176587841763 /* NSDecimalNumber+Stripe_Currency.h */; };
+		BF_841232890610 /* STPSourceRedirect+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_724259384552 /* STPSourceRedirect+Private.h */; };
+		BF_841939749835 /* NSError+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_354724297581 /* NSError+Stripe.h */; };
+		BF_842059543370 /* STPImageLibrary+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_591183502734 /* STPImageLibrary+Private.h */; };
+		BF_845184473776 /* STPPaymentContextAmountModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_428794804154 /* STPPaymentContextAmountModel.h */; };
+		BF_845198702840 /* STPAddress.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_830637254163 /* STPAddress.h */; };
+		BF_845335545682 /* STPLocalizationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_529784366644 /* STPLocalizationUtils.m */; };
+		BF_845841139589 /* STPShippingAddressViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_190529263507 /* STPShippingAddressViewController.h */; };
+		BF_846560459294 /* NSError+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_354724297581 /* NSError+Stripe.h */; };
+		BF_846667158072 /* STPPaymentMethodTuple.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_489307065831 /* STPPaymentMethodTuple.h */; };
+		BF_846793332782 /* NSString+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_470744425341 /* NSString+Stripe.h */; };
+		BF_847291989349 /* STPEmailAddressValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_657711760784 /* STPEmailAddressValidator.m */; };
+		BF_848211254093 /* stp_card_mastercard.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_423603962795 /* stp_card_mastercard.png */; };
+		BF_848254338918 /* STPBankAccountParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_359239314212 /* STPBankAccountParams.h */; };
+		BF_848594506740 /* stp_card_discover@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_818474340164 /* stp_card_discover@2x.png */; };
+		BF_850232326309 /* STPCoreScrollViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_251439661499 /* STPCoreScrollViewController+Private.h */; };
+		BF_850628345573 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_353316542796 /* libPINOperation-ios-9.0.a */; };
+		BF_852077649031 /* PINMemoryCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_600019716014 /* PINMemoryCache.h */; };
+		BF_852318462908 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_668440300851 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_852904719974 /* STPEmailAddressValidator.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_388659491173 /* STPEmailAddressValidator.h */; };
+		BF_853024008497 /* STPSourceVerification.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_216387680131 /* STPSourceVerification.h */; };
+		BF_853346063620 /* STPConnectAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_572796611138 /* STPConnectAccountParams.m */; };
+		BF_853979415908 /* STPFormTextField.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_153226209751 /* STPFormTextField.h */; };
+		BF_854114344938 /* STPEphemeralKeyManager.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_593739516315 /* STPEphemeralKeyManager.h */; };
+		BF_854297538363 /* STPFile+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_358655835312 /* STPFile+Private.h */; };
+		BF_855562422631 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_253734139691 /* AppDelegate.m */; };
+		BF_856011478606 /* NSError+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_434788842793 /* NSError+Stripe.m */; };
+		BF_857638390821 /* STPSourceCardDetails+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_880704464323 /* STPSourceCardDetails+Private.h */; };
+		BF_857725329044 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_143673724944 /* PINDiskCache.m */; };
+		BF_858175137351 /* STPURLCallbackHandler.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_336262010096 /* STPURLCallbackHandler.h */; };
+		BF_858489200029 /* ShareExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_115263350237 /* ShareExtension-Info.plist */; };
+		BF_859149025202 /* stp_card_mastercard_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_232572251428 /* stp_card_mastercard_template@2x.png */; };
+		BF_859335257745 /* UIViewController+Stripe_ParentViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_737907561380 /* UIViewController+Stripe_ParentViewController.h */; };
+		BF_859620595924 /* STPFile.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_441979129851 /* STPFile.h */; };
+		BF_860109961268 /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_200668121419 /* stp_card_applepay.png */; };
+		BF_862208142468 /* STPSourceVerification.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_749349441066 /* STPSourceVerification.h */; };
+		BF_864516097820 /* stp_card_diners_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_738136358357 /* stp_card_diners_template@2x.png */; };
+		BF_864601913654 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_620301149926 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */; };
+		BF_865312341190 /* stp_card_visa_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_171399986210 /* stp_card_visa_template.png */; };
+		BF_865423218224 /* UIToolbar+Stripe_InputAccessory.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_563361406910 /* UIToolbar+Stripe_InputAccessory.h */; };
+		BF_867265947213 /* STPSourceSEPADebitDetails.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_609302522033 /* STPSourceSEPADebitDetails.h */; };
+		BF_867400988080 /* stp_card_cvc_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_770241236915 /* stp_card_cvc_amex@3x.png */; };
+		BF_867757176281 /* STPAddressViewModel.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_700370057985 /* STPAddressViewModel.h */; };
+		BF_868279965357 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_183755575988 /* UIImage+Stripe.m */; };
+		BF_868495247631 /* STPCardParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_600578543769 /* STPCardParams.h */; };
+		BF_869285449676 /* PINCacheMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_495367858217 /* PINCacheMacros.h */; };
+		BF_869420912167 /* STPSourceProtocol.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_421045928597 /* STPSourceProtocol.h */; };
+		BF_869499576351 /* STPBackendAPIAdapter.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_133576635973 /* STPBackendAPIAdapter.h */; };
+		BF_869835224510 /* stp_card_jcb_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_779248810941 /* stp_card_jcb_template.png */; };
+		BF_870268343510 /* UIToolbar+Stripe_InputAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_594159834513 /* UIToolbar+Stripe_InputAccessory.m */; };
+		BF_870378261019 /* UrlGetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_734554573488 /* UrlGetViewController.m */; };
+		BF_872007431300 /* STPEphemeralKey.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_897166241393 /* STPEphemeralKey.h */; };
+		BF_872087434557 /* STPBackendAPIAdapter.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_133576635973 /* STPBackendAPIAdapter.h */; };
+		BF_872366323585 /* stp_card_mastercard_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_878039505509 /* stp_card_mastercard_template.png */; };
+		BF_872525723563 /* STPTheme.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_256578496436 /* STPTheme.h */; };
+		BF_872593558093 /* STPPaymentMethodsViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_753343340710 /* STPPaymentMethodsViewController+Private.h */; };
+		BF_873250804444 /* STPMultipartFormDataPart.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_500693267193 /* STPMultipartFormDataPart.h */; };
+		BF_874479752220 /* STPPaymentMethodsViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_162423673141 /* STPPaymentMethodsViewController.h */; };
+		BF_874646431482 /* PINCacheMacros.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_703899038574 /* PINCacheMacros.h */; };
+		BF_874960947885 /* PINOperation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_656725481201 /* PINOperation.h */; };
+		BF_875539600787 /* stp_icon_checkmark@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_851662726671 /* stp_icon_checkmark@2x.png */; };
+		BF_875554489720 /* PINDiskCache.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_170769962236 /* PINDiskCache.h */; };
+		BF_876120395905 /* STPMultipartFormDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_695779107005 /* STPMultipartFormDataEncoder.m */; };
+		BF_877111062382 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_542306643416 /* stp_card_amex.png */; };
+		BF_877675794012 /* STPSourcePoller.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_649967179890 /* STPSourcePoller.h */; };
+		BF_879139214009 /* STPSourceEnums.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_565065630971 /* STPSourceEnums.h */; };
+		BF_879243780838 /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_769504085116 /* STPAPIClient+ApplePay.m */; };
+		BF_880548692885 /* STPSourceSEPADebitDetails.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_314640988313 /* STPSourceSEPADebitDetails.h */; };
+		BF_880616391997 /* STPCustomerContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_455055307449 /* STPCustomerContext.h */; };
+		BF_880637916596 /* STPPaymentMethodsViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_162423673141 /* STPPaymentMethodsViewController.h */; };
+		BF_881197284158 /* STPFormEncoder.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_187518438601 /* STPFormEncoder.h */; };
+		BF_883432793737 /* stp_card_applepay@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_716391505040 /* stp_card_applepay@3x.png */; };
+		BF_883920894635 /* stp_card_jcb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_492175780721 /* stp_card_jcb@2x.png */; };
+		BF_884282777467 /* STPCoreScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_311622561615 /* STPCoreScrollViewController.m */; };
+		BF_885114134832 /* libPINCache-Arc-exception-safe-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_292167901401 /* libPINCache-Arc-exception-safe-ios-12.0.a */; };
+		BF_885826923241 /* STPPaymentMethod.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_748329317110 /* STPPaymentMethod.h */; };
+		BF_887227005087 /* STPEphemeralKeyProvider.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_496554446077 /* STPEphemeralKeyProvider.h */; };
+		BF_887507580698 /* STPEphemeralKeyManager.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_634151600220 /* STPEphemeralKeyManager.h */; };
+		BF_888519593251 /* STPBINRange.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_404009520577 /* STPBINRange.h */; };
+		BF_889127824037 /* stp_card_unionpay_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_340610195773 /* stp_card_unionpay_en.png */; };
+		BF_889909272663 /* PINOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_373510968019 /* PINOperationQueue.m */; };
+		BF_890245801013 /* STPAPIRequest.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_863899671502 /* STPAPIRequest.h */; };
+		BF_891699548570 /* stp_card_applepay@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_196593282791 /* stp_card_applepay@2x.png */; };
+		BF_892735993335 /* Fabric+FABKits.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_485689218719 /* Fabric+FABKits.h */; };
+		BF_892747823754 /* STPPaymentContext+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_187663198768 /* STPPaymentContext+Private.h */; };
+		BF_893153948993 /* STPTelemetryClient.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_826898134611 /* STPTelemetryClient.h */; };
+		BF_893287338731 /* stp_card_jcb_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_755922952676 /* stp_card_jcb_template@2x.png */; };
+		BF_893335691237 /* STPApplePayPaymentMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_321591135654 /* STPApplePayPaymentMethod.m */; };
+		BF_893378746244 /* UINavigationController+Stripe_Completion.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_498549693882 /* UINavigationController+Stripe_Completion.h */; };
+		BF_894870115046 /* STPStringUtils.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_574570312868 /* STPStringUtils.h */; };
+		BF_895595545075 /* SiriExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_497557335011 /* SiriExtension-Info.plist */; };
+		BF_896149289071 /* STPImageLibrary.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_563808066373 /* STPImageLibrary.h */; };
+		BF_897890258860 /* STPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_908317792274 /* STPAPIClient.m */; };
+		BF_898026823466 /* stp_card_error@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_804401515869 /* stp_card_error@3x.png */; };
+		BF_898457484024 /* UIBarButtonItem+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_660486720752 /* UIBarButtonItem+Stripe.m */; };
+		BF_899107596582 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_599031596757 /* NSBundle+Stripe_AppName.m */; };
+		BF_899109362603 /* STPSourceRedirect.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_427684117497 /* STPSourceRedirect.h */; };
+		BF_900889973275 /* STPLegalEntityParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_459027505856 /* STPLegalEntityParams.h */; };
+		BF_901142508449 /* STPCustomer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_390537239017 /* STPCustomer.h */; };
+		BF_901245616579 /* STPPaymentCardTextFieldViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_583395561891 /* STPPaymentCardTextFieldViewModel.m */; };
+		BF_902313281118 /* UIView+Stripe_SafeAreaBounds.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_708327290125 /* UIView+Stripe_SafeAreaBounds.h */; };
+		BF_903654427761 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_604030021498 /* GoogleNetworkingUtilities.framework */; };
+		BF_903765825652 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_779344507530 /* GoogleSymbolUtilities.framework */; };
+		BF_903795981010 /* STPSourceOwner.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_437529102342 /* STPSourceOwner.h */; };
+		BF_904714273747 /* STPCustomer+SourceTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_679404232338 /* STPCustomer+SourceTuple.m */; };
+		BF_905870717195 /* STPSourceParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_386854374165 /* STPSourceParams.m */; };
+		BF_906674504504 /* STPCardParams.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_380855240261 /* STPCardParams.h */; };
+		BF_906973596745 /* STPImageLibrary.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_563808066373 /* STPImageLibrary.h */; };
+		BF_907512446919 /* stp_card_discover_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_142523824475 /* stp_card_discover_template@2x.png */; };
+		BF_907762169657 /* STPPaymentContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_906691198581 /* STPPaymentContext.h */; };
+		BF_908099116251 /* STPShippingMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_236953861390 /* STPShippingMethodsViewController.m */; };
+		BF_908648225751 /* STPDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_410892256394 /* STPDelegateProxy.m */; };
+		BF_909873506410 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_743842026332 /* GoogleAuthUtilities.framework */; };
+		BF_911112024558 /* STPBankAccountParams+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_859246040826 /* STPBankAccountParams+Private.h */; };
+		BF_912355922148 /* STPCustomer.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_390537239017 /* STPCustomer.h */; };
+		BF_917515496184 /* STPBundleLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_798914995582 /* STPBundleLocator.m */; };
+		BF_917711275756 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_321171250374 /* libUrlGetClasses-ios-9.0.a */; };
+		BF_917870419091 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_551274171982 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
+		BF_918442450254 /* NSMutableURLRequest+Stripe.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_469496801272 /* NSMutableURLRequest+Stripe.h */; };
+		BF_918471961904 /* FauxPasAnnotations.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_310737407634 /* FauxPasAnnotations.h */; };
+		BF_919956655886 /* NSString+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_281431888822 /* NSString+Stripe.m */; };
+		BF_921252546392 /* STPRedirectContext.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_666150738023 /* STPRedirectContext.h */; };
+		BF_921545965922 /* stp_card_amex_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_468113573340 /* stp_card_amex_template@3x.png */; };
+		BF_930529541670 /* stp_card_unionpay_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_212508126291 /* stp_card_unionpay_zh@3x.png */; };
+		BF_942912852986 /* STPAddCardViewController+Private.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_395102338138 /* STPAddCardViewController+Private.h */; };
+		BF_961509480863 /* STPPaymentMethodsViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_799082704884 /* STPPaymentMethodsViewController.h */; };
+		BF_966256741207 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_176089150530 /* STPSectionHeaderView.m */; };
+		BF_973399829844 /* STPCardBrand.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_843671643897 /* STPCardBrand.h */; };
+		BF_985690579445 /* STPAddCardViewController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = FR_296560133436 /* STPAddCardViewController.h */; };
+		BF_988355903664 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_628989537343 /* STPRedirectContext.m */; };
+		BF_996283831704 /* UrlGet-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_174283433844 /* UrlGet-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		CIP_44300245758 /* PBXContainerItemProxy */ = {
+		CIP_70572684590 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_4793904575952 /* Project object */;
+			containerPortal = P_4192881629041 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_243789410170;
-			remoteInfo = "share-extension";
+			remoteGlobalIDString = NT_757956135481;
+			remoteInfo = "ios-app";
 		};
-		"CIP_44300245758-1" /* PBXContainerItemProxy */ = {
+		CIP_74502314307 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_4793904575952 /* Project object */;
+			containerPortal = P_4192881629041 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_361814418977;
+			remoteGlobalIDString = NT_287747118355;
 			remoteInfo = "siri-extension";
 		};
-		"CIP_44300245758-2" /* PBXContainerItemProxy */ = {
+		CIP_77935498165 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_4793904575952 /* Project object */;
+			containerPortal = P_4192881629041 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_910389829219;
+			remoteGlobalIDString = NT_757956135481;
+			remoteInfo = "ios-app";
+		};
+		CIP_81887985952 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P_4192881629041 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT_205363634933;
+			remoteInfo = "share-extension";
+		};
+		CIP_83587674885 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P_4192881629041 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT_107066082523;
 			remoteInfo = "strings-extension";
-		};
-		CIP_58354672782 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_4793904575952 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_443002457585;
-			remoteInfo = "ios-app";
-		};
-		CIP_87012950138 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_4793904575952 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_443002457585;
-			remoteInfo = "ios-app";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		CFBP_6358864645 /* CopyFiles */ = {
+		CFBP_1192997001 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_654317303678 /* AppDelegate.h in CopyFiles */,
+				BF_129442605958 /* Some.hpp in CopyFiles */,
+				BF_694096876398 /* UrlGetViewController.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_1548478967 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_533342140868 /* FABKitProtocol.h in CopyFiles */,
+				BF_755849946898 /* FABKitProtocol.h in CopyFiles */,
+				BF_649301406038 /* Fabric+FABKits.h in CopyFiles */,
+				BF_492061585534 /* Fabric+FABKits.h in CopyFiles */,
+				BF_319277470730 /* Fabric.h in CopyFiles */,
+				BF_549129403466 /* Fabric.h in CopyFiles */,
+				BF_781804809790 /* FauxPasAnnotations.h in CopyFiles */,
+				BF_918471961904 /* FauxPasAnnotations.h in CopyFiles */,
+				BF_460147438551 /* NSArray+Stripe.h in CopyFiles */,
+				BF_148813291472 /* NSArray+Stripe.h in CopyFiles */,
+				BF_320484224139 /* NSBundle+Stripe_AppName.h in CopyFiles */,
+				BF_280480574053 /* NSBundle+Stripe_AppName.h in CopyFiles */,
+				BF_201941927316 /* NSCharacterSet+Stripe.h in CopyFiles */,
+				BF_301449658397 /* NSCharacterSet+Stripe.h in CopyFiles */,
+				BF_354243208020 /* NSDecimalNumber+Stripe_Currency.h in CopyFiles */,
+				BF_437008572190 /* NSDecimalNumber+Stripe_Currency.h in CopyFiles */,
+				BF_739943495228 /* NSDictionary+Stripe.h in CopyFiles */,
+				BF_795516723710 /* NSDictionary+Stripe.h in CopyFiles */,
+				BF_841939749835 /* NSError+Stripe.h in CopyFiles */,
+				BF_662605744307 /* NSError+Stripe.h in CopyFiles */,
+				BF_918442450254 /* NSMutableURLRequest+Stripe.h in CopyFiles */,
+				BF_418364721790 /* NSMutableURLRequest+Stripe.h in CopyFiles */,
+				BF_846793332782 /* NSString+Stripe.h in CopyFiles */,
+				BF_496327918804 /* NSString+Stripe.h in CopyFiles */,
+				BF_463357683021 /* NSURLComponents+Stripe.h in CopyFiles */,
+				BF_192470649449 /* NSURLComponents+Stripe.h in CopyFiles */,
+				BF_158017278741 /* PKPayment+Stripe.h in CopyFiles */,
+				BF_584113318929 /* PKPayment+Stripe.h in CopyFiles */,
+				BF_463191881014 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in CopyFiles */,
+				BF_717872951990 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in CopyFiles */,
+				BF_488527143184 /* STPAPIClient+ApplePay.h in CopyFiles */,
+				BF_194493693132 /* STPAPIClient+ApplePay.h in CopyFiles */,
+				BF_174244889509 /* STPAPIClient+Private.h in CopyFiles */,
+				BF_781128673283 /* STPAPIClient+Private.h in CopyFiles */,
+				BF_236310643340 /* STPAPIClient.h in CopyFiles */,
+				BF_612947230634 /* STPAPIClient.h in CopyFiles */,
+				BF_890245801013 /* STPAPIRequest.h in CopyFiles */,
+				BF_200762616227 /* STPAPIRequest.h in CopyFiles */,
+				BF_458560551921 /* STPAPIResponseDecodable.h in CopyFiles */,
+				BF_587241892406 /* STPAPIResponseDecodable.h in CopyFiles */,
+				BF_537907193664 /* STPAddCardViewController+Private.h in CopyFiles */,
+				BF_599487230604 /* STPAddCardViewController+Private.h in CopyFiles */,
+				BF_712036193580 /* STPAddCardViewController.h in CopyFiles */,
+				BF_985690579445 /* STPAddCardViewController.h in CopyFiles */,
+				BF_371070407565 /* STPAddress.h in CopyFiles */,
+				BF_718406769513 /* STPAddress.h in CopyFiles */,
+				BF_279850284898 /* STPAddressFieldTableViewCell.h in CopyFiles */,
+				BF_255666967363 /* STPAddressFieldTableViewCell.h in CopyFiles */,
+				BF_591354843568 /* STPAddressViewModel.h in CopyFiles */,
+				BF_867757176281 /* STPAddressViewModel.h in CopyFiles */,
+				BF_720601400496 /* STPAnalyticsClient.h in CopyFiles */,
+				BF_470288652110 /* STPAnalyticsClient.h in CopyFiles */,
+				BF_736236657369 /* STPApplePayPaymentMethod.h in CopyFiles */,
+				BF_377519697110 /* STPApplePayPaymentMethod.h in CopyFiles */,
+				BF_246151654463 /* STPAspects.h in CopyFiles */,
+				BF_752215109014 /* STPAspects.h in CopyFiles */,
+				BF_207703320722 /* STPBINRange.h in CopyFiles */,
+				BF_557021896850 /* STPBINRange.h in CopyFiles */,
+				BF_533019153936 /* STPBackendAPIAdapter.h in CopyFiles */,
+				BF_869499576351 /* STPBackendAPIAdapter.h in CopyFiles */,
+				BF_455037699108 /* STPBankAccount.h in CopyFiles */,
+				BF_332688033468 /* STPBankAccount.h in CopyFiles */,
+				BF_603955496550 /* STPBankAccountParams+Private.h in CopyFiles */,
+				BF_217425227990 /* STPBankAccountParams+Private.h in CopyFiles */,
+				BF_104922805231 /* STPBankAccountParams.h in CopyFiles */,
+				BF_848254338918 /* STPBankAccountParams.h in CopyFiles */,
+				BF_652165739522 /* STPBlocks.h in CopyFiles */,
+				BF_386629431164 /* STPBlocks.h in CopyFiles */,
+				BF_663116816096 /* STPBundleLocator.h in CopyFiles */,
+				BF_183934373416 /* STPBundleLocator.h in CopyFiles */,
+				BF_426499012757 /* STPCard+Private.h in CopyFiles */,
+				BF_429301656895 /* STPCard+Private.h in CopyFiles */,
+				BF_710345899699 /* STPCard.h in CopyFiles */,
+				BF_396132512980 /* STPCard.h in CopyFiles */,
+				BF_973399829844 /* STPCardBrand.h in CopyFiles */,
+				BF_307754168989 /* STPCardBrand.h in CopyFiles */,
+				BF_312874409667 /* STPCardIOProxy.h in CopyFiles */,
+				BF_497669979549 /* STPCardIOProxy.h in CopyFiles */,
+				BF_114085359031 /* STPCardParams.h in CopyFiles */,
+				BF_868495247631 /* STPCardParams.h in CopyFiles */,
+				BF_190125344918 /* STPCardValidationState.h in CopyFiles */,
+				BF_145804100375 /* STPCardValidationState.h in CopyFiles */,
+				BF_616460888190 /* STPCardValidator.h in CopyFiles */,
+				BF_144071511099 /* STPCardValidator.h in CopyFiles */,
+				BF_153172028372 /* STPCategoryLoader.h in CopyFiles */,
+				BF_770870274260 /* STPCategoryLoader.h in CopyFiles */,
+				BF_605002578850 /* STPColorUtils.h in CopyFiles */,
+				BF_817466125506 /* STPColorUtils.h in CopyFiles */,
+				BF_137228820791 /* STPConnectAccountParams.h in CopyFiles */,
+				BF_636460932467 /* STPConnectAccountParams.h in CopyFiles */,
+				BF_400290070131 /* STPCoreScrollViewController+Private.h in CopyFiles */,
+				BF_100603453597 /* STPCoreScrollViewController+Private.h in CopyFiles */,
+				BF_231739405054 /* STPCoreScrollViewController.h in CopyFiles */,
+				BF_215861264855 /* STPCoreScrollViewController.h in CopyFiles */,
+				BF_394612155069 /* STPCoreTableViewController+Private.h in CopyFiles */,
+				BF_210645786994 /* STPCoreTableViewController+Private.h in CopyFiles */,
+				BF_180979737359 /* STPCoreTableViewController.h in CopyFiles */,
+				BF_352193689126 /* STPCoreTableViewController.h in CopyFiles */,
+				BF_541984527700 /* STPCoreViewController+Private.h in CopyFiles */,
+				BF_724589153213 /* STPCoreViewController+Private.h in CopyFiles */,
+				BF_611959448208 /* STPCoreViewController.h in CopyFiles */,
+				BF_578906339526 /* STPCoreViewController.h in CopyFiles */,
+				BF_213494327648 /* STPCustomer+Private.h in CopyFiles */,
+				BF_683682685556 /* STPCustomer+Private.h in CopyFiles */,
+				BF_291205570528 /* STPCustomer+SourceTuple.h in CopyFiles */,
+				BF_524857575538 /* STPCustomer+SourceTuple.h in CopyFiles */,
+				BF_901142508449 /* STPCustomer.h in CopyFiles */,
+				BF_710323036496 /* STPCustomer.h in CopyFiles */,
+				BF_880616391997 /* STPCustomerContext.h in CopyFiles */,
+				BF_795903619981 /* STPCustomerContext.h in CopyFiles */,
+				BF_595803006362 /* STPDelegateProxy.h in CopyFiles */,
+				BF_165842399401 /* STPDelegateProxy.h in CopyFiles */,
+				BF_700714835948 /* STPDispatchFunctions.h in CopyFiles */,
+				BF_689014154181 /* STPDispatchFunctions.h in CopyFiles */,
+				BF_271795342133 /* STPEmailAddressValidator.h in CopyFiles */,
+				BF_852904719974 /* STPEmailAddressValidator.h in CopyFiles */,
+				BF_130098066142 /* STPEphemeralKey.h in CopyFiles */,
+				BF_243171785764 /* STPEphemeralKey.h in CopyFiles */,
+				BF_854114344938 /* STPEphemeralKeyManager.h in CopyFiles */,
+				BF_887507580698 /* STPEphemeralKeyManager.h in CopyFiles */,
+				BF_340933732939 /* STPEphemeralKeyProvider.h in CopyFiles */,
+				BF_887227005087 /* STPEphemeralKeyProvider.h in CopyFiles */,
+				BF_839205472018 /* STPFile+Private.h in CopyFiles */,
+				BF_137377739778 /* STPFile+Private.h in CopyFiles */,
+				BF_332524283285 /* STPFile.h in CopyFiles */,
+				BF_166860047134 /* STPFile.h in CopyFiles */,
+				BF_606909180832 /* STPFormEncodable.h in CopyFiles */,
+				BF_111108499174 /* STPFormEncodable.h in CopyFiles */,
+				BF_241035691797 /* STPFormEncoder.h in CopyFiles */,
+				BF_881197284158 /* STPFormEncoder.h in CopyFiles */,
+				BF_840158473028 /* STPFormTextField.h in CopyFiles */,
+				BF_197009564453 /* STPFormTextField.h in CopyFiles */,
+				BF_842059543370 /* STPImageLibrary+Private.h in CopyFiles */,
+				BF_229523316496 /* STPImageLibrary+Private.h in CopyFiles */,
+				BF_249856706881 /* STPImageLibrary.h in CopyFiles */,
+				BF_896149289071 /* STPImageLibrary.h in CopyFiles */,
+				BF_559718294321 /* STPInternalAPIResponseDecodable.h in CopyFiles */,
+				BF_550890492479 /* STPInternalAPIResponseDecodable.h in CopyFiles */,
+				BF_136155763923 /* STPLegalEntityParams.h in CopyFiles */,
+				BF_595507140671 /* STPLegalEntityParams.h in CopyFiles */,
+				BF_554008743498 /* STPLocalizationUtils.h in CopyFiles */,
+				BF_541423578972 /* STPLocalizationUtils.h in CopyFiles */,
+				BF_487984092344 /* STPMultipartFormDataEncoder.h in CopyFiles */,
+				BF_127014736755 /* STPMultipartFormDataEncoder.h in CopyFiles */,
+				BF_873250804444 /* STPMultipartFormDataPart.h in CopyFiles */,
+				BF_712363952044 /* STPMultipartFormDataPart.h in CopyFiles */,
+				BF_646731671250 /* STPPaymentActivityIndicatorView.h in CopyFiles */,
+				BF_707222492630 /* STPPaymentActivityIndicatorView.h in CopyFiles */,
+				BF_815609127357 /* STPPaymentCardTextField+Private.h in CopyFiles */,
+				BF_547493121527 /* STPPaymentCardTextField+Private.h in CopyFiles */,
+				BF_558954520920 /* STPPaymentCardTextField.h in CopyFiles */,
+				BF_664828362108 /* STPPaymentCardTextField.h in CopyFiles */,
+				BF_320315038553 /* STPPaymentCardTextFieldCell.h in CopyFiles */,
+				BF_781224844460 /* STPPaymentCardTextFieldCell.h in CopyFiles */,
+				BF_644346539646 /* STPPaymentCardTextFieldViewModel.h in CopyFiles */,
+				BF_445613793524 /* STPPaymentCardTextFieldViewModel.h in CopyFiles */,
+				BF_550314237865 /* STPPaymentConfiguration+Private.h in CopyFiles */,
+				BF_132160679787 /* STPPaymentConfiguration+Private.h in CopyFiles */,
+				BF_551983870758 /* STPPaymentConfiguration.h in CopyFiles */,
+				BF_349486581716 /* STPPaymentConfiguration.h in CopyFiles */,
+				BF_892747823754 /* STPPaymentContext+Private.h in CopyFiles */,
+				BF_246968793155 /* STPPaymentContext+Private.h in CopyFiles */,
+				BF_164445430449 /* STPPaymentContext.h in CopyFiles */,
+				BF_907762169657 /* STPPaymentContext.h in CopyFiles */,
+				BF_526963054110 /* STPPaymentContextAmountModel.h in CopyFiles */,
+				BF_102169882211 /* STPPaymentContextAmountModel.h in CopyFiles */,
+				BF_725700492600 /* STPPaymentMethod.h in CopyFiles */,
+				BF_233235282272 /* STPPaymentMethod.h in CopyFiles */,
+				BF_580063542734 /* STPPaymentMethodTableViewCell.h in CopyFiles */,
+				BF_223123858378 /* STPPaymentMethodTableViewCell.h in CopyFiles */,
+				BF_601455989561 /* STPPaymentMethodTuple.h in CopyFiles */,
+				BF_846667158072 /* STPPaymentMethodTuple.h in CopyFiles */,
+				BF_333086167823 /* STPPaymentMethodsInternalViewController.h in CopyFiles */,
+				BF_439874366934 /* STPPaymentMethodsInternalViewController.h in CopyFiles */,
+				BF_648562762332 /* STPPaymentMethodsViewController+Private.h in CopyFiles */,
+				BF_821768833841 /* STPPaymentMethodsViewController+Private.h in CopyFiles */,
+				BF_874479752220 /* STPPaymentMethodsViewController.h in CopyFiles */,
+				BF_961509480863 /* STPPaymentMethodsViewController.h in CopyFiles */,
+				BF_175137485039 /* STPPaymentResult.h in CopyFiles */,
+				BF_174348858309 /* STPPaymentResult.h in CopyFiles */,
+				BF_656814611262 /* STPPhoneNumberValidator.h in CopyFiles */,
+				BF_665107086376 /* STPPhoneNumberValidator.h in CopyFiles */,
+				BF_357323148348 /* STPPostalCodeValidator.h in CopyFiles */,
+				BF_526770364330 /* STPPostalCodeValidator.h in CopyFiles */,
+				BF_762079931330 /* STPPromise.h in CopyFiles */,
+				BF_720283447267 /* STPPromise.h in CopyFiles */,
+				BF_921252546392 /* STPRedirectContext.h in CopyFiles */,
+				BF_133395627932 /* STPRedirectContext.h in CopyFiles */,
+				BF_144351754131 /* STPSectionHeaderView.h in CopyFiles */,
+				BF_632696438025 /* STPSectionHeaderView.h in CopyFiles */,
+				BF_523854442262 /* STPShippingAddressViewController.h in CopyFiles */,
+				BF_156073223996 /* STPShippingAddressViewController.h in CopyFiles */,
+				BF_726160460471 /* STPShippingMethodTableViewCell.h in CopyFiles */,
+				BF_456907750469 /* STPShippingMethodTableViewCell.h in CopyFiles */,
+				BF_185796462300 /* STPShippingMethodsViewController.h in CopyFiles */,
+				BF_634068117988 /* STPShippingMethodsViewController.h in CopyFiles */,
+				BF_284630288850 /* STPSource+Private.h in CopyFiles */,
+				BF_533139797846 /* STPSource+Private.h in CopyFiles */,
+				BF_583334210316 /* STPSource.h in CopyFiles */,
+				BF_576791073433 /* STPSource.h in CopyFiles */,
+				BF_324442077506 /* STPSourceCardDetails+Private.h in CopyFiles */,
+				BF_556472663789 /* STPSourceCardDetails+Private.h in CopyFiles */,
+				BF_103914288281 /* STPSourceCardDetails.h in CopyFiles */,
+				BF_259137754468 /* STPSourceCardDetails.h in CopyFiles */,
+				BF_319135685673 /* STPSourceEnums.h in CopyFiles */,
+				BF_537015205276 /* STPSourceEnums.h in CopyFiles */,
+				BF_387516634905 /* STPSourceOwner.h in CopyFiles */,
+				BF_327076790512 /* STPSourceOwner.h in CopyFiles */,
+				BF_158442569045 /* STPSourceParams+Private.h in CopyFiles */,
+				BF_329201445433 /* STPSourceParams+Private.h in CopyFiles */,
+				BF_117584520624 /* STPSourceParams.h in CopyFiles */,
+				BF_419385641509 /* STPSourceParams.h in CopyFiles */,
+				BF_877675794012 /* STPSourcePoller.h in CopyFiles */,
+				BF_207911305607 /* STPSourcePoller.h in CopyFiles */,
+				BF_869420912167 /* STPSourceProtocol.h in CopyFiles */,
+				BF_670611076258 /* STPSourceProtocol.h in CopyFiles */,
+				BF_821964836057 /* STPSourceReceiver.h in CopyFiles */,
+				BF_241021670094 /* STPSourceReceiver.h in CopyFiles */,
+				BF_841232890610 /* STPSourceRedirect+Private.h in CopyFiles */,
+				BF_752750884043 /* STPSourceRedirect+Private.h in CopyFiles */,
+				BF_899109362603 /* STPSourceRedirect.h in CopyFiles */,
+				BF_201977440511 /* STPSourceRedirect.h in CopyFiles */,
+				BF_880548692885 /* STPSourceSEPADebitDetails.h in CopyFiles */,
+				BF_867265947213 /* STPSourceSEPADebitDetails.h in CopyFiles */,
+				BF_379564040014 /* STPSourceVerification+Private.h in CopyFiles */,
+				BF_483363410580 /* STPSourceVerification+Private.h in CopyFiles */,
+				BF_853024008497 /* STPSourceVerification.h in CopyFiles */,
+				BF_824955833590 /* STPSourceVerification.h in CopyFiles */,
+				BF_711203980455 /* STPStringUtils.h in CopyFiles */,
+				BF_321275598237 /* STPStringUtils.h in CopyFiles */,
+				BF_832988560206 /* STPSwitchTableViewCell.h in CopyFiles */,
+				BF_574479621621 /* STPSwitchTableViewCell.h in CopyFiles */,
+				BF_199378233254 /* STPTelemetryClient.h in CopyFiles */,
+				BF_138472644633 /* STPTelemetryClient.h in CopyFiles */,
+				BF_166990927798 /* STPTheme.h in CopyFiles */,
+				BF_748382559973 /* STPTheme.h in CopyFiles */,
+				BF_746399658810 /* STPToken.h in CopyFiles */,
+				BF_683203182624 /* STPToken.h in CopyFiles */,
+				BF_338270222352 /* STPURLCallbackHandler.h in CopyFiles */,
+				BF_353638367833 /* STPURLCallbackHandler.h in CopyFiles */,
+				BF_278333102912 /* STPUserInformation.h in CopyFiles */,
+				BF_468271912137 /* STPUserInformation.h in CopyFiles */,
+				BF_476701351716 /* STPValidatedTextField.h in CopyFiles */,
+				BF_217248561129 /* STPValidatedTextField.h in CopyFiles */,
+				BF_227693182834 /* STPWeakStrongMacros.h in CopyFiles */,
+				BF_450073368424 /* STPWeakStrongMacros.h in CopyFiles */,
+				BF_310549301087 /* Stripe.h in CopyFiles */,
+				BF_334152094445 /* Stripe.h in CopyFiles */,
+				BF_176578096799 /* StripeError.h in CopyFiles */,
+				BF_346272866687 /* StripeError.h in CopyFiles */,
+				BF_811394832804 /* UIBarButtonItem+Stripe.h in CopyFiles */,
+				BF_186075171313 /* UIBarButtonItem+Stripe.h in CopyFiles */,
+				BF_569899831647 /* UIImage+Stripe.h in CopyFiles */,
+				BF_602281982503 /* UIImage+Stripe.h in CopyFiles */,
+				BF_331504465853 /* UINavigationBar+Stripe_Theme.h in CopyFiles */,
+				BF_697575071468 /* UINavigationBar+Stripe_Theme.h in CopyFiles */,
+				BF_304341542293 /* UINavigationController+Stripe_Completion.h in CopyFiles */,
+				BF_732196886655 /* UINavigationController+Stripe_Completion.h in CopyFiles */,
+				BF_443954776903 /* UITableViewCell+Stripe_Borders.h in CopyFiles */,
+				BF_479143927617 /* UITableViewCell+Stripe_Borders.h in CopyFiles */,
+				BF_554251084243 /* UIToolbar+Stripe_InputAccessory.h in CopyFiles */,
+				BF_865423218224 /* UIToolbar+Stripe_InputAccessory.h in CopyFiles */,
+				BF_780445515388 /* UIView+Stripe_FirstResponder.h in CopyFiles */,
+				BF_200106439412 /* UIView+Stripe_FirstResponder.h in CopyFiles */,
+				BF_902313281118 /* UIView+Stripe_SafeAreaBounds.h in CopyFiles */,
+				BF_795733996006 /* UIView+Stripe_SafeAreaBounds.h in CopyFiles */,
+				BF_522195337332 /* UIViewController+Stripe_KeyboardAvoiding.h in CopyFiles */,
+				BF_384316649234 /* UIViewController+Stripe_KeyboardAvoiding.h in CopyFiles */,
+				BF_432714044264 /* UIViewController+Stripe_NavigationItemProxy.h in CopyFiles */,
+				BF_275773117433 /* UIViewController+Stripe_NavigationItemProxy.h in CopyFiles */,
+				BF_394931725478 /* UIViewController+Stripe_ParentViewController.h in CopyFiles */,
+				BF_190332253133 /* UIViewController+Stripe_ParentViewController.h in CopyFiles */,
+				BF_539811780662 /* UIViewController+Stripe_Promises.h in CopyFiles */,
+				BF_384805256193 /* UIViewController+Stripe_Promises.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_2000350847 /* Embed App Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				BF_389902562892 /* share-extension.appex in CopyFiles */,
-				BF_803562003601 /* siri-extension.appex in CopyFiles */,
-				BF_309045885116 /* strings-extension.appex in CopyFiles */,
+				BF_797161458492 /* strings-extension.appex in Embed App Extensions */,
+				BF_198878007932 /* siri-extension.appex in Embed App Extensions */,
+				BF_336991966280 /* share-extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_2043682735 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_142092478818 /* PINCache.h in CopyFiles */,
+				BF_601788139586 /* PINCache.h in CopyFiles */,
+				BF_325133916291 /* PINCacheMacros.h in CopyFiles */,
+				BF_106827386674 /* PINCacheMacros.h in CopyFiles */,
+				BF_548176440234 /* PINCacheObjectSubscripting.h in CopyFiles */,
+				BF_316400397438 /* PINCacheObjectSubscripting.h in CopyFiles */,
+				BF_436684481566 /* PINCaching.h in CopyFiles */,
+				BF_377176486795 /* PINCaching.h in CopyFiles */,
+				BF_875554489720 /* PINDiskCache.h in CopyFiles */,
+				BF_213327728178 /* PINDiskCache.h in CopyFiles */,
+				BF_150275074078 /* PINMemoryCache.h in CopyFiles */,
+				BF_239251576981 /* PINMemoryCache.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_3307452246 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_874960947885 /* PINOperation.h in CopyFiles */,
+				BF_379596458405 /* PINOperation.h in CopyFiles */,
+				BF_579970270682 /* PINOperationGroup.h in CopyFiles */,
+				BF_550263340238 /* PINOperationGroup.h in CopyFiles */,
+				BF_806327248992 /* PINOperationMacros.h in CopyFiles */,
+				BF_750512776469 /* PINOperationMacros.h in CopyFiles */,
+				BF_223700651165 /* PINOperationQueue.h in CopyFiles */,
+				BF_793949375173 /* PINOperationQueue.h in CopyFiles */,
+				BF_359639414693 /* PINOperationTypes.h in CopyFiles */,
+				BF_595198601241 /* PINOperationTypes.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_3440035043 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_340528636515 /* HeaderLib.hpp in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_3613973714 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_736370347193 /* PINCache.h in CopyFiles */,
+				BF_690686155656 /* PINCache.h in CopyFiles */,
+				BF_235752708584 /* PINCacheMacros.h in CopyFiles */,
+				BF_874646431482 /* PINCacheMacros.h in CopyFiles */,
+				BF_500902037116 /* PINCacheObjectSubscripting.h in CopyFiles */,
+				BF_589188210696 /* PINCacheObjectSubscripting.h in CopyFiles */,
+				BF_387460061294 /* PINCaching.h in CopyFiles */,
+				BF_353203537674 /* PINCaching.h in CopyFiles */,
+				BF_485760438581 /* PINDiskCache.h in CopyFiles */,
+				BF_550459375374 /* PINDiskCache.h in CopyFiles */,
+				BF_666439790854 /* PINMemoryCache.h in CopyFiles */,
+				BF_135641607626 /* PINMemoryCache.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_3825973267 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_769390461961 /* FABKitProtocol.h in CopyFiles */,
+				BF_629941936974 /* FABKitProtocol.h in CopyFiles */,
+				BF_100146255098 /* Fabric+FABKits.h in CopyFiles */,
+				BF_892735993335 /* Fabric+FABKits.h in CopyFiles */,
+				BF_556483001857 /* Fabric.h in CopyFiles */,
+				BF_286736495414 /* Fabric.h in CopyFiles */,
+				BF_399349584461 /* FauxPasAnnotations.h in CopyFiles */,
+				BF_344141107682 /* FauxPasAnnotations.h in CopyFiles */,
+				BF_683530227445 /* NSArray+Stripe.h in CopyFiles */,
+				BF_565384582904 /* NSArray+Stripe.h in CopyFiles */,
+				BF_447256914684 /* NSBundle+Stripe_AppName.h in CopyFiles */,
+				BF_756694657825 /* NSBundle+Stripe_AppName.h in CopyFiles */,
+				BF_727077927178 /* NSCharacterSet+Stripe.h in CopyFiles */,
+				BF_564483627286 /* NSCharacterSet+Stripe.h in CopyFiles */,
+				BF_504906925819 /* NSDecimalNumber+Stripe_Currency.h in CopyFiles */,
+				BF_840224660358 /* NSDecimalNumber+Stripe_Currency.h in CopyFiles */,
+				BF_107059998957 /* NSDictionary+Stripe.h in CopyFiles */,
+				BF_669332903893 /* NSDictionary+Stripe.h in CopyFiles */,
+				BF_846560459294 /* NSError+Stripe.h in CopyFiles */,
+				BF_633638727304 /* NSError+Stripe.h in CopyFiles */,
+				BF_196387551046 /* NSMutableURLRequest+Stripe.h in CopyFiles */,
+				BF_233165390610 /* NSMutableURLRequest+Stripe.h in CopyFiles */,
+				BF_148824861067 /* NSString+Stripe.h in CopyFiles */,
+				BF_637475383201 /* NSString+Stripe.h in CopyFiles */,
+				BF_805740141929 /* NSURLComponents+Stripe.h in CopyFiles */,
+				BF_504610670413 /* NSURLComponents+Stripe.h in CopyFiles */,
+				BF_621297371033 /* PKPayment+Stripe.h in CopyFiles */,
+				BF_554214730689 /* PKPayment+Stripe.h in CopyFiles */,
+				BF_864601913654 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in CopyFiles */,
+				BF_186704525098 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h in CopyFiles */,
+				BF_550612809375 /* STPAPIClient+ApplePay.h in CopyFiles */,
+				BF_773012804294 /* STPAPIClient+ApplePay.h in CopyFiles */,
+				BF_123137700688 /* STPAPIClient+Private.h in CopyFiles */,
+				BF_370084113100 /* STPAPIClient+Private.h in CopyFiles */,
+				BF_534133201948 /* STPAPIClient.h in CopyFiles */,
+				BF_287688546313 /* STPAPIClient.h in CopyFiles */,
+				BF_329509230679 /* STPAPIRequest.h in CopyFiles */,
+				BF_549225706027 /* STPAPIRequest.h in CopyFiles */,
+				BF_557434726307 /* STPAPIResponseDecodable.h in CopyFiles */,
+				BF_324947308668 /* STPAPIResponseDecodable.h in CopyFiles */,
+				BF_656310590468 /* STPAddCardViewController+Private.h in CopyFiles */,
+				BF_942912852986 /* STPAddCardViewController+Private.h in CopyFiles */,
+				BF_677261258913 /* STPAddCardViewController.h in CopyFiles */,
+				BF_580588333688 /* STPAddCardViewController.h in CopyFiles */,
+				BF_845198702840 /* STPAddress.h in CopyFiles */,
+				BF_570983647477 /* STPAddress.h in CopyFiles */,
+				BF_227467098705 /* STPAddressFieldTableViewCell.h in CopyFiles */,
+				BF_348272881363 /* STPAddressFieldTableViewCell.h in CopyFiles */,
+				BF_617648187444 /* STPAddressViewModel.h in CopyFiles */,
+				BF_391460386182 /* STPAddressViewModel.h in CopyFiles */,
+				BF_502665421922 /* STPAnalyticsClient.h in CopyFiles */,
+				BF_253963778803 /* STPAnalyticsClient.h in CopyFiles */,
+				BF_615736622874 /* STPApplePayPaymentMethod.h in CopyFiles */,
+				BF_349909356229 /* STPApplePayPaymentMethod.h in CopyFiles */,
+				BF_345971164535 /* STPAspects.h in CopyFiles */,
+				BF_400807889795 /* STPAspects.h in CopyFiles */,
+				BF_753390046774 /* STPBINRange.h in CopyFiles */,
+				BF_888519593251 /* STPBINRange.h in CopyFiles */,
+				BF_441143570909 /* STPBackendAPIAdapter.h in CopyFiles */,
+				BF_872087434557 /* STPBackendAPIAdapter.h in CopyFiles */,
+				BF_462583713399 /* STPBankAccount.h in CopyFiles */,
+				BF_471993719881 /* STPBankAccount.h in CopyFiles */,
+				BF_677745771921 /* STPBankAccountParams+Private.h in CopyFiles */,
+				BF_911112024558 /* STPBankAccountParams+Private.h in CopyFiles */,
+				BF_108843500906 /* STPBankAccountParams.h in CopyFiles */,
+				BF_670172723121 /* STPBankAccountParams.h in CopyFiles */,
+				BF_439404861791 /* STPBlocks.h in CopyFiles */,
+				BF_243777181681 /* STPBlocks.h in CopyFiles */,
+				BF_633410647955 /* STPBundleLocator.h in CopyFiles */,
+				BF_301160263931 /* STPBundleLocator.h in CopyFiles */,
+				BF_657262140631 /* STPCard+Private.h in CopyFiles */,
+				BF_744717184211 /* STPCard+Private.h in CopyFiles */,
+				BF_447117284785 /* STPCard.h in CopyFiles */,
+				BF_598961581630 /* STPCard.h in CopyFiles */,
+				BF_348553538684 /* STPCardBrand.h in CopyFiles */,
+				BF_808784190597 /* STPCardBrand.h in CopyFiles */,
+				BF_547467272222 /* STPCardIOProxy.h in CopyFiles */,
+				BF_548404306289 /* STPCardIOProxy.h in CopyFiles */,
+				BF_906674504504 /* STPCardParams.h in CopyFiles */,
+				BF_528256391815 /* STPCardParams.h in CopyFiles */,
+				BF_677400779752 /* STPCardValidationState.h in CopyFiles */,
+				BF_553283229840 /* STPCardValidationState.h in CopyFiles */,
+				BF_348910236732 /* STPCardValidator.h in CopyFiles */,
+				BF_698473776974 /* STPCardValidator.h in CopyFiles */,
+				BF_322336096484 /* STPCategoryLoader.h in CopyFiles */,
+				BF_607164502273 /* STPCategoryLoader.h in CopyFiles */,
+				BF_607070386912 /* STPColorUtils.h in CopyFiles */,
+				BF_441130999656 /* STPColorUtils.h in CopyFiles */,
+				BF_319427141132 /* STPConnectAccountParams.h in CopyFiles */,
+				BF_422344483627 /* STPConnectAccountParams.h in CopyFiles */,
+				BF_850232326309 /* STPCoreScrollViewController+Private.h in CopyFiles */,
+				BF_611229103734 /* STPCoreScrollViewController+Private.h in CopyFiles */,
+				BF_417261323696 /* STPCoreScrollViewController.h in CopyFiles */,
+				BF_123790181276 /* STPCoreScrollViewController.h in CopyFiles */,
+				BF_441239768776 /* STPCoreTableViewController+Private.h in CopyFiles */,
+				BF_409598630067 /* STPCoreTableViewController+Private.h in CopyFiles */,
+				BF_244856205536 /* STPCoreTableViewController.h in CopyFiles */,
+				BF_547903250638 /* STPCoreTableViewController.h in CopyFiles */,
+				BF_256602909817 /* STPCoreViewController+Private.h in CopyFiles */,
+				BF_474960562947 /* STPCoreViewController+Private.h in CopyFiles */,
+				BF_370616232422 /* STPCoreViewController.h in CopyFiles */,
+				BF_696851575369 /* STPCoreViewController.h in CopyFiles */,
+				BF_573040290455 /* STPCustomer+Private.h in CopyFiles */,
+				BF_778216471773 /* STPCustomer+Private.h in CopyFiles */,
+				BF_257558791404 /* STPCustomer+SourceTuple.h in CopyFiles */,
+				BF_273428119225 /* STPCustomer+SourceTuple.h in CopyFiles */,
+				BF_912355922148 /* STPCustomer.h in CopyFiles */,
+				BF_706090347626 /* STPCustomer.h in CopyFiles */,
+				BF_834104184485 /* STPCustomerContext.h in CopyFiles */,
+				BF_823227850974 /* STPCustomerContext.h in CopyFiles */,
+				BF_511203901761 /* STPDelegateProxy.h in CopyFiles */,
+				BF_633128707324 /* STPDelegateProxy.h in CopyFiles */,
+				BF_234524631364 /* STPDispatchFunctions.h in CopyFiles */,
+				BF_232886281401 /* STPDispatchFunctions.h in CopyFiles */,
+				BF_446933985080 /* STPEmailAddressValidator.h in CopyFiles */,
+				BF_469824851714 /* STPEmailAddressValidator.h in CopyFiles */,
+				BF_872007431300 /* STPEphemeralKey.h in CopyFiles */,
+				BF_803011142765 /* STPEphemeralKey.h in CopyFiles */,
+				BF_427057640073 /* STPEphemeralKeyManager.h in CopyFiles */,
+				BF_596643458939 /* STPEphemeralKeyManager.h in CopyFiles */,
+				BF_663796921581 /* STPEphemeralKeyProvider.h in CopyFiles */,
+				BF_667707193631 /* STPEphemeralKeyProvider.h in CopyFiles */,
+				BF_854297538363 /* STPFile+Private.h in CopyFiles */,
+				BF_253368692998 /* STPFile+Private.h in CopyFiles */,
+				BF_859620595924 /* STPFile.h in CopyFiles */,
+				BF_301542515092 /* STPFile.h in CopyFiles */,
+				BF_451005353506 /* STPFormEncodable.h in CopyFiles */,
+				BF_426709595180 /* STPFormEncodable.h in CopyFiles */,
+				BF_220632397395 /* STPFormEncoder.h in CopyFiles */,
+				BF_818300223791 /* STPFormEncoder.h in CopyFiles */,
+				BF_853979415908 /* STPFormTextField.h in CopyFiles */,
+				BF_794987405795 /* STPFormTextField.h in CopyFiles */,
+				BF_474599747974 /* STPImageLibrary+Private.h in CopyFiles */,
+				BF_280938055037 /* STPImageLibrary+Private.h in CopyFiles */,
+				BF_656913513255 /* STPImageLibrary.h in CopyFiles */,
+				BF_906973596745 /* STPImageLibrary.h in CopyFiles */,
+				BF_238336665490 /* STPInternalAPIResponseDecodable.h in CopyFiles */,
+				BF_484127874607 /* STPInternalAPIResponseDecodable.h in CopyFiles */,
+				BF_636871656877 /* STPLegalEntityParams.h in CopyFiles */,
+				BF_900889973275 /* STPLegalEntityParams.h in CopyFiles */,
+				BF_692824832486 /* STPLocalizationUtils.h in CopyFiles */,
+				BF_419236608986 /* STPLocalizationUtils.h in CopyFiles */,
+				BF_552934083707 /* STPMultipartFormDataEncoder.h in CopyFiles */,
+				BF_614327253500 /* STPMultipartFormDataEncoder.h in CopyFiles */,
+				BF_196835437059 /* STPMultipartFormDataPart.h in CopyFiles */,
+				BF_313673711928 /* STPMultipartFormDataPart.h in CopyFiles */,
+				BF_202768383446 /* STPPaymentActivityIndicatorView.h in CopyFiles */,
+				BF_663686741949 /* STPPaymentActivityIndicatorView.h in CopyFiles */,
+				BF_442937624512 /* STPPaymentCardTextField+Private.h in CopyFiles */,
+				BF_818394404850 /* STPPaymentCardTextField+Private.h in CopyFiles */,
+				BF_585028702972 /* STPPaymentCardTextField.h in CopyFiles */,
+				BF_286835721677 /* STPPaymentCardTextField.h in CopyFiles */,
+				BF_570611123316 /* STPPaymentCardTextFieldCell.h in CopyFiles */,
+				BF_274107263036 /* STPPaymentCardTextFieldCell.h in CopyFiles */,
+				BF_210015723451 /* STPPaymentCardTextFieldViewModel.h in CopyFiles */,
+				BF_536300143534 /* STPPaymentCardTextFieldViewModel.h in CopyFiles */,
+				BF_683052243089 /* STPPaymentConfiguration+Private.h in CopyFiles */,
+				BF_564986401887 /* STPPaymentConfiguration+Private.h in CopyFiles */,
+				BF_477766101315 /* STPPaymentConfiguration.h in CopyFiles */,
+				BF_705261524169 /* STPPaymentConfiguration.h in CopyFiles */,
+				BF_332563396093 /* STPPaymentContext+Private.h in CopyFiles */,
+				BF_557718603905 /* STPPaymentContext+Private.h in CopyFiles */,
+				BF_674231239736 /* STPPaymentContext.h in CopyFiles */,
+				BF_301587847104 /* STPPaymentContext.h in CopyFiles */,
+				BF_845184473776 /* STPPaymentContextAmountModel.h in CopyFiles */,
+				BF_542733884215 /* STPPaymentContextAmountModel.h in CopyFiles */,
+				BF_885826923241 /* STPPaymentMethod.h in CopyFiles */,
+				BF_419437199489 /* STPPaymentMethod.h in CopyFiles */,
+				BF_377635648661 /* STPPaymentMethodTableViewCell.h in CopyFiles */,
+				BF_198210767515 /* STPPaymentMethodTableViewCell.h in CopyFiles */,
+				BF_286432145384 /* STPPaymentMethodTuple.h in CopyFiles */,
+				BF_110567999400 /* STPPaymentMethodTuple.h in CopyFiles */,
+				BF_285352739005 /* STPPaymentMethodsInternalViewController.h in CopyFiles */,
+				BF_499388278079 /* STPPaymentMethodsInternalViewController.h in CopyFiles */,
+				BF_872593558093 /* STPPaymentMethodsViewController+Private.h in CopyFiles */,
+				BF_815107472923 /* STPPaymentMethodsViewController+Private.h in CopyFiles */,
+				BF_880637916596 /* STPPaymentMethodsViewController.h in CopyFiles */,
+				BF_349542215895 /* STPPaymentMethodsViewController.h in CopyFiles */,
+				BF_800824306451 /* STPPaymentResult.h in CopyFiles */,
+				BF_681407398214 /* STPPaymentResult.h in CopyFiles */,
+				BF_802212837063 /* STPPhoneNumberValidator.h in CopyFiles */,
+				BF_390127553943 /* STPPhoneNumberValidator.h in CopyFiles */,
+				BF_746714470153 /* STPPostalCodeValidator.h in CopyFiles */,
+				BF_828073877901 /* STPPostalCodeValidator.h in CopyFiles */,
+				BF_171809984581 /* STPPromise.h in CopyFiles */,
+				BF_192939647191 /* STPPromise.h in CopyFiles */,
+				BF_272070534199 /* STPRedirectContext.h in CopyFiles */,
+				BF_440925310579 /* STPRedirectContext.h in CopyFiles */,
+				BF_676957737800 /* STPSectionHeaderView.h in CopyFiles */,
+				BF_758774651870 /* STPSectionHeaderView.h in CopyFiles */,
+				BF_845841139589 /* STPShippingAddressViewController.h in CopyFiles */,
+				BF_280516295555 /* STPShippingAddressViewController.h in CopyFiles */,
+				BF_708687516173 /* STPShippingMethodTableViewCell.h in CopyFiles */,
+				BF_308592078285 /* STPShippingMethodTableViewCell.h in CopyFiles */,
+				BF_586866993565 /* STPShippingMethodsViewController.h in CopyFiles */,
+				BF_120847667496 /* STPShippingMethodsViewController.h in CopyFiles */,
+				BF_365335193276 /* STPSource+Private.h in CopyFiles */,
+				BF_445930735906 /* STPSource+Private.h in CopyFiles */,
+				BF_101230637733 /* STPSource.h in CopyFiles */,
+				BF_133887420812 /* STPSource.h in CopyFiles */,
+				BF_377871186748 /* STPSourceCardDetails+Private.h in CopyFiles */,
+				BF_857638390821 /* STPSourceCardDetails+Private.h in CopyFiles */,
+				BF_271492252716 /* STPSourceCardDetails.h in CopyFiles */,
+				BF_590301139518 /* STPSourceCardDetails.h in CopyFiles */,
+				BF_879139214009 /* STPSourceEnums.h in CopyFiles */,
+				BF_588930220508 /* STPSourceEnums.h in CopyFiles */,
+				BF_439411478194 /* STPSourceOwner.h in CopyFiles */,
+				BF_903795981010 /* STPSourceOwner.h in CopyFiles */,
+				BF_104714549948 /* STPSourceParams+Private.h in CopyFiles */,
+				BF_271887872074 /* STPSourceParams+Private.h in CopyFiles */,
+				BF_219567242214 /* STPSourceParams.h in CopyFiles */,
+				BF_536656955521 /* STPSourceParams.h in CopyFiles */,
+				BF_332058350591 /* STPSourcePoller.h in CopyFiles */,
+				BF_728133248104 /* STPSourcePoller.h in CopyFiles */,
+				BF_381600174431 /* STPSourceProtocol.h in CopyFiles */,
+				BF_148892726201 /* STPSourceProtocol.h in CopyFiles */,
+				BF_688548530308 /* STPSourceReceiver.h in CopyFiles */,
+				BF_415270383479 /* STPSourceReceiver.h in CopyFiles */,
+				BF_225737491335 /* STPSourceRedirect+Private.h in CopyFiles */,
+				BF_656381699164 /* STPSourceRedirect+Private.h in CopyFiles */,
+				BF_639049821515 /* STPSourceRedirect.h in CopyFiles */,
+				BF_203808042422 /* STPSourceRedirect.h in CopyFiles */,
+				BF_583670923783 /* STPSourceSEPADebitDetails.h in CopyFiles */,
+				BF_715931941628 /* STPSourceSEPADebitDetails.h in CopyFiles */,
+				BF_408465547746 /* STPSourceVerification+Private.h in CopyFiles */,
+				BF_143196074828 /* STPSourceVerification+Private.h in CopyFiles */,
+				BF_484323380262 /* STPSourceVerification.h in CopyFiles */,
+				BF_862208142468 /* STPSourceVerification.h in CopyFiles */,
+				BF_894870115046 /* STPStringUtils.h in CopyFiles */,
+				BF_483120801550 /* STPStringUtils.h in CopyFiles */,
+				BF_579705915869 /* STPSwitchTableViewCell.h in CopyFiles */,
+				BF_234221106414 /* STPSwitchTableViewCell.h in CopyFiles */,
+				BF_893153948993 /* STPTelemetryClient.h in CopyFiles */,
+				BF_230146524333 /* STPTelemetryClient.h in CopyFiles */,
+				BF_340560239601 /* STPTheme.h in CopyFiles */,
+				BF_872525723563 /* STPTheme.h in CopyFiles */,
+				BF_347272708167 /* STPToken.h in CopyFiles */,
+				BF_124956471100 /* STPToken.h in CopyFiles */,
+				BF_858175137351 /* STPURLCallbackHandler.h in CopyFiles */,
+				BF_746330347275 /* STPURLCallbackHandler.h in CopyFiles */,
+				BF_132059510992 /* STPUserInformation.h in CopyFiles */,
+				BF_334327636283 /* STPUserInformation.h in CopyFiles */,
+				BF_630704383611 /* STPValidatedTextField.h in CopyFiles */,
+				BF_362145821284 /* STPValidatedTextField.h in CopyFiles */,
+				BF_425025203089 /* STPWeakStrongMacros.h in CopyFiles */,
+				BF_209206423450 /* STPWeakStrongMacros.h in CopyFiles */,
+				BF_231653111479 /* Stripe.h in CopyFiles */,
+				BF_381194798012 /* Stripe.h in CopyFiles */,
+				BF_225363930007 /* StripeError.h in CopyFiles */,
+				BF_310201476180 /* StripeError.h in CopyFiles */,
+				BF_454309773871 /* UIBarButtonItem+Stripe.h in CopyFiles */,
+				BF_259187615236 /* UIBarButtonItem+Stripe.h in CopyFiles */,
+				BF_310644130665 /* UIImage+Stripe.h in CopyFiles */,
+				BF_390732101066 /* UIImage+Stripe.h in CopyFiles */,
+				BF_812087440491 /* UINavigationBar+Stripe_Theme.h in CopyFiles */,
+				BF_274055105852 /* UINavigationBar+Stripe_Theme.h in CopyFiles */,
+				BF_413008443157 /* UINavigationController+Stripe_Completion.h in CopyFiles */,
+				BF_893378746244 /* UINavigationController+Stripe_Completion.h in CopyFiles */,
+				BF_616983081347 /* UITableViewCell+Stripe_Borders.h in CopyFiles */,
+				BF_352077015212 /* UITableViewCell+Stripe_Borders.h in CopyFiles */,
+				BF_660181566425 /* UIToolbar+Stripe_InputAccessory.h in CopyFiles */,
+				BF_296366995311 /* UIToolbar+Stripe_InputAccessory.h in CopyFiles */,
+				BF_554873144876 /* UIView+Stripe_FirstResponder.h in CopyFiles */,
+				BF_813765486872 /* UIView+Stripe_FirstResponder.h in CopyFiles */,
+				BF_631160075017 /* UIView+Stripe_SafeAreaBounds.h in CopyFiles */,
+				BF_824099007553 /* UIView+Stripe_SafeAreaBounds.h in CopyFiles */,
+				BF_807296877452 /* UIViewController+Stripe_KeyboardAvoiding.h in CopyFiles */,
+				BF_233631577233 /* UIViewController+Stripe_KeyboardAvoiding.h in CopyFiles */,
+				BF_678696729482 /* UIViewController+Stripe_NavigationItemProxy.h in CopyFiles */,
+				BF_138908459130 /* UIViewController+Stripe_NavigationItemProxy.h in CopyFiles */,
+				BF_565451141735 /* UIViewController+Stripe_ParentViewController.h in CopyFiles */,
+				BF_859335257745 /* UIViewController+Stripe_ParentViewController.h in CopyFiles */,
+				BF_319684961598 /* UIViewController+Stripe_Promises.h in CopyFiles */,
+				BF_297095191265 /* UIViewController+Stripe_Promises.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_4459384815 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_268374256153 /* AppJerry.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_4550878434 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_791606347633 /* PINOperation.h in CopyFiles */,
+				BF_157760965950 /* PINOperation.h in CopyFiles */,
+				BF_150553243167 /* PINOperationGroup.h in CopyFiles */,
+				BF_240712445821 /* PINOperationGroup.h in CopyFiles */,
+				BF_226783325786 /* PINOperationMacros.h in CopyFiles */,
+				BF_538525263717 /* PINOperationMacros.h in CopyFiles */,
+				BF_805591497955 /* PINOperationQueue.h in CopyFiles */,
+				BF_590596019249 /* PINOperationQueue.h in CopyFiles */,
+				BF_724008586335 /* PINOperationTypes.h in CopyFiles */,
+				BF_518725300039 /* PINOperationTypes.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_5088663457 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_206231436836 /* HeaderLib.hpp in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_6605403167 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_730550012423 /* PINCache.h in CopyFiles */,
+				BF_209931254852 /* PINCache.h in CopyFiles */,
+				BF_353232387432 /* PINCacheMacros.h in CopyFiles */,
+				BF_559862217917 /* PINCacheMacros.h in CopyFiles */,
+				BF_824224080322 /* PINCacheObjectSubscripting.h in CopyFiles */,
+				BF_202675181349 /* PINCacheObjectSubscripting.h in CopyFiles */,
+				BF_482937980884 /* PINCaching.h in CopyFiles */,
+				BF_738675055335 /* PINCaching.h in CopyFiles */,
+				BF_393344152740 /* PINDiskCache.h in CopyFiles */,
+				BF_398559820423 /* PINDiskCache.h in CopyFiles */,
+				BF_400448975998 /* PINMemoryCache.h in CopyFiles */,
+				BF_520157303909 /* PINMemoryCache.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_7126762060 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_481459157621 /* PINCache.h in CopyFiles */,
+				BF_488257176070 /* PINCache.h in CopyFiles */,
+				BF_869285449676 /* PINCacheMacros.h in CopyFiles */,
+				BF_242007217085 /* PINCacheMacros.h in CopyFiles */,
+				BF_499403324285 /* PINCacheObjectSubscripting.h in CopyFiles */,
+				BF_293638183421 /* PINCacheObjectSubscripting.h in CopyFiles */,
+				BF_716964868962 /* PINCaching.h in CopyFiles */,
+				BF_700321127624 /* PINCaching.h in CopyFiles */,
+				BF_253644441454 /* PINDiskCache.h in CopyFiles */,
+				BF_483597779937 /* PINDiskCache.h in CopyFiles */,
+				BF_852077649031 /* PINMemoryCache.h in CopyFiles */,
+				BF_619170717804 /* PINMemoryCache.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_7780861546 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_588001213672 /* AppDelegate.h in CopyFiles */,
+				BF_691261085238 /* Some.hpp in CopyFiles */,
+				BF_440885593334 /* UrlGetViewController.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CFBP_7861390617 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				BF_334982662971 /* AppIntent.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		FR_100119553883 /* NSURLComponents+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLComponents+Stripe.h"; sourceTree = "<group>"; };
-		FR_100219285940 /* UrlGet-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "UrlGet-Info.plist"; sourceTree = "<group>"; };
-		FR_100956106933 /* PINOperationGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationGroup.h; sourceTree = "<group>"; };
-		FR_100956106934 /* PINOperationGroup.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINOperationGroup.m; sourceTree = "<group>"; };
-		FR_104204687231 /* Stub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Stub.m; sourceTree = "<group>"; };
-		FR_107900841834 /* libios-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-ext-bin.a"; sourceTree = "<group>"; };
-		FR_113418609357 /* STPLegalEntityParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLegalEntityParams.h; sourceTree = "<group>"; };
-		FR_113779000903 /* STPSourceSEPADebitDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceSEPADebitDetails.h; sourceTree = "<group>"; };
-		FR_114615500587 /* PKPayment+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PKPayment+Stripe.m"; sourceTree = "<group>"; };
-		"FR_114615500587-1" /* PKPayment+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPayment+Stripe.h"; sourceTree = "<group>"; };
-		FR_117348292070 /* STPWeakStrongMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPWeakStrongMacros.h; sourceTree = "<group>"; };
-		FR_118015691316 /* STPFormTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormTextField.h; sourceTree = "<group>"; };
-		"FR_118015691316-1" /* STPFormTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFormTextField.m; sourceTree = "<group>"; };
-		FR_118429332705 /* STPEphemeralKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEphemeralKey.m; sourceTree = "<group>"; };
-		"FR_118429332705-1" /* STPEphemeralKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKey.h; sourceTree = "<group>"; };
-		FR_118440206517 /* PINOperationTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationTypes.h; sourceTree = "<group>"; };
-		FR_119347389557 /* stp_card_unionpay_en@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_en@3x.png"; sourceTree = "<group>"; };
-		FR_119347408405 /* stp_card_unionpay_en@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_en@2x.png"; sourceTree = "<group>"; };
-		FR_123089320494 /* STPPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethod.h; sourceTree = "<group>"; };
-		FR_125791735798 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
-		FR_127100525052 /* stp_card_unionpay_zh@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_zh@3x.png"; sourceTree = "<group>"; };
-		FR_127100545188 /* stp_card_unionpay_zh@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_zh@2x.png"; sourceTree = "<group>"; };
-		FR_135608655768 /* STPBankAccount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccount.h; sourceTree = "<group>"; };
-		FR_135654520087 /* STPFormEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncoder.h; sourceTree = "<group>"; };
-		FR_136387137481 /* NSError+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+Stripe.h"; sourceTree = "<group>"; };
-		"FR_136387137481-1" /* NSError+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSError+Stripe.m"; sourceTree = "<group>"; };
-		FR_138203417337 /* STPAPIClient+ApplePay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+ApplePay.h"; sourceTree = "<group>"; };
-		FR_140569352166 /* STPAnalyticsClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAnalyticsClient.m; sourceTree = "<group>"; };
-		"FR_140569352166-1" /* STPAnalyticsClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAnalyticsClient.h; sourceTree = "<group>"; };
-		FR_141732336605 /* STPCardValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidator.h; sourceTree = "<group>"; };
-		FR_147204469035 /* STPConnectAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPConnectAccountParams.h; sourceTree = "<group>"; };
-		FR_147245088243 /* libUrlGetClasses-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libUrlGetClasses-ios-9.0.a"; sourceTree = "<group>"; };
-		FR_149344760381 /* STPCoreScrollViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreScrollViewController+Private.h"; sourceTree = "<group>"; };
-		FR_149668560898 /* STPPaymentResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentResult.m; sourceTree = "<group>"; };
-		FR_150617010141 /* stp_card_cvc@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc@3x.png"; sourceTree = "<group>"; };
-		FR_150667978887 /* PINOperationGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationGroup.h; sourceTree = "<group>"; };
-		FR_153681520641 /* stp_card_applepay.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_applepay.png; sourceTree = "<group>"; };
-		FR_159129633610 /* STPCardValidationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidationState.h; sourceTree = "<group>"; };
-		FR_159160499476 /* PINOperationTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationTypes.h; sourceTree = "<group>"; };
-		FR_160191336416 /* stp_card_mastercard@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard@3x.png"; sourceTree = "<group>"; };
-		FR_160191367084 /* stp_card_mastercard@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard@2x.png"; sourceTree = "<group>"; };
-		FR_160370391416 /* STPSourceCardDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceCardDetails.h; sourceTree = "<group>"; };
-		FR_161131115028 /* NSDictionary+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+Stripe.h"; sourceTree = "<group>"; };
-		"FR_161131115028-1" /* NSDictionary+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+Stripe.m"; sourceTree = "<group>"; };
-		FR_161685209527 /* stp_card_visa_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa_template@2x.png"; sourceTree = "<group>"; };
-		FR_161686194489 /* stp_card_visa_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa_template@3x.png"; sourceTree = "<group>"; };
-		FR_162583091328 /* stp_card_discover_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover_template@2x.png"; sourceTree = "<group>"; };
-		FR_162624925573 /* stp_card_discover_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover_template@3x.png"; sourceTree = "<group>"; };
-		FR_166108154819 /* stp_shipping_form@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_shipping_form@2x.png"; sourceTree = "<group>"; };
-		FR_166622418620 /* Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
-		FR_167175369874 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Base; path = Base.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
-		FR_168416049633 /* PKPayment+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPayment+Stripe.h"; sourceTree = "<group>"; };
-		FR_169157621063 /* STPPaymentResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentResult.h; sourceTree = "<group>"; };
-		FR_169594879022 /* libsiri-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libsiri-ext-bin.a"; sourceTree = "<group>"; };
-		FR_169948489485 /* STPSourceVerification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceVerification.h; sourceTree = "<group>"; };
-		FR_170908667679 /* STPEphemeralKeyManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEphemeralKeyManager.m; sourceTree = "<group>"; };
-		"FR_170908667679-1" /* STPEphemeralKeyManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyManager.h; sourceTree = "<group>"; };
-		FR_171962769898 /* UIImage+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Stripe.h"; sourceTree = "<group>"; };
-		"FR_171962769898-1" /* UIImage+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Stripe.m"; sourceTree = "<group>"; };
-		FR_175169517365 /* STPCoreTableViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreTableViewController+Private.h"; sourceTree = "<group>"; };
-		FR_175464452737 /* STPCoreTableViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreTableViewController.m; sourceTree = "<group>"; };
-		FR_175704718595 /* UrlGetClasses-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "UrlGetClasses-ios-9.0.a"; path = "libUrlGetClasses-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_177669650679 /* STPPromise.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPromise.h; sourceTree = "<group>"; };
-		"FR_177669650679-1" /* STPPromise.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPromise.m; sourceTree = "<group>"; };
-		FR_179453799913 /* ios-app-Bazel.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app-Bazel.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_179612585631 /* UINavigationController+Stripe_Completion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+Stripe_Completion.h"; sourceTree = "<group>"; };
-		FR_180708382140 /* STPCustomer+SourceTuple.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPCustomer+SourceTuple.m"; sourceTree = "<group>"; };
-		"FR_180708382140-1" /* STPCustomer+SourceTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+SourceTuple.h"; sourceTree = "<group>"; };
-		FR_181346025846 /* STPPostalCodeValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidator.m; sourceTree = "<group>"; };
-		"FR_181346025846-1" /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
-		FR_190239098214 /* STPShippingMethodsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingMethodsViewController.m; sourceTree = "<group>"; };
-		FR_190239098217 /* STPShippingMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodsViewController.h; sourceTree = "<group>"; };
-		FR_192292988800 /* PINCacheMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheMacros.h; sourceTree = "<group>"; };
-		FR_193256557604 /* STPApplePayPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPApplePayPaymentMethod.h; sourceTree = "<group>"; };
-		FR_196722873933 /* Stripe-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "Stripe-ios-11.3.a"; path = "libStripe-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_200260125720 /* STPEphemeralKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKey.h; sourceTree = "<group>"; };
-		FR_201151680337 /* PINCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCache.h; sourceTree = "<group>"; };
-		"FR_201151680337-1" /* PINCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINCache.m; sourceTree = "<group>"; };
-		FR_202016520148 /* stp_card_cvc@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc@2x.png"; sourceTree = "<group>"; };
-		FR_203274481819 /* STPWeakStrongMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPWeakStrongMacros.h; sourceTree = "<group>"; };
-		FR_203734164041 /* STPPaymentMethodsViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethodsViewController+Private.h"; sourceTree = "<group>"; };
-		FR_205813692671 /* libPINCache-Arc-exception-safe-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Arc-exception-safe-ios-9.0.a"; sourceTree = "<group>"; };
-		FR_207298251625 /* STPAddress.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddress.m; sourceTree = "<group>"; };
-		FR_210015125307 /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
-		FR_211137171978 /* STPApplePayPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPApplePayPaymentMethod.h; sourceTree = "<group>"; };
-		FR_212529072788 /* STPCoreTableViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreTableViewController.h; sourceTree = "<group>"; };
-		FR_213958106393 /* stp_icon_checkmark.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_icon_checkmark.png; sourceTree = "<group>"; };
-		FR_215562581198 /* STPEphemeralKeyManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyManager.h; sourceTree = "<group>"; };
-		FR_218958582687 /* STPTheme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPTheme.m; sourceTree = "<group>"; };
-		FR_221232691705 /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
-		FR_221232691707 /* STPAddressFieldTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddressFieldTableViewCell.m; sourceTree = "<group>"; };
-		FR_221764191289 /* Diags.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Diags.xcconfig; sourceTree = "<group>"; };
-		FR_222214992417 /* stp_card_amex_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_amex_template.png; sourceTree = "<group>"; };
-		FR_225093974291 /* STPAspects.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAspects.m; sourceTree = "<group>"; };
-		"FR_225093974291-1" /* STPAspects.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAspects.h; sourceTree = "<group>"; };
-		FR_226012233892 /* STPPaymentConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentConfiguration+Private.h"; sourceTree = "<group>"; };
-		FR_227675484416 /* STPFile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFile.m; sourceTree = "<group>"; };
-		FR_233450545627 /* STPRedirectContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPRedirectContext.h; sourceTree = "<group>"; };
-		FR_234015152924 /* STPImageLibrary+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPImageLibrary+Private.h"; sourceTree = "<group>"; };
-		FR_235441027813 /* STPSource.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSource.m; sourceTree = "<group>"; };
-		FR_237398221790 /* STPBankAccountParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPBankAccountParams+Private.h"; sourceTree = "<group>"; };
-		FR_238855777613 /* STPBankAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccountParams.h; sourceTree = "<group>"; };
-		FR_239638141147 /* StripeError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeError.h; sourceTree = "<group>"; };
-		FR_240384147847 /* STPDelegateProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDelegateProxy.h; sourceTree = "<group>"; };
-		FR_240384147848 /* STPDelegateProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPDelegateProxy.m; sourceTree = "<group>"; };
-		FR_243789410170 /* share-extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "share-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_244377844184 /* STPAddCardViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAddCardViewController+Private.h"; sourceTree = "<group>"; };
-		FR_253406074136 /* siri-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "siri-ext-bin.a"; path = "libsiri-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_256481006549 /* stp_card_unionpay_en.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_en.png; sourceTree = "<group>"; };
-		FR_262777658410 /* libUrlGetClasses-ios-11.3.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libUrlGetClasses-ios-11.3.a"; sourceTree = "<group>"; };
-		FR_264154326158 /* STPPaymentContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContext.h; sourceTree = "<group>"; };
-		FR_265776775943 /* UIToolbar+Stripe_InputAccessory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIToolbar+Stripe_InputAccessory.h"; sourceTree = "<group>"; };
-		FR_266195411392 /* STPMultipartFormDataEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataEncoder.h; sourceTree = "<group>"; };
-		FR_266252253452 /* UIBarButtonItem+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBarButtonItem+Stripe.h"; sourceTree = "<group>"; };
-		"FR_266252253452-1" /* UIBarButtonItem+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIBarButtonItem+Stripe.m"; sourceTree = "<group>"; };
-		FR_270060349354 /* UIView+Stripe_FirstResponder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_FirstResponder.h"; sourceTree = "<group>"; };
-		"FR_270060349354-1" /* UIView+Stripe_FirstResponder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+Stripe_FirstResponder.m"; sourceTree = "<group>"; };
-		FR_271701757351 /* STPCustomer+SourceTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+SourceTuple.h"; sourceTree = "<group>"; };
-		FR_272405693051 /* Some.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Some.hpp; sourceTree = "<group>"; };
-		FR_275055915589 /* STPSource+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSource+Private.h"; sourceTree = "<group>"; };
-		FR_275604636587 /* stp_card_cvc.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_cvc.png; sourceTree = "<group>"; };
-		FR_276366160308 /* StripeError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StripeError.m; sourceTree = "<group>"; };
-		FR_282022996649 /* Some.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Some.cc; sourceTree = "<group>"; };
-		FR_282440445482 /* STPBankAccountParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPBankAccountParams+Private.h"; sourceTree = "<group>"; };
-		FR_283825756115 /* STPSourceSEPADebitDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceSEPADebitDetails.h; sourceTree = "<group>"; };
-		FR_284380484049 /* STPSectionHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSectionHeaderView.h; sourceTree = "<group>"; };
-		FR_287994782021 /* STPFormEncodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncodable.h; sourceTree = "<group>"; };
-		FR_290482945381 /* STPAddCardViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddCardViewController.h; sourceTree = "<group>"; };
-		FR_296053825144 /* STPPaymentActivityIndicatorView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentActivityIndicatorView.h; sourceTree = "<group>"; };
-		FR_301377298368 /* STPPaymentConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentConfiguration.h; sourceTree = "<group>"; };
-		FR_302600842104 /* STPPaymentContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContext.h; sourceTree = "<group>"; };
-		FR_303088826339 /* STPPaymentMethodsInternalViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodsInternalViewController.m; sourceTree = "<group>"; };
-		FR_303088832029 /* STPPaymentMethodsInternalViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsInternalViewController.h; sourceTree = "<group>"; };
-		FR_303363389556 /* NSError+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+Stripe.h"; sourceTree = "<group>"; };
-		FR_305934251603 /* STPPaymentMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsViewController.h; sourceTree = "<group>"; };
-		FR_307274708587 /* UIImage+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Stripe.h"; sourceTree = "<group>"; };
-		FR_308451946297 /* STPAPIClient+ApplePay.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPAPIClient+ApplePay.m"; sourceTree = "<group>"; };
-		FR_309446203354 /* STPCard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCard.h; sourceTree = "<group>"; };
-		FR_311576797096 /* STPMultipartFormDataPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataPart.h; sourceTree = "<group>"; };
-		FR_313827850627 /* stp_card_unknown@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unknown@3x.png"; sourceTree = "<group>"; };
-		FR_314016843022 /* STPImageLibrary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPImageLibrary.m; sourceTree = "<group>"; };
-		FR_314191844776 /* UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_315436813377 /* stp_card_diners.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_diners.png; sourceTree = "<group>"; };
-		FR_318471428702 /* STPPaymentMethodTuple.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTuple.m; sourceTree = "<group>"; };
-		"FR_318471428702-1" /* STPPaymentMethodTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTuple.h; sourceTree = "<group>"; };
-		FR_319111102880 /* NSBundle+Stripe_AppName.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+Stripe_AppName.h"; sourceTree = "<group>"; };
-		"FR_319111102880-1" /* NSBundle+Stripe_AppName.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+Stripe_AppName.m"; sourceTree = "<group>"; };
-		FR_319645862806 /* STPSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSource.h; sourceTree = "<group>"; };
-		FR_326429966766 /* STPSourceEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceEnums.h; sourceTree = "<group>"; };
-		FR_326473329617 /* STPSourceOwner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceOwner.h; sourceTree = "<group>"; };
-		FR_327069580859 /* STPSource+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSource+Private.h"; sourceTree = "<group>"; };
-		FR_328574352852 /* PINMemoryCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINMemoryCache.h; sourceTree = "<group>"; };
-		FR_329418993821 /* stp_card_diners_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners_template@2x.png"; sourceTree = "<group>"; };
-		FR_329419374230 /* stp_card_diners_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners_template@3x.png"; sourceTree = "<group>"; };
-		FR_331004124905 /* STPCardParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardParams.h; sourceTree = "<group>"; };
-		FR_334313231181 /* libStripe-ios-11.3.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libStripe-ios-11.3.a"; sourceTree = "<group>"; };
-		FR_341536377834 /* STPSourceParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceParams+Private.h"; sourceTree = "<group>"; };
-		FR_341722897024 /* stp_card_diners_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_diners_template.png; sourceTree = "<group>"; };
-		FR_344043994903 /* STPMultipartFormDataEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPMultipartFormDataEncoder.m; sourceTree = "<group>"; };
-		FR_344043994904 /* STPMultipartFormDataEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataEncoder.h; sourceTree = "<group>"; };
-		FR_344823093939 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.m"; sourceTree = "<group>"; };
-		"FR_344823093939-1" /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.h"; sourceTree = "<group>"; };
-		FR_346842595418 /* STPAddressViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressViewModel.h; sourceTree = "<group>"; };
-		FR_347917955852 /* STPSourceVerification+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceVerification+Private.h"; sourceTree = "<group>"; };
-		FR_348062610832 /* stp_card_jcb_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb_template@3x.png"; sourceTree = "<group>"; };
-		FR_348062819194 /* stp_card_jcb_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb_template@2x.png"; sourceTree = "<group>"; };
-		FR_349373308093 /* STPSourceReceiver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceReceiver.h; sourceTree = "<group>"; };
-		FR_351629510243 /* stp_card_unionpay_zh.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_zh.png; sourceTree = "<group>"; };
-		FR_351883541716 /* GoogleAppIndexingResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleAppIndexingResources.bundle; sourceTree = "<group>"; };
-		FR_352992722793 /* STPPaymentCardTextFieldViewModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextFieldViewModel.m; sourceTree = "<group>"; };
-		FR_352992724052 /* STPPaymentCardTextFieldViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldViewModel.h; sourceTree = "<group>"; };
-		FR_353990188355 /* GoogleAppIndexing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleAppIndexing.framework; path = Vendor/GoogleAppIndexing/Frameworks/GoogleAppIndexing.framework; sourceTree = "<group>"; };
-		FR_357507703280 /* FauxPasAnnotations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FauxPasAnnotations.h; sourceTree = "<group>"; };
-		FR_357921302656 /* STPSourceRedirect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceRedirect.h; sourceTree = "<group>"; };
-		FR_358060139028 /* GoogleAuthUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleAuthUtilities.framework; path = Vendor/GoogleAuthUtilities/Frameworks/frameworks/GoogleAuthUtilities.framework; sourceTree = "<group>"; };
-		FR_361266480566 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_361814418977 /* siri-extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "siri-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_365229780069 /* STPValidatedTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPValidatedTextField.h; sourceTree = "<group>"; };
-		FR_367740908522 /* NSBundle+Stripe_AppName.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+Stripe_AppName.h"; sourceTree = "<group>"; };
-		FR_371561332475 /* STPCard.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCard.m; sourceTree = "<group>"; };
-		FR_374398035812 /* STPLocalizationUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLocalizationUtils.h; sourceTree = "<group>"; };
-		FR_374398035813 /* STPLocalizationUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPLocalizationUtils.m; sourceTree = "<group>"; };
-		FR_375651978668 /* STPFormEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFormEncoder.m; sourceTree = "<group>"; };
-		"FR_375651978668-1" /* STPFormEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncoder.h; sourceTree = "<group>"; };
-		FR_376986173380 /* STPPaymentCardTextField+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentCardTextField+Private.h"; sourceTree = "<group>"; };
-		FR_380861112100 /* STPFormEncodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncodable.h; sourceTree = "<group>"; };
-		FR_381304510417 /* STPAPIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIClient.h; sourceTree = "<group>"; };
-		FR_383186939534 /* NSString+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+Stripe.h"; sourceTree = "<group>"; };
-		"FR_383186939534-1" /* NSString+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSString+Stripe.m"; sourceTree = "<group>"; };
-		FR_383188188562 /* STPCategoryLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
-		"FR_383188188562-1" /* STPCategoryLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCategoryLoader.m; sourceTree = "<group>"; };
-		FR_385860430238 /* STPCategoryLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
-		FR_387477859828 /* FABKitProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FABKitProtocol.h; sourceTree = "<group>"; };
-		FR_387879201639 /* Fabric+FABKits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fabric+FABKits.h"; sourceTree = "<group>"; };
-		FR_388157799616 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		FR_388629378203 /* STPCustomerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomerContext.h; sourceTree = "<group>"; };
-		FR_390212303514 /* stp_card_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_amex.png; sourceTree = "<group>"; };
-		FR_392500181869 /* STPBundleLocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBundleLocator.h; sourceTree = "<group>"; };
-		FR_393824443136 /* STPPaymentContextAmountModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContextAmountModel.m; sourceTree = "<group>"; };
-		FR_393824443137 /* STPPaymentContextAmountModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContextAmountModel.h; sourceTree = "<group>"; };
-		FR_394482207665 /* STPPaymentMethodsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodsViewController.m; sourceTree = "<group>"; };
-		FR_394531061746 /* UIView+Stripe_SafeAreaBounds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_SafeAreaBounds.h"; sourceTree = "<group>"; };
-		"FR_394531061746-1" /* UIView+Stripe_SafeAreaBounds.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+Stripe_SafeAreaBounds.m"; sourceTree = "<group>"; };
-		FR_397431763487 /* STPValidatedTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPValidatedTextField.h; sourceTree = "<group>"; };
-		"FR_397431763487-1" /* STPValidatedTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPValidatedTextField.m; sourceTree = "<group>"; };
-		FR_398400160687 /* STPInternalAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPInternalAPIResponseDecodable.h; sourceTree = "<group>"; };
-		FR_401789639718 /* STPStringUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
-		"FR_401789639718-1" /* STPStringUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPStringUtils.m; sourceTree = "<group>"; };
-		FR_407393141614 /* STPSourceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceProtocol.h; sourceTree = "<group>"; };
-		FR_411337456535 /* STPAnalyticsClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAnalyticsClient.h; sourceTree = "<group>"; };
-		FR_411830352510 /* STPBackendAPIAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBackendAPIAdapter.h; sourceTree = "<group>"; };
-		FR_413373192620 /* libPINCache-Arc-exception-safe-ios-11.3.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Arc-exception-safe-ios-11.3.a"; sourceTree = "<group>"; };
-		FR_416552303869 /* STPCardBrand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardBrand.h; sourceTree = "<group>"; };
-		FR_417020094137 /* STPURLCallbackHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPURLCallbackHandler.m; sourceTree = "<group>"; };
-		"FR_417020094137-1" /* STPURLCallbackHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPURLCallbackHandler.h; sourceTree = "<group>"; };
-		FR_426141564192 /* STPPaymentMethodTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTableViewCell.m; sourceTree = "<group>"; };
-		FR_426141564195 /* STPPaymentMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTableViewCell.h; sourceTree = "<group>"; };
-		FR_430199726738 /* STPMultipartFormDataPart.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPMultipartFormDataPart.m; sourceTree = "<group>"; };
-		"FR_430199726738-1" /* STPMultipartFormDataPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataPart.h; sourceTree = "<group>"; };
-		FR_431507780270 /* STPSourceVerification.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceVerification.m; sourceTree = "<group>"; };
-		FR_433875149495 /* STPBundleLocator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBundleLocator.m; sourceTree = "<group>"; };
-		"FR_433875149495-1" /* STPBundleLocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBundleLocator.h; sourceTree = "<group>"; };
-		FR_435082555494 /* stp_card_form_back@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_back@3x.png"; sourceTree = "<group>"; };
-		FR_436439106628 /* NSCharacterSet+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSCharacterSet+Stripe.h"; sourceTree = "<group>"; };
-		FR_436922295096 /* stp_card_unionpay_template_en@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_en@3x.png"; sourceTree = "<group>"; };
-		FR_438132085983 /* STPPaymentCardTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextField.m; sourceTree = "<group>"; };
-		FR_438213232580 /* stp_card_unionpay_template_zh@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_zh@2x.png"; sourceTree = "<group>"; };
-		FR_438548292773 /* stp_card_unionpay_template_zh@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_zh@3x.png"; sourceTree = "<group>"; };
-		FR_440272897295 /* stp_card_unionpay_template_en@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_en@2x.png"; sourceTree = "<group>"; };
-		FR_440606856915 /* STPCustomer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Private.h"; sourceTree = "<group>"; };
-		FR_441695822925 /* stp_card_cvc_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc_amex@2x.png"; sourceTree = "<group>"; };
-		FR_443002457585 /* ios-app.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_446151064510 /* stp_icon_add.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_icon_add.png; sourceTree = "<group>"; };
-		FR_447194245190 /* Tests2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests2.m; sourceTree = "<group>"; };
-		FR_448345672017 /* FABKitProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FABKitProtocol.h; sourceTree = "<group>"; };
-		FR_451065136063 /* UIViewController+Stripe_NavigationItemProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_NavigationItemProxy.m"; sourceTree = "<group>"; };
-		"FR_451065136063-1" /* UIViewController+Stripe_NavigationItemProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_NavigationItemProxy.h"; sourceTree = "<group>"; };
-		FR_454126136560 /* STPAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIResponseDecodable.h; sourceTree = "<group>"; };
-		FR_454291026560 /* STPPaymentConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentConfiguration.m; sourceTree = "<group>"; };
-		FR_454823234837 /* NoArc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NoArc.m; sourceTree = "<group>"; };
-		FR_454974753213 /* stp_icon_checkmark@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_checkmark@3x.png"; sourceTree = "<group>"; };
-		FR_458081448840 /* stp_card_unknown.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unknown.png; sourceTree = "<group>"; };
-		FR_458863902474 /* STPSourceVerification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceVerification.h; sourceTree = "<group>"; };
-		FR_458974510861 /* stp_card_applepay@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_applepay@2x.png"; sourceTree = "<group>"; };
-		FR_460131545307 /* UrlGetClasses-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "UrlGetClasses-ios-11.3.a"; path = "libUrlGetClasses-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_460374501185 /* STPRedirectContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPRedirectContext.h; sourceTree = "<group>"; };
-		FR_460546061817 /* stp_card_discover@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover@3x.png"; sourceTree = "<group>"; };
-		FR_462265337593 /* stp_icon_checkmark@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_checkmark@2x.png"; sourceTree = "<group>"; };
-		FR_464213115625 /* stp_card_visa@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa@2x.png"; sourceTree = "<group>"; };
-		FR_466427502225 /* STPPaymentContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContext.m; sourceTree = "<group>"; };
-		FR_468896292749 /* STPEphemeralKeyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyProvider.h; sourceTree = "<group>"; };
-		FR_471192665951 /* stp_card_form_back@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_back@2x.png"; sourceTree = "<group>"; };
-		FR_473219612446 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
-		FR_474473428077 /* UITableViewCell+Stripe_Borders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UITableViewCell+Stripe_Borders.h"; sourceTree = "<group>"; };
-		FR_474857769163 /* UIView+Stripe_FirstResponder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_FirstResponder.h"; sourceTree = "<group>"; };
-		FR_476338718337 /* PINCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCaching.h; sourceTree = "<group>"; };
-		FR_479483572541 /* PINMemoryCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINMemoryCache.h; sourceTree = "<group>"; };
-		"FR_479483572541-1" /* PINMemoryCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINMemoryCache.m; sourceTree = "<group>"; };
-		FR_480331574684 /* UINavigationBar+Stripe_Theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+Stripe_Theme.h"; sourceTree = "<group>"; };
-		FR_484428159681 /* STPCoreTableViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreTableViewController.h; sourceTree = "<group>"; };
-		FR_485300186976 /* NSDecimalNumber+Stripe_Currency.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDecimalNumber+Stripe_Currency.h"; sourceTree = "<group>"; };
-		FR_485300186977 /* NSDecimalNumber+Stripe_Currency.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDecimalNumber+Stripe_Currency.m"; sourceTree = "<group>"; };
-		FR_485714325221 /* stp_card_discover.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_discover.png; sourceTree = "<group>"; };
-		FR_486615080111 /* UINavigationBar+Stripe_Theme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UINavigationBar+Stripe_Theme.m"; sourceTree = "<group>"; };
-		FR_489565775328 /* STPSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSource.h; sourceTree = "<group>"; };
-		FR_490229470460 /* NSURLComponents+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLComponents+Stripe.h"; sourceTree = "<group>"; };
-		"FR_490229470460-1" /* NSURLComponents+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURLComponents+Stripe.m"; sourceTree = "<group>"; };
-		FR_493781913276 /* STPColorUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPColorUtils.h; sourceTree = "<group>"; };
-		FR_494783133802 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "zh-Hans"; path = "zh-Hans.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
-		FR_498036443375 /* stp_card_jcb@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb@2x.png"; sourceTree = "<group>"; };
-		FR_499280427849 /* stp_card_diners@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners@2x.png"; sourceTree = "<group>"; };
-		FR_501274904079 /* AppIntent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppIntent.m; sourceTree = "<group>"; };
-		"FR_501274904079-1" /* AppIntent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppIntent.h; sourceTree = "<group>"; };
-		FR_501678888554 /* STPAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddress.h; sourceTree = "<group>"; };
-		FR_504172386443 /* STPPaymentCardTextFieldCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldCell.h; sourceTree = "<group>"; };
-		FR_504279331501 /* STPAPIRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIRequest.h; sourceTree = "<group>"; };
-		FR_506863260541 /* STPCoreScrollViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreScrollViewController.h; sourceTree = "<group>"; };
-		FR_507863811111 /* STPCustomer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomer.h; sourceTree = "<group>"; };
-		FR_514597362078 /* STPAPIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIClient.h; sourceTree = "<group>"; };
-		FR_515018785028 /* PINCache-Arc-exception-safe-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Arc-exception-safe-ios-11.3.a"; path = "libPINCache-Arc-exception-safe-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_515110400273 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.h"; sourceTree = "<group>"; };
-		FR_518266894407 /* libStripe-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libStripe-ios-9.0.a"; sourceTree = "<group>"; };
-		FR_518632870935 /* STPCardValidationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidationState.h; sourceTree = "<group>"; };
-		FR_519916175206 /* STPCustomer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Private.h"; sourceTree = "<group>"; };
-		FR_519940329301 /* STPUserInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPUserInformation.h; sourceTree = "<group>"; };
-		FR_520364995872 /* STPBankAccount.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBankAccount.m; sourceTree = "<group>"; };
-		FR_522111507539 /* STPRedirectContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPRedirectContext.m; sourceTree = "<group>"; };
-		FR_523050043014 /* PINOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperation.h; sourceTree = "<group>"; };
-		FR_524308052075 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.plug-in"; path = "Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_525936809580 /* PINCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCache.h; sourceTree = "<group>"; };
-		FR_529018358997 /* STPPaymentMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTableViewCell.h; sourceTree = "<group>"; };
-		FR_535609714789 /* stp_card_visa_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_visa_template.png; sourceTree = "<group>"; };
-		FR_536748644256 /* STPPaymentConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentConfiguration.h; sourceTree = "<group>"; };
-		FR_536943478702 /* GoogleNetworkingUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleNetworkingUtilities.framework; path = Vendor/GoogleNetworkingUtilities/Frameworks/frameworks/GoogleNetworkingUtilities.framework; sourceTree = "<group>"; };
-		FR_537648693821 /* STPSourceCardDetails+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceCardDetails+Private.h"; sourceTree = "<group>"; };
-		FR_538535395111 /* STPToken.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPToken.m; sourceTree = "<group>"; };
-		FR_540393113192 /* PINCache-Arc-exception-safe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Arc-exception-safe-ios-9.0.a"; path = "libPINCache-Arc-exception-safe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_543365396645 /* STPApplePayPaymentMethod.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPApplePayPaymentMethod.m; sourceTree = "<group>"; };
-		FR_544048132697 /* STPBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBlocks.h; sourceTree = "<group>"; };
-		FR_544868232734 /* STPPaymentContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentContext+Private.h"; sourceTree = "<group>"; };
-		FR_545855187610 /* STPPaymentMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsViewController.h; sourceTree = "<group>"; };
-		FR_546285993684 /* NSString+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+Stripe.h"; sourceTree = "<group>"; };
-		FR_547267518002 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_547792905644 /* STPCoreViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreViewController.m; sourceTree = "<group>"; };
-		FR_549563930037 /* STPTheme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTheme.h; sourceTree = "<group>"; };
-		FR_549793573278 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_550412986688 /* stp_card_error.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_error.png; sourceTree = "<group>"; };
-		FR_550565498786 /* stp_card_error@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error@3x.png"; sourceTree = "<group>"; };
-		FR_551038918304 /* STPToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPToken.h; sourceTree = "<group>"; };
-		FR_553085332782 /* STPCardValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidator.h; sourceTree = "<group>"; };
-		FR_554896677909 /* stp_card_jcb@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb@3x.png"; sourceTree = "<group>"; };
-		FR_555038450084 /* STPCardParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardParams.h; sourceTree = "<group>"; };
-		FR_560961278475 /* STPPromise.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPromise.h; sourceTree = "<group>"; };
-		FR_563291007487 /* STPCoreViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreViewController+Private.h"; sourceTree = "<group>"; };
-		FR_564276906433 /* STPPaymentCardTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextField.h; sourceTree = "<group>"; };
-		FR_573019928512 /* STPPaymentActivityIndicatorView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentActivityIndicatorView.h; sourceTree = "<group>"; };
-		FR_573089660403 /* UIViewController+Stripe_KeyboardAvoiding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_KeyboardAvoiding.h"; sourceTree = "<group>"; };
-		FR_573665251373 /* STPImageLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPImageLibrary.h; sourceTree = "<group>"; };
-		FR_573822806939 /* STPColorUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPColorUtils.m; sourceTree = "<group>"; };
-		"FR_573822806939-1" /* STPColorUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPColorUtils.h; sourceTree = "<group>"; };
-		FR_575999326641 /* StringsExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "StringsExtension-Info.plist"; sourceTree = "<group>"; };
-		FR_577405838685 /* GoogleSymbolUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleSymbolUtilities.framework; path = Vendor/GoogleSymbolUtilities/Frameworks/frameworks/GoogleSymbolUtilities.framework; sourceTree = "<group>"; };
-		FR_578888125127 /* libPINOperation-ios-11.3.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINOperation-ios-11.3.a"; sourceTree = "<group>"; };
-		FR_581387210768 /* stp_card_form_back.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_form_back.png; sourceTree = "<group>"; };
-		FR_582257680537 /* STPToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPToken.h; sourceTree = "<group>"; };
-		FR_582943901244 /* STPUserInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPUserInformation.h; sourceTree = "<group>"; };
-		FR_583546727827 /* UnitTestsWithHost.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UnitTestsWithHost.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_584192437806 /* stp_card_jcb_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_jcb_template.png; sourceTree = "<group>"; };
-		FR_584380253982 /* PINDiskCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINDiskCache.h; sourceTree = "<group>"; };
-		FR_587518550104 /* stp_shipping_form@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_shipping_form@3x.png"; sourceTree = "<group>"; };
-		FR_593532437987 /* share-extension-Bazel.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = "share-extension-Bazel.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_595618312739 /* libPINCache-Core-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Core-ios-9.0.a"; sourceTree = "<group>"; };
-		FR_597218262530 /* stp_card_form_front.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_form_front.png; sourceTree = "<group>"; };
-		FR_599715734317 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_600589277732 /* STPPaymentMethodsViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethodsViewController+Private.h"; sourceTree = "<group>"; };
-		FR_606586344904 /* STPAspects.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAspects.h; sourceTree = "<group>"; };
-		FR_606866437089 /* STPPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethod.h; sourceTree = "<group>"; };
-		FR_607555391478 /* stp_card_unionpay_template_en.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_template_en.png; sourceTree = "<group>"; };
-		FR_607867791021 /* stp_card_unionpay_template_zh.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_template_zh.png; sourceTree = "<group>"; };
-		FR_609723908966 /* SiriExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "SiriExtension-Info.plist"; sourceTree = "<group>"; };
-		FR_609916384487 /* STPPaymentCardTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextField.h; sourceTree = "<group>"; };
-		FR_609969202553 /* STPPaymentResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentResult.h; sourceTree = "<group>"; };
-		FR_610748361952 /* libios-app-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-app-bin.a"; sourceTree = "<group>"; };
-		FR_611231413868 /* PINDiskCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINDiskCache.m; sourceTree = "<group>"; };
-		"FR_611231413868-1" /* PINDiskCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINDiskCache.h; sourceTree = "<group>"; };
-		FR_612435877299 /* STPSourceOwner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceOwner.h; sourceTree = "<group>"; };
-		FR_613101804389 /* STPSourceReceiver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceReceiver.h; sourceTree = "<group>"; };
-		FR_613113088567 /* STPSourceEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceEnums.h; sourceTree = "<group>"; };
-		FR_616218057689 /* stp_card_visa@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa@3x.png"; sourceTree = "<group>"; };
-		FR_616663993966 /* STPPaymentContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentContext+Private.h"; sourceTree = "<group>"; };
-		FR_617610467620 /* NSMutableURLRequest+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Stripe.h"; sourceTree = "<group>"; };
-		FR_618474416247 /* STPAddCardViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddCardViewController.h; sourceTree = "<group>"; };
-		FR_618722400902 /* StripeError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeError.h; sourceTree = "<group>"; };
-		FR_620185860855 /* stp_card_visa.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_visa.png; sourceTree = "<group>"; };
-		FR_627505725116 /* STPFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPFile+Private.h"; sourceTree = "<group>"; };
-		FR_631274162632 /* STPBINRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBINRange.h; sourceTree = "<group>"; };
-		FR_634891479805 /* STPUserInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPUserInformation.m; sourceTree = "<group>"; };
-		FR_635484072488 /* PINOperationMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationMacros.h; sourceTree = "<group>"; };
-		FR_637944311431 /* ios-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "ios-ext-bin.a"; path = "libios-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_638194865189 /* STPSourceParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceParams.h; sourceTree = "<group>"; };
-		FR_639248881296 /* STPSourceSEPADebitDetails.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceSEPADebitDetails.m; sourceTree = "<group>"; };
-		FR_641873512346 /* UIView+Stripe_SafeAreaBounds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_SafeAreaBounds.h"; sourceTree = "<group>"; };
-		FR_642952555060 /* PINCacheObjectSubscripting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheObjectSubscripting.h; sourceTree = "<group>"; };
-		FR_644623788371 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_644827855298 /* stp_icon_add@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_add@3x.png"; sourceTree = "<group>"; };
-		FR_648806668237 /* stp_card_cvc_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_cvc_amex.png; sourceTree = "<group>"; };
-		FR_650044337253 /* STPAddressViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressViewModel.h; sourceTree = "<group>"; };
-		"FR_650044337253-1" /* STPAddressViewModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddressViewModel.m; sourceTree = "<group>"; };
-		FR_651201787786 /* STPCoreScrollViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreScrollViewController.m; sourceTree = "<group>"; };
-		FR_651430382944 /* STPShippingMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodTableViewCell.h; sourceTree = "<group>"; };
-		FR_653524283850 /* stp_card_unknown@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unknown@2x.png"; sourceTree = "<group>"; };
-		FR_655732831542 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
-		FR_657046115910 /* STPEmailAddressValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEmailAddressValidator.h; sourceTree = "<group>"; };
-		FR_661294188967 /* STPShippingAddressViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingAddressViewController.h; sourceTree = "<group>"; };
-		FR_661735356868 /* STPPaymentContextAmountModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContextAmountModel.h; sourceTree = "<group>"; };
-		FR_662890025590 /* STPCustomerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomerContext.h; sourceTree = "<group>"; };
-		FR_666369934619 /* libstrings-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libstrings-ext-bin.a"; sourceTree = "<group>"; };
-		FR_669064331373 /* STPShippingMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodsViewController.h; sourceTree = "<group>"; };
-		FR_670019473135 /* STPAddCardViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddCardViewController.m; sourceTree = "<group>"; };
-		FR_670697261324 /* STPBINRange.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBINRange.m; sourceTree = "<group>"; };
-		"FR_670697261324-1" /* STPBINRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBINRange.h; sourceTree = "<group>"; };
-		FR_674978004924 /* PINCacheMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheMacros.h; sourceTree = "<group>"; };
-		FR_676905157532 /* STPURLCallbackHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPURLCallbackHandler.h; sourceTree = "<group>"; };
-		FR_679194175341 /* STPBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBlocks.h; sourceTree = "<group>"; };
-		FR_680138288521 /* PINCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCaching.h; sourceTree = "<group>"; };
-		FR_680787884007 /* STPPaymentCardTextField+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentCardTextField+Private.h"; sourceTree = "<group>"; };
-		FR_683299749236 /* NSDictionary+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+Stripe.h"; sourceTree = "<group>"; };
-		FR_683369487726 /* libPINCache-Core-ios-11.3.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Core-ios-11.3.a"; sourceTree = "<group>"; };
-		FR_684957151634 /* stp_card_error_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error_amex@3x.png"; sourceTree = "<group>"; };
-		FR_684957154701 /* stp_card_error_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error_amex@2x.png"; sourceTree = "<group>"; };
-		FR_686972168627 /* PINCache-Core-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Core-ios-9.0.a"; path = "libPINCache-Core-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_688345473974 /* STPBackendAPIAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBackendAPIAdapter.h; sourceTree = "<group>"; };
-		FR_689735932342 /* STPSourceCardDetails.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceCardDetails.m; sourceTree = "<group>"; };
-		FR_691297741334 /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
-		FR_691812537693 /* stp_card_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex@2x.png"; sourceTree = "<group>"; };
-		FR_694358125905 /* Fabric+FABKits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fabric+FABKits.h"; sourceTree = "<group>"; };
-		FR_695303806021 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_697092322085 /* STPPaymentMethodsInternalViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsInternalViewController.h; sourceTree = "<group>"; };
-		FR_697115907292 /* FauxPasAnnotations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FauxPasAnnotations.h; sourceTree = "<group>"; };
-		FR_697405215088 /* STPLegalEntityParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLegalEntityParams.h; sourceTree = "<group>"; };
-		FR_699522203998 /* NSArray+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSArray+Stripe.h"; sourceTree = "<group>"; };
-		FR_699697656028 /* STPShippingAddressViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingAddressViewController.h; sourceTree = "<group>"; };
-		FR_701860410388 /* stp_icon_add@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_add@2x.png"; sourceTree = "<group>"; };
-		FR_704991007882 /* STPImageLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPImageLibrary.h; sourceTree = "<group>"; };
-		FR_707080851040 /* Stripe-Stripe_Bundle_Stripe-ios-11.3.bundle */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.plug-in"; path = "Stripe-Stripe_Bundle_Stripe-ios-11.3.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_708756170642 /* STPSourceCardDetails+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceCardDetails+Private.h"; sourceTree = "<group>"; };
-		FR_709442092021 /* STPPaymentMethodTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTuple.h; sourceTree = "<group>"; };
-		FR_711062668967 /* STPCard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCard.h; sourceTree = "<group>"; };
-		FR_711084170905 /* STPFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFile.h; sourceTree = "<group>"; };
-		FR_713747347031 /* UINavigationBar+Stripe_Theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+Stripe_Theme.h"; sourceTree = "<group>"; };
-		FR_714908972385 /* Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Stripe.h; sourceTree = "<group>"; };
-		FR_716273040248 /* STPCardValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardValidator.m; sourceTree = "<group>"; };
-		FR_719224241995 /* stp_card_mastercard_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_mastercard_template.png; sourceTree = "<group>"; };
-		FR_720345196462 /* AppJerry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppJerry.h; sourceTree = "<group>"; };
-		"FR_720345196462-1" /* AppJerry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppJerry.m; sourceTree = "<group>"; };
-		FR_720396073744 /* stp_shipping_form.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_shipping_form.png; sourceTree = "<group>"; };
-		FR_720729207925 /* STPCardIOProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardIOProxy.h; sourceTree = "<group>"; };
-		FR_727895182634 /* STPCoreViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreViewController+Private.h"; sourceTree = "<group>"; };
-		FR_728079807747 /* stp_card_error_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_error_amex.png; sourceTree = "<group>"; };
-		FR_729302817175 /* HeaderLib.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = HeaderLib.hpp; sourceTree = "<group>"; };
-		FR_729837640388 /* STPAPIClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAPIClient.m; sourceTree = "<group>"; };
-		FR_731018226313 /* UIViewController+Stripe_ParentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_ParentViewController.h"; sourceTree = "<group>"; };
-		FR_732161840902 /* stp_card_discover_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_discover_template.png; sourceTree = "<group>"; };
-		FR_736834917512 /* PINOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperation.h; sourceTree = "<group>"; };
-		FR_737799052203 /* STPAddCardViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAddCardViewController+Private.h"; sourceTree = "<group>"; };
-		FR_739797562620 /* stp_card_jcb.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_jcb.png; sourceTree = "<group>"; };
-		FR_739869940011 /* STPAPIClient+ApplePay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+ApplePay.h"; sourceTree = "<group>"; };
-		FR_740003049424 /* STPBankAccountParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBankAccountParams.m; sourceTree = "<group>"; };
-		FR_742505614292 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_742895067730 /* libPINOperation-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINOperation-ios-9.0.a"; sourceTree = "<group>"; };
-		FR_744357543627 /* PINCacheObjectSubscripting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheObjectSubscripting.h; sourceTree = "<group>"; };
-		FR_744571361438 /* STPAPIRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIRequest.h; sourceTree = "<group>"; };
-		"FR_744571361438-1" /* STPAPIRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAPIRequest.m; sourceTree = "<group>"; };
-		FR_744666232521 /* STPShippingAddressViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingAddressViewController.m; sourceTree = "<group>"; };
-		FR_745612128133 /* strings-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "strings-ext-bin.a"; path = "libstrings-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_746622612454 /* UINavigationController+Stripe_Completion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+Stripe_Completion.h"; sourceTree = "<group>"; };
-		FR_746622613527 /* UINavigationController+Stripe_Completion.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UINavigationController+Stripe_Completion.m"; sourceTree = "<group>"; };
-		FR_747790741358 /* STPSourcePoller.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourcePoller.h; sourceTree = "<group>"; };
-		"FR_747790741358-1" /* STPSourcePoller.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourcePoller.m; sourceTree = "<group>"; };
-		FR_747893419826 /* NSDecimalNumber+Stripe_Currency.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDecimalNumber+Stripe_Currency.h"; sourceTree = "<group>"; };
-		FR_748997447722 /* STPSourceParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceParams.m; sourceTree = "<group>"; };
-		FR_752684654079 /* STPAPIClient+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+Private.h"; sourceTree = "<group>"; };
-		FR_753050319742 /* UIBarButtonItem+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBarButtonItem+Stripe.h"; sourceTree = "<group>"; };
-		FR_754231351934 /* STPSourceCardDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceCardDetails.h; sourceTree = "<group>"; };
-		FR_756124038298 /* STPSwitchTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSwitchTableViewCell.h; sourceTree = "<group>"; };
-		FR_756408111234 /* HeaderLib-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "HeaderLib-ios-9.0.a"; path = "libHeaderLib-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_760644560579 /* STPPhoneNumberValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPhoneNumberValidator.h; sourceTree = "<group>"; };
-		FR_761061955139 /* STPSourceOwner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceOwner.m; sourceTree = "<group>"; };
-		FR_761662219184 /* UrlGetViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UrlGetViewController.h; sourceTree = "<group>"; };
-		"FR_761662219184-1" /* UrlGetViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UrlGetViewController.m; sourceTree = "<group>"; };
-		FR_761930139089 /* Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Stripe.h; sourceTree = "<group>"; };
-		FR_763956267392 /* STPPaymentConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentConfiguration+Private.h"; sourceTree = "<group>"; };
-		FR_764575073058 /* HeaderLib-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "HeaderLib-ios-11.3.a"; path = "libHeaderLib-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_764679247202 /* STPCustomerContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCustomerContext.m; sourceTree = "<group>"; };
-		FR_766919050802 /* stp_card_amex_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex_template@2x.png"; sourceTree = "<group>"; };
-		FR_766928612639 /* stp_card_amex_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex_template@3x.png"; sourceTree = "<group>"; };
-		FR_767601579243 /* stp_card_form_front@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_front@2x.png"; sourceTree = "<group>"; };
-		FR_767601582739 /* stp_card_form_front@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_front@3x.png"; sourceTree = "<group>"; };
-		FR_770631286662 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
-		FR_770817608373 /* STPSourceRedirect.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceRedirect.m; sourceTree = "<group>"; };
-		FR_772386701230 /* Fabric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
-		FR_774763671036 /* STPSourceVerification+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceVerification+Private.h"; sourceTree = "<group>"; };
-		FR_775444959222 /* STPCustomer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCustomer.m; sourceTree = "<group>"; };
-		FR_776001027518 /* PINOperation-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINOperation-ios-9.0.a"; path = "libPINOperation-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_776344734580 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		FR_777337581099 /* STPBankAccount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccount.h; sourceTree = "<group>"; };
-		FR_777944667952 /* STPSourceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceProtocol.h; sourceTree = "<group>"; };
-		FR_778052571267 /* STPBankAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccountParams.h; sourceTree = "<group>"; };
-		FR_778931539736 /* STPSourceParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceParams+Private.h"; sourceTree = "<group>"; };
-		FR_779405691145 /* STPCoreTableViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreTableViewController+Private.h"; sourceTree = "<group>"; };
-		FR_780452303071 /* STPTheme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTheme.h; sourceTree = "<group>"; };
-		FR_784978928035 /* UIViewController+Stripe_KeyboardAvoiding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_KeyboardAvoiding.m"; sourceTree = "<group>"; };
-		FR_784978929968 /* UIViewController+Stripe_KeyboardAvoiding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_KeyboardAvoiding.h"; sourceTree = "<group>"; };
-		FR_786618818576 /* stp_card_diners@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners@3x.png"; sourceTree = "<group>"; };
-		FR_786851096828 /* STPPaymentCardTextFieldCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldCell.h; sourceTree = "<group>"; };
-		FR_786851096829 /* STPPaymentCardTextFieldCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextFieldCell.m; sourceTree = "<group>"; };
-		FR_788950277856 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		FR_790877768775 /* STPPaymentCardTextFieldViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldViewModel.h; sourceTree = "<group>"; };
-		FR_791050653111 /* UIViewController+Stripe_NavigationItemProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_NavigationItemProxy.h"; sourceTree = "<group>"; };
-		FR_791168379253 /* stp_test_upload_image.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = stp_test_upload_image.jpeg; sourceTree = "<group>"; };
-		FR_793128565775 /* STPSourceReceiver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceReceiver.m; sourceTree = "<group>"; };
-		FR_793362014210 /* STPSwitchTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSwitchTableViewCell.h; sourceTree = "<group>"; };
-		"FR_793362014210-1" /* STPSwitchTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSwitchTableViewCell.m; sourceTree = "<group>"; };
-		FR_795421255062 /* STPConnectAccountParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPConnectAccountParams.m; sourceTree = "<group>"; };
-		FR_803655950633 /* STPCardIOProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardIOProxy.h; sourceTree = "<group>"; };
-		"FR_803655950633-1" /* STPCardIOProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardIOProxy.m; sourceTree = "<group>"; };
-		FR_805275538402 /* PINCache-Core-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Core-ios-11.3.a"; path = "libPINCache-Core-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_805980394107 /* STPShippingMethodTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingMethodTableViewCell.m; sourceTree = "<group>"; };
-		FR_805980394109 /* STPShippingMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodTableViewCell.h; sourceTree = "<group>"; };
-		FR_808039309519 /* STPSourceRedirect+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceRedirect+Private.h"; sourceTree = "<group>"; };
-		FR_809418927836 /* STPDelegateProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDelegateProxy.h; sourceTree = "<group>"; };
-		FR_813294530495 /* Stripe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "Stripe-ios-9.0.a"; path = "libStripe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_813949290948 /* STPCoreScrollViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreScrollViewController+Private.h"; sourceTree = "<group>"; };
-		FR_819492685632 /* stp_card_mastercard.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_mastercard.png; sourceTree = "<group>"; };
-		FR_820602908988 /* STPEmailAddressValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEmailAddressValidator.m; sourceTree = "<group>"; };
-		FR_820602908989 /* STPEmailAddressValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEmailAddressValidator.h; sourceTree = "<group>"; };
-		FR_823402288931 /* STPAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddress.h; sourceTree = "<group>"; };
-		FR_824435249884 /* Fabric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
-		FR_827262883523 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		FR_828784758374 /* STPSourcePoller.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourcePoller.h; sourceTree = "<group>"; };
-		FR_828800361135 /* STPSourceParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceParams.h; sourceTree = "<group>"; };
-		FR_829657687624 /* NSMutableURLRequest+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Stripe.h"; sourceTree = "<group>"; };
-		FR_829657687628 /* NSMutableURLRequest+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSMutableURLRequest+Stripe.m"; sourceTree = "<group>"; };
-		FR_832542114231 /* PINOperation-ios-11.3.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINOperation-ios-11.3.a"; path = "libPINOperation-ios-11.3.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_835891206247 /* PINOperationQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationQueue.h; sourceTree = "<group>"; };
-		FR_836284080868 /* STPTelemetryClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPTelemetryClient.m; sourceTree = "<group>"; };
-		"FR_836284080868-1" /* STPTelemetryClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTelemetryClient.h; sourceTree = "<group>"; };
-		FR_838405705884 /* stp_card_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex@3x.png"; sourceTree = "<group>"; };
-		FR_838755216449 /* STPImageLibrary+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPImageLibrary+Private.h"; sourceTree = "<group>"; };
-		FR_838972687587 /* empty-main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "empty-main.m"; sourceTree = "<group>"; };
-		FR_841504889253 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
-		FR_841504889387 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
-		FR_841907106254 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_845699426889 /* STPPhoneNumberValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPhoneNumberValidator.m; sourceTree = "<group>"; };
-		"FR_845699426889-1" /* STPPhoneNumberValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPhoneNumberValidator.h; sourceTree = "<group>"; };
-		FR_847087900331 /* STPPaymentActivityIndicatorView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentActivityIndicatorView.m; sourceTree = "<group>"; };
-		FR_849166683791 /* stp_card_error@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error@2x.png"; sourceTree = "<group>"; };
-		FR_851062106151 /* UIToolbar+Stripe_InputAccessory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIToolbar+Stripe_InputAccessory.m"; sourceTree = "<group>"; };
-		FR_851062106152 /* UIToolbar+Stripe_InputAccessory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIToolbar+Stripe_InputAccessory.h"; sourceTree = "<group>"; };
-		FR_856763993418 /* NSCharacterSet+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSCharacterSet+Stripe.m"; sourceTree = "<group>"; };
-		"FR_856763993418-1" /* NSCharacterSet+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSCharacterSet+Stripe.h"; sourceTree = "<group>"; };
-		FR_857114782727 /* NSArray+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Stripe.m"; sourceTree = "<group>"; };
-		"FR_857114782727-1" /* NSArray+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSArray+Stripe.h"; sourceTree = "<group>"; };
-		FR_859356790791 /* STPTelemetryClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTelemetryClient.h; sourceTree = "<group>"; };
-		FR_862049125356 /* STPFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPFile+Private.h"; sourceTree = "<group>"; };
-		FR_863295554989 /* STPDispatchFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDispatchFunctions.h; sourceTree = "<group>"; };
-		FR_863295555018 /* STPDispatchFunctions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPDispatchFunctions.m; sourceTree = "<group>"; };
-		FR_863581397541 /* STPLegalEntityParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPLegalEntityParams.m; sourceTree = "<group>"; };
-		FR_865850458143 /* STPLocalizationUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLocalizationUtils.h; sourceTree = "<group>"; };
-		FR_866423752002 /* stp_card_applepay@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_applepay@3x.png"; sourceTree = "<group>"; };
-		FR_866814615747 /* UIViewController+Stripe_ParentViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_ParentViewController.m"; sourceTree = "<group>"; };
-		"FR_866814615747-1" /* UIViewController+Stripe_ParentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_ParentViewController.h"; sourceTree = "<group>"; };
-		FR_867716578881 /* stp_card_discover@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover@2x.png"; sourceTree = "<group>"; };
-		FR_870129501381 /* UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_871158067621 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = cs; path = cs.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
-		FR_871742726913 /* STPAPIClient+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+Private.h"; sourceTree = "<group>"; };
-		FR_875549008649 /* ios-app-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "ios-app-bin.a"; path = "libios-app-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_878727202200 /* STPEphemeralKeyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyProvider.h; sourceTree = "<group>"; };
-		FR_882551670747 /* UITableViewCell+Stripe_Borders.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UITableViewCell+Stripe_Borders.m"; sourceTree = "<group>"; };
-		FR_882551670748 /* UITableViewCell+Stripe_Borders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UITableViewCell+Stripe_Borders.h"; sourceTree = "<group>"; };
-		FR_883876637273 /* PINOperationMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationMacros.h; sourceTree = "<group>"; };
-		FR_884927251036 /* STPAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIResponseDecodable.h; sourceTree = "<group>"; };
-		FR_887010092861 /* UrlGetViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UrlGetViewController.xib; sourceTree = "<group>"; };
-		FR_887633340860 /* STPCardBrand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardBrand.h; sourceTree = "<group>"; };
-		FR_888449823097 /* STPSectionHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSectionHeaderView.h; sourceTree = "<group>"; };
-		"FR_888449823097-1" /* STPSectionHeaderView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSectionHeaderView.m; sourceTree = "<group>"; };
-		FR_889566942228 /* STPSourceRedirect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceRedirect.h; sourceTree = "<group>"; };
-		FR_891417925643 /* STPSourceRedirect+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceRedirect+Private.h"; sourceTree = "<group>"; };
-		FR_891431900870 /* STPDispatchFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDispatchFunctions.h; sourceTree = "<group>"; };
-		FR_895047324232 /* STPStringUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
-		FR_897080895086 /* STPCustomer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomer.h; sourceTree = "<group>"; };
-		FR_898827650356 /* PINOperationQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationQueue.h; sourceTree = "<group>"; };
-		"FR_898827650356-1" /* PINOperationQueue.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINOperationQueue.m; sourceTree = "<group>"; };
-		FR_900194878155 /* STPCoreScrollViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreScrollViewController.h; sourceTree = "<group>"; };
-		FR_903454413342 /* STPFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFile.h; sourceTree = "<group>"; };
-		FR_904866835747 /* UIViewController+Stripe_Promises.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_Promises.m"; sourceTree = "<group>"; };
-		FR_904866835750 /* UIViewController+Stripe_Promises.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_Promises.h"; sourceTree = "<group>"; };
-		FR_905090839392 /* STPCoreViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreViewController.h; sourceTree = "<group>"; };
-		FR_910389829219 /* strings-extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "strings-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_911085306196 /* STPConnectAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPConnectAccountParams.h; sourceTree = "<group>"; };
-		FR_912348913657 /* STPCoreViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreViewController.h; sourceTree = "<group>"; };
-		FR_914453841196 /* ShareExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ShareExtension-Info.plist"; sourceTree = "<group>"; };
-		FR_914734393950 /* stp_card_mastercard_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard_template@3x.png"; sourceTree = "<group>"; };
-		FR_914737022420 /* stp_card_mastercard_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard_template@2x.png"; sourceTree = "<group>"; };
-		FR_916856507218 /* stp_card_cvc_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc_amex@3x.png"; sourceTree = "<group>"; };
-		FR_920174354034 /* STPFormTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormTextField.h; sourceTree = "<group>"; };
-		FR_953710188013 /* UIViewController+Stripe_Promises.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_Promises.h"; sourceTree = "<group>"; };
-		FR_983798454349 /* STPCardParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardParams.m; sourceTree = "<group>"; };
-		FR_986136575822 /* STPInternalAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPInternalAPIResponseDecodable.h; sourceTree = "<group>"; };
+		FR_100918364096 /* STPTheme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTheme.h; sourceTree = "<group>"; };
+		FR_102943442467 /* StringsExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "StringsExtension-Info.plist"; sourceTree = "<group>"; };
+		FR_106153810107 /* PINCacheObjectSubscripting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheObjectSubscripting.h; sourceTree = "<group>"; };
+		FR_106165532869 /* STPCoreViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreViewController.h; sourceTree = "<group>"; };
+		FR_107066082523 /* strings-extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "strings-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_107323960575 /* stp_card_diners@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners@2x.png"; sourceTree = "<group>"; };
+		FR_107405673473 /* STPAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIResponseDecodable.h; sourceTree = "<group>"; };
+		FR_109100472565 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		FR_110318688237 /* STPEphemeralKeyManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEphemeralKeyManager.m; sourceTree = "<group>"; };
+		FR_111986568000 /* UIBarButtonItem+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBarButtonItem+Stripe.h"; sourceTree = "<group>"; };
+		FR_112095401783 /* STPPaymentCardTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextField.h; sourceTree = "<group>"; };
+		FR_112556541763 /* STPPaymentCardTextField+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentCardTextField+Private.h"; sourceTree = "<group>"; };
+		FR_114090975619 /* STPShippingAddressViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingAddressViewController.m; sourceTree = "<group>"; };
+		FR_115263350237 /* ShareExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ShareExtension-Info.plist"; sourceTree = "<group>"; };
+		FR_115569304376 /* libStripe-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libStripe-ios-9.0.a"; sourceTree = "<group>"; };
+		FR_116888961223 /* Diags.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Diags.xcconfig; sourceTree = "<group>"; };
+		FR_117244705373 /* STPPaymentCardTextFieldViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldViewModel.h; sourceTree = "<group>"; };
+		FR_119185384321 /* STPCard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCard.h; sourceTree = "<group>"; };
+		FR_119461237896 /* STPAPIRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAPIRequest.m; sourceTree = "<group>"; };
+		FR_124520506223 /* STPPaymentConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentConfiguration.h; sourceTree = "<group>"; };
+		FR_124543526378 /* STPCategoryLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
+		FR_127475428263 /* stp_card_mastercard@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard@3x.png"; sourceTree = "<group>"; };
+		FR_128201504065 /* stp_card_unionpay_zh.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_zh.png; sourceTree = "<group>"; };
+		FR_130046752603 /* NSArray+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSArray+Stripe.h"; sourceTree = "<group>"; };
+		FR_130346079060 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		FR_131920372131 /* PINCache-Arc-exception-safe-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Arc-exception-safe-ios-12.0.a"; path = "libPINCache-Arc-exception-safe-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_133576635973 /* STPBackendAPIAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBackendAPIAdapter.h; sourceTree = "<group>"; };
+		FR_134445234443 /* NSURLComponents+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLComponents+Stripe.h"; sourceTree = "<group>"; };
+		FR_134719527222 /* stp_card_cvc_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_cvc_amex.png; sourceTree = "<group>"; };
+		FR_138502338795 /* PINCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCache.h; sourceTree = "<group>"; };
+		FR_140562483639 /* stp_card_amex_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_amex_template.png; sourceTree = "<group>"; };
+		FR_142523824475 /* stp_card_discover_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover_template@2x.png"; sourceTree = "<group>"; };
+		FR_143673724944 /* PINDiskCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINDiskCache.m; sourceTree = "<group>"; };
+		FR_145688362384 /* STPInternalAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPInternalAPIResponseDecodable.h; sourceTree = "<group>"; };
+		FR_150902497411 /* STPFormEncodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncodable.h; sourceTree = "<group>"; };
+		FR_152553107307 /* PINOperationGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationGroup.h; sourceTree = "<group>"; };
+		FR_153226209751 /* STPFormTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormTextField.h; sourceTree = "<group>"; };
+		FR_153688961655 /* stp_shipping_form.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_shipping_form.png; sourceTree = "<group>"; };
+		FR_157587722902 /* STPPaymentCardTextFieldViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldViewModel.h; sourceTree = "<group>"; };
+		FR_160259185428 /* STPRedirectContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPRedirectContext.h; sourceTree = "<group>"; };
+		FR_162101825678 /* UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_162423673141 /* STPPaymentMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsViewController.h; sourceTree = "<group>"; };
+		FR_164344606297 /* STPShippingMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodsViewController.h; sourceTree = "<group>"; };
+		FR_165114611545 /* STPCoreScrollViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreScrollViewController+Private.h"; sourceTree = "<group>"; };
+		FR_166620028473 /* STPShippingMethodTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingMethodTableViewCell.m; sourceTree = "<group>"; };
+		FR_166695994825 /* STPFormEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFormEncoder.m; sourceTree = "<group>"; };
+		FR_166918657392 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.m"; sourceTree = "<group>"; };
+		FR_167666946058 /* Some.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Some.cc; sourceTree = "<group>"; };
+		FR_169041491584 /* STPPaymentMethodTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTuple.h; sourceTree = "<group>"; };
+		FR_170596598734 /* UIView+Stripe_FirstResponder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_FirstResponder.h"; sourceTree = "<group>"; };
+		FR_170614256090 /* UINavigationController+Stripe_Completion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+Stripe_Completion.h"; sourceTree = "<group>"; };
+		FR_170769962236 /* PINDiskCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINDiskCache.h; sourceTree = "<group>"; };
+		FR_171399986210 /* stp_card_visa_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_visa_template.png; sourceTree = "<group>"; };
+		FR_171679345202 /* STPApplePayPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPApplePayPaymentMethod.h; sourceTree = "<group>"; };
+		FR_172739966665 /* STPLocalizationUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLocalizationUtils.h; sourceTree = "<group>"; };
+		FR_172958393529 /* UIToolbar+Stripe_InputAccessory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIToolbar+Stripe_InputAccessory.h"; sourceTree = "<group>"; };
+		FR_174283433844 /* UrlGet-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "UrlGet-Info.plist"; sourceTree = "<group>"; };
+		FR_174620530590 /* STPCoreViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreViewController.m; sourceTree = "<group>"; };
+		FR_176089150530 /* STPSectionHeaderView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSectionHeaderView.m; sourceTree = "<group>"; };
+		FR_176587841763 /* NSDecimalNumber+Stripe_Currency.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDecimalNumber+Stripe_Currency.h"; sourceTree = "<group>"; };
+		FR_179040801106 /* STPSourceCardDetails.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceCardDetails.m; sourceTree = "<group>"; };
+		FR_180206282362 /* Some.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Some.hpp; sourceTree = "<group>"; };
+		FR_182438507920 /* STPImageLibrary+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPImageLibrary+Private.h"; sourceTree = "<group>"; };
+		FR_183338914811 /* stp_card_unknown@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unknown@3x.png"; sourceTree = "<group>"; };
+		FR_183755575988 /* UIImage+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Stripe.m"; sourceTree = "<group>"; };
+		FR_184535322115 /* STPShippingMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodTableViewCell.h; sourceTree = "<group>"; };
+		FR_185670732342 /* STPFormTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFormTextField.m; sourceTree = "<group>"; };
+		FR_187518438601 /* STPFormEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncoder.h; sourceTree = "<group>"; };
+		FR_187663198768 /* STPPaymentContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentContext+Private.h"; sourceTree = "<group>"; };
+		FR_189036277762 /* STPSource.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSource.m; sourceTree = "<group>"; };
+		FR_190529263507 /* STPShippingAddressViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingAddressViewController.h; sourceTree = "<group>"; };
+		FR_190995174488 /* PINOperationQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationQueue.h; sourceTree = "<group>"; };
+		FR_190999170508 /* STPBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBlocks.h; sourceTree = "<group>"; };
+		FR_193926384296 /* UIViewController+Stripe_Promises.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_Promises.h"; sourceTree = "<group>"; };
+		FR_195508064871 /* STPUserInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPUserInformation.h; sourceTree = "<group>"; };
+		FR_196593282791 /* stp_card_applepay@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_applepay@2x.png"; sourceTree = "<group>"; };
+		FR_196725857447 /* UrlGetClasses-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "UrlGetClasses-ios-9.0.a"; path = "libUrlGetClasses-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_197802340500 /* STPPaymentCardTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextField.m; sourceTree = "<group>"; };
+		FR_199387754190 /* STPAPIClient+ApplePay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+ApplePay.h"; sourceTree = "<group>"; };
+		FR_200668121419 /* stp_card_applepay.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_applepay.png; sourceTree = "<group>"; };
+		FR_201763267702 /* STPSourceParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceParams+Private.h"; sourceTree = "<group>"; };
+		FR_204424633043 /* STPSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSource.h; sourceTree = "<group>"; };
+		FR_205363634933 /* share-extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "share-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_205650942905 /* stp_card_unionpay_en@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_en@2x.png"; sourceTree = "<group>"; };
+		FR_210368222096 /* PINOperationMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationMacros.h; sourceTree = "<group>"; };
+		FR_212508126291 /* stp_card_unionpay_zh@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_zh@3x.png"; sourceTree = "<group>"; };
+		FR_213034861182 /* StripeError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeError.h; sourceTree = "<group>"; };
+		FR_214160927202 /* STPDispatchFunctions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPDispatchFunctions.m; sourceTree = "<group>"; };
+		FR_214570034228 /* STPCoreScrollViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreScrollViewController.h; sourceTree = "<group>"; };
+		FR_216387680131 /* STPSourceVerification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceVerification.h; sourceTree = "<group>"; };
+		FR_217618539785 /* STPStringUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
+		FR_218112984498 /* STPPromise.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPromise.m; sourceTree = "<group>"; };
+		FR_218663833597 /* PINOperationGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationGroup.h; sourceTree = "<group>"; };
+		FR_222347419161 /* STPTelemetryClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTelemetryClient.h; sourceTree = "<group>"; };
+		FR_223874375474 /* UIImage+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Stripe.h"; sourceTree = "<group>"; };
+		FR_224088827831 /* PINOperationTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationTypes.h; sourceTree = "<group>"; };
+		FR_225976546120 /* STPPaymentMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTableViewCell.h; sourceTree = "<group>"; };
+		FR_227516787760 /* Fabric+FABKits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fabric+FABKits.h"; sourceTree = "<group>"; };
+		FR_227724747281 /* PINCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCache.h; sourceTree = "<group>"; };
+		FR_228923531634 /* STPCoreViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreViewController.h; sourceTree = "<group>"; };
+		FR_232037670091 /* PINCache-Core-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Core-ios-12.0.a"; path = "libPINCache-Core-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_232572251428 /* stp_card_mastercard_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard_template@2x.png"; sourceTree = "<group>"; };
+		FR_233085860418 /* STPWeakStrongMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPWeakStrongMacros.h; sourceTree = "<group>"; };
+		FR_233098522244 /* stp_card_visa_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa_template@2x.png"; sourceTree = "<group>"; };
+		FR_235596592030 /* UIView+Stripe_FirstResponder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+Stripe_FirstResponder.m"; sourceTree = "<group>"; };
+		FR_236953861390 /* STPShippingMethodsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingMethodsViewController.m; sourceTree = "<group>"; };
+		FR_240590486966 /* STPBankAccount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccount.h; sourceTree = "<group>"; };
+		FR_240832335761 /* NSDictionary+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+Stripe.h"; sourceTree = "<group>"; };
+		FR_240970093763 /* STPCardParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardParams.m; sourceTree = "<group>"; };
+		FR_241491748011 /* STPSourceOwner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceOwner.h; sourceTree = "<group>"; };
+		FR_242554983927 /* stp_card_jcb.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_jcb.png; sourceTree = "<group>"; };
+		FR_246982922734 /* NSMutableURLRequest+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSMutableURLRequest+Stripe.m"; sourceTree = "<group>"; };
+		FR_248304595826 /* STPAddCardViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddCardViewController.m; sourceTree = "<group>"; };
+		FR_249006138549 /* STPAnalyticsClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAnalyticsClient.m; sourceTree = "<group>"; };
+		FR_250934899452 /* FauxPasAnnotations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FauxPasAnnotations.h; sourceTree = "<group>"; };
+		FR_251439661499 /* STPCoreScrollViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreScrollViewController+Private.h"; sourceTree = "<group>"; };
+		FR_252761981132 /* STPAnalyticsClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAnalyticsClient.h; sourceTree = "<group>"; };
+		FR_253734139691 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		FR_254186187103 /* STPSourceCardDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceCardDetails.h; sourceTree = "<group>"; };
+		FR_256578496436 /* STPTheme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTheme.h; sourceTree = "<group>"; };
+		FR_257482490656 /* STPSourceVerification+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceVerification+Private.h"; sourceTree = "<group>"; };
+		FR_258616937111 /* libios-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-ext-bin.a"; sourceTree = "<group>"; };
+		FR_260626407590 /* stp_card_error@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error@2x.png"; sourceTree = "<group>"; };
+		FR_263771945362 /* FABKitProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FABKitProtocol.h; sourceTree = "<group>"; };
+		FR_265863572154 /* stp_test_upload_image.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = stp_test_upload_image.jpeg; sourceTree = "<group>"; };
+		FR_269033352898 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_270361851280 /* NSArray+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Stripe.m"; sourceTree = "<group>"; };
+		FR_271927629469 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_275560902555 /* NSCharacterSet+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSCharacterSet+Stripe.m"; sourceTree = "<group>"; };
+		FR_276281345727 /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
+		FR_279289880954 /* PINOperationGroup.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINOperationGroup.m; sourceTree = "<group>"; };
+		FR_281431888822 /* NSString+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSString+Stripe.m"; sourceTree = "<group>"; };
+		FR_281566021398 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
+		FR_284420664639 /* STPSectionHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSectionHeaderView.h; sourceTree = "<group>"; };
+		FR_285060110180 /* STPCustomer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Private.h"; sourceTree = "<group>"; };
+		FR_285793989872 /* STPValidatedTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPValidatedTextField.h; sourceTree = "<group>"; };
+		FR_287240998336 /* STPFormEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncoder.h; sourceTree = "<group>"; };
+		FR_287747118355 /* siri-extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "siri-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_289951473723 /* STPShippingMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodsViewController.h; sourceTree = "<group>"; };
+		FR_292167901401 /* libPINCache-Arc-exception-safe-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Arc-exception-safe-ios-12.0.a"; sourceTree = "<group>"; };
+		FR_293229987775 /* STPURLCallbackHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPURLCallbackHandler.m; sourceTree = "<group>"; };
+		FR_295663962341 /* stp_card_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex@3x.png"; sourceTree = "<group>"; };
+		FR_296560133436 /* STPAddCardViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddCardViewController.h; sourceTree = "<group>"; };
+		FR_299376274777 /* NSDecimalNumber+Stripe_Currency.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDecimalNumber+Stripe_Currency.m"; sourceTree = "<group>"; };
+		FR_300701900501 /* STPSourceParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceParams.h; sourceTree = "<group>"; };
+		FR_306688222964 /* STPPaymentConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentConfiguration.h; sourceTree = "<group>"; };
+		FR_308536515212 /* STPCardValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidator.h; sourceTree = "<group>"; };
+		FR_310086671711 /* PINMemoryCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINMemoryCache.m; sourceTree = "<group>"; };
+		FR_310141525667 /* UINavigationBar+Stripe_Theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+Stripe_Theme.h"; sourceTree = "<group>"; };
+		FR_310737407634 /* FauxPasAnnotations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FauxPasAnnotations.h; sourceTree = "<group>"; };
+		FR_311622561615 /* STPCoreScrollViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreScrollViewController.m; sourceTree = "<group>"; };
+		FR_314640988313 /* STPSourceSEPADebitDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceSEPADebitDetails.h; sourceTree = "<group>"; };
+		FR_314953714155 /* STPPaymentResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentResult.m; sourceTree = "<group>"; };
+		FR_320799198594 /* STPAPIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIClient.h; sourceTree = "<group>"; };
+		FR_321038524600 /* HeaderLib-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "HeaderLib-ios-9.0.a"; path = "libHeaderLib-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_321171250374 /* libUrlGetClasses-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libUrlGetClasses-ios-9.0.a"; sourceTree = "<group>"; };
+		FR_321591135654 /* STPApplePayPaymentMethod.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPApplePayPaymentMethod.m; sourceTree = "<group>"; };
+		FR_322145952019 /* NSDictionary+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+Stripe.m"; sourceTree = "<group>"; };
+		FR_324415420402 /* stp_card_cvc@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc@2x.png"; sourceTree = "<group>"; };
+		FR_324426164016 /* stp_card_form_front@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_front@3x.png"; sourceTree = "<group>"; };
+		FR_325521637118 /* stp_card_form_back@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_back@3x.png"; sourceTree = "<group>"; };
+		FR_328254709834 /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
+		FR_328352920299 /* STPSourcePoller.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourcePoller.h; sourceTree = "<group>"; };
+		FR_332315537569 /* PKPayment+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPayment+Stripe.h"; sourceTree = "<group>"; };
+		FR_335537886290 /* UIViewController+Stripe_Promises.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_Promises.h"; sourceTree = "<group>"; };
+		FR_336262010096 /* STPURLCallbackHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPURLCallbackHandler.h; sourceTree = "<group>"; };
+		FR_336676787389 /* stp_card_visa.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_visa.png; sourceTree = "<group>"; };
+		FR_340610195773 /* stp_card_unionpay_en.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_en.png; sourceTree = "<group>"; };
+		FR_341953782072 /* STPPaymentMethodsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodsViewController.m; sourceTree = "<group>"; };
+		FR_344626064168 /* STPAspects.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAspects.m; sourceTree = "<group>"; };
+		FR_352033123735 /* STPPaymentActivityIndicatorView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentActivityIndicatorView.m; sourceTree = "<group>"; };
+		FR_353249173463 /* STPPromise.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPromise.h; sourceTree = "<group>"; };
+		FR_353316542796 /* libPINOperation-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINOperation-ios-9.0.a"; sourceTree = "<group>"; };
+		FR_353412325098 /* stp_card_cvc@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc@3x.png"; sourceTree = "<group>"; };
+		FR_354724297581 /* NSError+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+Stripe.h"; sourceTree = "<group>"; };
+		FR_358655835312 /* STPFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPFile+Private.h"; sourceTree = "<group>"; };
+		FR_359239314212 /* STPBankAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccountParams.h; sourceTree = "<group>"; };
+		FR_360464332296 /* STPPaymentMethodsInternalViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsInternalViewController.h; sourceTree = "<group>"; };
+		FR_362535988676 /* stp_card_unionpay_en@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_en@3x.png"; sourceTree = "<group>"; };
+		FR_362637812812 /* STPCustomer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCustomer.m; sourceTree = "<group>"; };
+		FR_363247867339 /* stp_card_form_back.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_form_back.png; sourceTree = "<group>"; };
+		FR_363658341124 /* stp_card_discover@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover@3x.png"; sourceTree = "<group>"; };
+		FR_368887152771 /* STPSourceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceProtocol.h; sourceTree = "<group>"; };
+		FR_369657259990 /* STPApplePayPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPApplePayPaymentMethod.h; sourceTree = "<group>"; };
+		FR_370123180763 /* STPPaymentMethodTuple.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTuple.m; sourceTree = "<group>"; };
+		FR_373510968019 /* PINOperationQueue.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINOperationQueue.m; sourceTree = "<group>"; };
+		FR_374236941753 /* STPPaymentResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentResult.h; sourceTree = "<group>"; };
+		FR_376164653878 /* STPCard.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCard.m; sourceTree = "<group>"; };
+		FR_379671331039 /* HeaderLib.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = HeaderLib.hpp; sourceTree = "<group>"; };
+		FR_380855240261 /* STPCardParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardParams.h; sourceTree = "<group>"; };
+		FR_381541692670 /* STPBankAccount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccount.h; sourceTree = "<group>"; };
+		FR_386854374165 /* STPSourceParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceParams.m; sourceTree = "<group>"; };
+		FR_386885018930 /* STPImageLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPImageLibrary.h; sourceTree = "<group>"; };
+		FR_387226535794 /* stp_card_form_front.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_form_front.png; sourceTree = "<group>"; };
+		FR_387408549256 /* STPLocalizationUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLocalizationUtils.h; sourceTree = "<group>"; };
+		FR_388659491173 /* STPEmailAddressValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEmailAddressValidator.h; sourceTree = "<group>"; };
+		FR_390537239017 /* STPCustomer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomer.h; sourceTree = "<group>"; };
+		FR_391708229706 /* STPMultipartFormDataEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataEncoder.h; sourceTree = "<group>"; };
+		FR_392574313117 /* STPFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFile.h; sourceTree = "<group>"; };
+		FR_393687196501 /* stp_card_unionpay_template_en.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_template_en.png; sourceTree = "<group>"; };
+		FR_394586624846 /* UnitTestsWithHost.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UnitTestsWithHost.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_394612788029 /* stp_card_visa@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa@3x.png"; sourceTree = "<group>"; };
+		FR_395102338138 /* STPAddCardViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAddCardViewController+Private.h"; sourceTree = "<group>"; };
+		FR_399258034997 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_399283558766 /* STPLegalEntityParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPLegalEntityParams.m; sourceTree = "<group>"; };
+		FR_401046103149 /* STPEphemeralKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEphemeralKey.m; sourceTree = "<group>"; };
+		FR_401159209257 /* STPPaymentCardTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextField.h; sourceTree = "<group>"; };
+		FR_404009520577 /* STPBINRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBINRange.h; sourceTree = "<group>"; };
+		FR_407411144964 /* STPCardIOProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardIOProxy.h; sourceTree = "<group>"; };
+		FR_408343592509 /* NSBundle+Stripe_AppName.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+Stripe_AppName.h"; sourceTree = "<group>"; };
+		FR_410892256394 /* STPDelegateProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPDelegateProxy.m; sourceTree = "<group>"; };
+		FR_410962885406 /* STPPaymentMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTableViewCell.h; sourceTree = "<group>"; };
+		FR_411547927351 /* Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
+		FR_413023481354 /* STPImageLibrary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPImageLibrary.m; sourceTree = "<group>"; };
+		FR_413649058186 /* STPPaymentConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentConfiguration+Private.h"; sourceTree = "<group>"; };
+		FR_413807607925 /* STPConnectAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPConnectAccountParams.h; sourceTree = "<group>"; };
+		FR_413991883976 /* STPBINRange.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBINRange.m; sourceTree = "<group>"; };
+		FR_416711012558 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.h"; sourceTree = "<group>"; };
+		FR_420487677011 /* STPColorUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPColorUtils.h; sourceTree = "<group>"; };
+		FR_420736451946 /* STPBundleLocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBundleLocator.h; sourceTree = "<group>"; };
+		FR_421043145734 /* stp_card_diners_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners_template@3x.png"; sourceTree = "<group>"; };
+		FR_421045928597 /* STPSourceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceProtocol.h; sourceTree = "<group>"; };
+		FR_423603962795 /* stp_card_mastercard.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_mastercard.png; sourceTree = "<group>"; };
+		FR_424267095963 /* libPINOperation-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINOperation-ios-12.0.a"; sourceTree = "<group>"; };
+		FR_424996891355 /* share-extension-Bazel.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = "share-extension-Bazel.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_426656857393 /* NSCharacterSet+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSCharacterSet+Stripe.h"; sourceTree = "<group>"; };
+		FR_427454786804 /* STPPaymentContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContext.m; sourceTree = "<group>"; };
+		FR_427684117497 /* STPSourceRedirect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceRedirect.h; sourceTree = "<group>"; };
+		FR_428794804154 /* STPPaymentContextAmountModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContextAmountModel.h; sourceTree = "<group>"; };
+		FR_429071574776 /* STPBankAccountParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBankAccountParams.m; sourceTree = "<group>"; };
+		FR_431919160946 /* STPLegalEntityParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLegalEntityParams.h; sourceTree = "<group>"; };
+		FR_434788842793 /* NSError+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSError+Stripe.m"; sourceTree = "<group>"; };
+		FR_435282719354 /* stp_card_unknown@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unknown@2x.png"; sourceTree = "<group>"; };
+		FR_437529102342 /* STPSourceOwner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceOwner.h; sourceTree = "<group>"; };
+		FR_437723492681 /* GoogleAppIndexing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleAppIndexing.framework; path = Vendor/GoogleAppIndexing/Frameworks/GoogleAppIndexing.framework; sourceTree = "<group>"; };
+		FR_437919225479 /* STPCardIOProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardIOProxy.h; sourceTree = "<group>"; };
+		FR_438694548221 /* STPPhoneNumberValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPhoneNumberValidator.h; sourceTree = "<group>"; };
+		FR_439275709173 /* STPAddressViewModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddressViewModel.m; sourceTree = "<group>"; };
+		FR_441651685045 /* UITableViewCell+Stripe_Borders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UITableViewCell+Stripe_Borders.h"; sourceTree = "<group>"; };
+		FR_441979129851 /* STPFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFile.h; sourceTree = "<group>"; };
+		FR_443179884003 /* STPPaymentContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContext.h; sourceTree = "<group>"; };
+		FR_443910781375 /* stp_card_unionpay_template_zh.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_template_zh.png; sourceTree = "<group>"; };
+		FR_443953828808 /* STPCustomer+SourceTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+SourceTuple.h"; sourceTree = "<group>"; };
+		FR_446067735536 /* STPSwitchTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSwitchTableViewCell.h; sourceTree = "<group>"; };
+		FR_453324145384 /* stp_card_error_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_error_amex.png; sourceTree = "<group>"; };
+		FR_453447722637 /* stp_card_jcb@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb@3x.png"; sourceTree = "<group>"; };
+		FR_454721095065 /* stp_card_cvc.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_cvc.png; sourceTree = "<group>"; };
+		FR_455055307449 /* STPCustomerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomerContext.h; sourceTree = "<group>"; };
+		FR_456109311282 /* stp_card_error_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error_amex@3x.png"; sourceTree = "<group>"; };
+		FR_456708297239 /* STPPhoneNumberValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPhoneNumberValidator.h; sourceTree = "<group>"; };
+		FR_457060453990 /* STPSourceOwner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceOwner.m; sourceTree = "<group>"; };
+		FR_458251636042 /* libStripe-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libStripe-ios-12.0.a"; sourceTree = "<group>"; };
+		FR_459027505856 /* STPLegalEntityParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLegalEntityParams.h; sourceTree = "<group>"; };
+		FR_459256248737 /* FABKitProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FABKitProtocol.h; sourceTree = "<group>"; };
+		FR_462403503968 /* STPSourceCardDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceCardDetails.h; sourceTree = "<group>"; };
+		FR_463415628327 /* STPPaymentContextAmountModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContextAmountModel.h; sourceTree = "<group>"; };
+		FR_464681328909 /* STPMultipartFormDataEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataEncoder.h; sourceTree = "<group>"; };
+		FR_465416715992 /* stp_card_mastercard_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard_template@3x.png"; sourceTree = "<group>"; };
+		FR_465632152352 /* STPAPIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIClient.h; sourceTree = "<group>"; };
+		FR_466327725618 /* PINCache-Core-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Core-ios-9.0.a"; path = "libPINCache-Core-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_468113573340 /* stp_card_amex_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex_template@3x.png"; sourceTree = "<group>"; };
+		FR_468517384487 /* STPFormTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormTextField.h; sourceTree = "<group>"; };
+		FR_468805634066 /* UIView+Stripe_FirstResponder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_FirstResponder.h"; sourceTree = "<group>"; };
+		FR_469267514516 /* PKPayment+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PKPayment+Stripe.m"; sourceTree = "<group>"; };
+		FR_469496801272 /* NSMutableURLRequest+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Stripe.h"; sourceTree = "<group>"; };
+		FR_470744425341 /* NSString+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+Stripe.h"; sourceTree = "<group>"; };
+		FR_470930712391 /* stp_card_mastercard@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard@2x.png"; sourceTree = "<group>"; };
+		FR_475562073492 /* stp_card_discover.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_discover.png; sourceTree = "<group>"; };
+		FR_477141207452 /* STPSourceReceiver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceReceiver.m; sourceTree = "<group>"; };
+		FR_479371064013 /* STPAddressFieldTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddressFieldTableViewCell.m; sourceTree = "<group>"; };
+		FR_480653613414 /* NSURLComponents+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLComponents+Stripe.h"; sourceTree = "<group>"; };
+		FR_481660996906 /* STPSectionHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSectionHeaderView.h; sourceTree = "<group>"; };
+		FR_481672282565 /* libPINCache-Core-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Core-ios-9.0.a"; sourceTree = "<group>"; };
+		FR_481907633182 /* stp_icon_add@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_add@3x.png"; sourceTree = "<group>"; };
+		FR_483144838889 /* STPSourceRedirect.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceRedirect.m; sourceTree = "<group>"; };
+		FR_484208255089 /* stp_card_form_front@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_front@2x.png"; sourceTree = "<group>"; };
+		FR_485689218719 /* Fabric+FABKits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fabric+FABKits.h"; sourceTree = "<group>"; };
+		FR_489307065831 /* STPPaymentMethodTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTuple.h; sourceTree = "<group>"; };
+		FR_489653346797 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "zh-Hans"; path = "zh-Hans.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
+		FR_492175780721 /* stp_card_jcb@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb@2x.png"; sourceTree = "<group>"; };
+		FR_493570425693 /* STPSwitchTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSwitchTableViewCell.m; sourceTree = "<group>"; };
+		FR_493757317549 /* PINCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCaching.h; sourceTree = "<group>"; };
+		FR_494301659888 /* STPCategoryLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCategoryLoader.m; sourceTree = "<group>"; };
+		FR_494798662852 /* STPFormEncodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncodable.h; sourceTree = "<group>"; };
+		FR_495367858217 /* PINCacheMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheMacros.h; sourceTree = "<group>"; };
+		FR_496554446077 /* STPEphemeralKeyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyProvider.h; sourceTree = "<group>"; };
+		FR_497557335011 /* SiriExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "SiriExtension-Info.plist"; sourceTree = "<group>"; };
+		FR_498316524810 /* STPCardValidationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidationState.h; sourceTree = "<group>"; };
+		FR_498549693882 /* UINavigationController+Stripe_Completion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+Stripe_Completion.h"; sourceTree = "<group>"; };
+		FR_499312825618 /* UIImage+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Stripe.h"; sourceTree = "<group>"; };
+		FR_500693267193 /* STPMultipartFormDataPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataPart.h; sourceTree = "<group>"; };
+		FR_501344631583 /* STPPaymentMethodsViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethodsViewController+Private.h"; sourceTree = "<group>"; };
+		FR_502474434784 /* STPAddCardViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAddCardViewController+Private.h"; sourceTree = "<group>"; };
+		FR_502904508636 /* STPCoreTableViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreTableViewController.m; sourceTree = "<group>"; };
+		FR_503123501592 /* UITableViewCell+Stripe_Borders.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UITableViewCell+Stripe_Borders.m"; sourceTree = "<group>"; };
+		FR_505294580563 /* STPPaymentContextAmountModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContextAmountModel.m; sourceTree = "<group>"; };
+		FR_508900331586 /* NSURLComponents+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURLComponents+Stripe.m"; sourceTree = "<group>"; };
+		FR_508923610275 /* STPSourcePoller.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourcePoller.m; sourceTree = "<group>"; };
+		FR_509452004334 /* UINavigationBar+Stripe_Theme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UINavigationBar+Stripe_Theme.m"; sourceTree = "<group>"; };
+		FR_523478154706 /* STPPhoneNumberValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPhoneNumberValidator.m; sourceTree = "<group>"; };
+		FR_524791267555 /* stp_card_diners.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_diners.png; sourceTree = "<group>"; };
+		FR_527811563431 /* StripeError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeError.h; sourceTree = "<group>"; };
+		FR_529604170619 /* STPEphemeralKeyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyProvider.h; sourceTree = "<group>"; };
+		FR_529784366644 /* STPLocalizationUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPLocalizationUtils.m; sourceTree = "<group>"; };
+		FR_530544298450 /* PINDiskCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINDiskCache.h; sourceTree = "<group>"; };
+		FR_535994124885 /* UIViewController+Stripe_ParentViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_ParentViewController.m"; sourceTree = "<group>"; };
+		FR_542047769331 /* stp_card_unionpay_template_en@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_en@2x.png"; sourceTree = "<group>"; };
+		FR_542306643416 /* stp_card_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_amex.png; sourceTree = "<group>"; };
+		FR_547023080128 /* STPFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPFile+Private.h"; sourceTree = "<group>"; };
+		FR_547151370574 /* NoArc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NoArc.m; sourceTree = "<group>"; };
+		FR_551274171982 /* libPINCache-Arc-exception-safe-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Arc-exception-safe-ios-9.0.a"; sourceTree = "<group>"; };
+		FR_555089210878 /* UIViewController+Stripe_KeyboardAvoiding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_KeyboardAvoiding.h"; sourceTree = "<group>"; };
+		FR_556956092926 /* stp_card_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex@2x.png"; sourceTree = "<group>"; };
+		FR_557820679266 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Base; path = Base.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
+		FR_563104549644 /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
+		FR_563361406910 /* UIToolbar+Stripe_InputAccessory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIToolbar+Stripe_InputAccessory.h"; sourceTree = "<group>"; };
+		FR_563808066373 /* STPImageLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPImageLibrary.h; sourceTree = "<group>"; };
+		FR_565065630971 /* STPSourceEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceEnums.h; sourceTree = "<group>"; };
+		FR_567993355124 /* STPCustomer+SourceTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+SourceTuple.h"; sourceTree = "<group>"; };
+		FR_568593882583 /* STPCategoryLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
+		FR_569620833385 /* UIViewController+Stripe_KeyboardAvoiding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_KeyboardAvoiding.m"; sourceTree = "<group>"; };
+		FR_572796611138 /* STPConnectAccountParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPConnectAccountParams.m; sourceTree = "<group>"; };
+		FR_574570312868 /* STPStringUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
+		FR_574597020760 /* stp_card_error_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error_amex@2x.png"; sourceTree = "<group>"; };
+		FR_575785382123 /* PINOperation-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINOperation-ios-12.0.a"; path = "libPINOperation-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_576098273475 /* siri-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "siri-ext-bin.a"; path = "libsiri-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_578847093777 /* AppIntent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppIntent.h; sourceTree = "<group>"; };
+		FR_582745043417 /* STPCustomerContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCustomerContext.m; sourceTree = "<group>"; };
+		FR_583395561891 /* STPPaymentCardTextFieldViewModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextFieldViewModel.m; sourceTree = "<group>"; };
+		FR_583674497367 /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
+		FR_583778395098 /* STPInternalAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPInternalAPIResponseDecodable.h; sourceTree = "<group>"; };
+		FR_589726050819 /* STPSwitchTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSwitchTableViewCell.h; sourceTree = "<group>"; };
+		FR_591183502734 /* STPImageLibrary+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPImageLibrary+Private.h"; sourceTree = "<group>"; };
+		FR_591392785580 /* PKPayment+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPayment+Stripe.h"; sourceTree = "<group>"; };
+		FR_591666596335 /* STPCoreViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreViewController+Private.h"; sourceTree = "<group>"; };
+		FR_592260627016 /* STPURLCallbackHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPURLCallbackHandler.h; sourceTree = "<group>"; };
+		FR_592944512740 /* STPAspects.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAspects.h; sourceTree = "<group>"; };
+		FR_593739516315 /* STPEphemeralKeyManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyManager.h; sourceTree = "<group>"; };
+		FR_594159834513 /* UIToolbar+Stripe_InputAccessory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIToolbar+Stripe_InputAccessory.m"; sourceTree = "<group>"; };
+		FR_596924801474 /* stp_shipping_form@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_shipping_form@2x.png"; sourceTree = "<group>"; };
+		FR_597436128584 /* STPCustomer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Private.h"; sourceTree = "<group>"; };
+		FR_599031596757 /* NSBundle+Stripe_AppName.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+Stripe_AppName.m"; sourceTree = "<group>"; };
+		FR_600019716014 /* PINMemoryCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINMemoryCache.h; sourceTree = "<group>"; };
+		FR_600578543769 /* STPCardParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardParams.h; sourceTree = "<group>"; };
+		FR_603110710953 /* PINOperationMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationMacros.h; sourceTree = "<group>"; };
+		FR_604030021498 /* GoogleNetworkingUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleNetworkingUtilities.framework; path = Vendor/GoogleNetworkingUtilities/Frameworks/frameworks/GoogleNetworkingUtilities.framework; sourceTree = "<group>"; };
+		FR_605183289017 /* STPAddCardViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddCardViewController.h; sourceTree = "<group>"; };
+		FR_608901290361 /* stp_card_diners_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_diners_template.png; sourceTree = "<group>"; };
+		FR_609262385738 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
+		FR_609302522033 /* STPSourceSEPADebitDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceSEPADebitDetails.h; sourceTree = "<group>"; };
+		FR_614447531043 /* AppJerry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppJerry.h; sourceTree = "<group>"; };
+		FR_618638349731 /* STPCoreTableViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreTableViewController+Private.h"; sourceTree = "<group>"; };
+		FR_618988043579 /* libPINCache-Core-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Core-ios-12.0.a"; sourceTree = "<group>"; };
+		FR_620301149926 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.h"; sourceTree = "<group>"; };
+		FR_621675436412 /* PINCacheObjectSubscripting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheObjectSubscripting.h; sourceTree = "<group>"; };
+		FR_622146132147 /* STPCoreTableViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreTableViewController.h; sourceTree = "<group>"; };
+		FR_622439046503 /* STPAnalyticsClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAnalyticsClient.h; sourceTree = "<group>"; };
+		FR_622754080338 /* stp_card_unknown.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unknown.png; sourceTree = "<group>"; };
+		FR_623044591305 /* STPUserInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPUserInformation.h; sourceTree = "<group>"; };
+		FR_623324372480 /* NSCharacterSet+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSCharacterSet+Stripe.h"; sourceTree = "<group>"; };
+		FR_623895726528 /* STPAddress.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddress.m; sourceTree = "<group>"; };
+		FR_628989537343 /* STPRedirectContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPRedirectContext.m; sourceTree = "<group>"; };
+		FR_629980649685 /* STPToken.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPToken.m; sourceTree = "<group>"; };
+		FR_633919745139 /* STPPaymentResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentResult.h; sourceTree = "<group>"; };
+		FR_634151600220 /* STPEphemeralKeyManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyManager.h; sourceTree = "<group>"; };
+		FR_635783061927 /* STPCardValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidator.h; sourceTree = "<group>"; };
+		FR_637121338601 /* STPSourceCardDetails+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceCardDetails+Private.h"; sourceTree = "<group>"; };
+		FR_637247309669 /* STPBundleLocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBundleLocator.h; sourceTree = "<group>"; };
+		FR_639161976165 /* STPCustomerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomerContext.h; sourceTree = "<group>"; };
+		FR_647615708741 /* STPCardValidationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidationState.h; sourceTree = "<group>"; };
+		FR_649006375359 /* stp_icon_checkmark@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_checkmark@3x.png"; sourceTree = "<group>"; };
+		FR_649967179890 /* STPSourcePoller.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourcePoller.h; sourceTree = "<group>"; };
+		FR_651211894634 /* STPPaymentContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentContext+Private.h"; sourceTree = "<group>"; };
+		FR_651847570475 /* STPDispatchFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDispatchFunctions.h; sourceTree = "<group>"; };
+		FR_652176105039 /* STPDelegateProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDelegateProxy.h; sourceTree = "<group>"; };
+		FR_654192010378 /* STPPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethod.h; sourceTree = "<group>"; };
+		FR_654509270410 /* STPCoreTableViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreTableViewController.h; sourceTree = "<group>"; };
+		FR_655977824079 /* ios-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "ios-ext-bin.a"; path = "libios-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_656630461598 /* PINCache-Arc-exception-safe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINCache-Arc-exception-safe-ios-9.0.a"; path = "libPINCache-Arc-exception-safe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_656725481201 /* PINOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperation.h; sourceTree = "<group>"; };
+		FR_657128263749 /* NSError+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+Stripe.h"; sourceTree = "<group>"; };
+		FR_657711760784 /* STPEmailAddressValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEmailAddressValidator.m; sourceTree = "<group>"; };
+		FR_657975526681 /* UIBarButtonItem+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBarButtonItem+Stripe.h"; sourceTree = "<group>"; };
+		FR_660486720752 /* UIBarButtonItem+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIBarButtonItem+Stripe.m"; sourceTree = "<group>"; };
+		FR_664069285608 /* Stripe-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "Stripe-ios-12.0.a"; path = "libStripe-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_664471815887 /* UINavigationController+Stripe_Completion.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UINavigationController+Stripe_Completion.m"; sourceTree = "<group>"; };
+		FR_666150738023 /* STPRedirectContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPRedirectContext.h; sourceTree = "<group>"; };
+		FR_667277485416 /* STPCard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCard.h; sourceTree = "<group>"; };
+		FR_668070994301 /* STPCustomer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomer.h; sourceTree = "<group>"; };
+		FR_668317149915 /* NSDictionary+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+Stripe.h"; sourceTree = "<group>"; };
+		FR_668440300851 /* Stub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Stub.m; sourceTree = "<group>"; };
+		FR_670837697807 /* NSMutableURLRequest+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Stripe.h"; sourceTree = "<group>"; };
+		FR_671409370609 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_674603271118 /* libsiri-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libsiri-ext-bin.a"; sourceTree = "<group>"; };
+		FR_675363467066 /* UIViewController+Stripe_NavigationItemProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_NavigationItemProxy.h"; sourceTree = "<group>"; };
+		FR_676661417209 /* STPCardBrand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardBrand.h; sourceTree = "<group>"; };
+		FR_677790726659 /* PINOperation-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "PINOperation-ios-9.0.a"; path = "libPINOperation-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_678946834674 /* STPTheme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPTheme.m; sourceTree = "<group>"; };
+		FR_679084602979 /* STPAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIResponseDecodable.h; sourceTree = "<group>"; };
+		FR_679404232338 /* STPCustomer+SourceTuple.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPCustomer+SourceTuple.m"; sourceTree = "<group>"; };
+		FR_680182050104 /* STPDispatchFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDispatchFunctions.h; sourceTree = "<group>"; };
+		FR_682116511702 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = cs; path = cs.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
+		FR_684008688115 /* Fancy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Fancy.m; sourceTree = "<group>"; };
+		FR_684714893235 /* PINOperationTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationTypes.h; sourceTree = "<group>"; };
+		FR_687805612898 /* STPBankAccount.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBankAccount.m; sourceTree = "<group>"; };
+		FR_688739162706 /* STPEmailAddressValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEmailAddressValidator.h; sourceTree = "<group>"; };
+		FR_689122585293 /* STPStringUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPStringUtils.m; sourceTree = "<group>"; };
+		FR_689893178935 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		FR_690817139963 /* UIViewController+Stripe_ParentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_ParentViewController.h"; sourceTree = "<group>"; };
+		FR_691227681167 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_692503360915 /* Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Stripe.h; sourceTree = "<group>"; };
+		FR_694828367809 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_695779107005 /* STPMultipartFormDataEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPMultipartFormDataEncoder.m; sourceTree = "<group>"; };
+		FR_700370057985 /* STPAddressViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressViewModel.h; sourceTree = "<group>"; };
+		FR_700633204216 /* ios-app-Bazel.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app-Bazel.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_701086246168 /* STPColorUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPColorUtils.h; sourceTree = "<group>"; };
+		FR_701197038044 /* STPAPIClient+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+Private.h"; sourceTree = "<group>"; };
+		FR_702731086180 /* STPSourceVerification+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceVerification+Private.h"; sourceTree = "<group>"; };
+		FR_703828678216 /* UIView+Stripe_SafeAreaBounds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_SafeAreaBounds.h"; sourceTree = "<group>"; };
+		FR_703899038574 /* PINCacheMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheMacros.h; sourceTree = "<group>"; };
+		FR_704198783520 /* Fabric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
+		FR_705928698620 /* stp_card_discover_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover_template@3x.png"; sourceTree = "<group>"; };
+		FR_706359988177 /* STPPromise.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPromise.h; sourceTree = "<group>"; };
+		FR_708327290125 /* UIView+Stripe_SafeAreaBounds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_SafeAreaBounds.h"; sourceTree = "<group>"; };
+		FR_709146189722 /* STPSourceEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceEnums.h; sourceTree = "<group>"; };
+		FR_709946777976 /* STPPostalCodeValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidator.m; sourceTree = "<group>"; };
+		FR_711629859574 /* STPPaymentMethodTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTableViewCell.m; sourceTree = "<group>"; };
+		FR_711918819728 /* STPCoreScrollViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreScrollViewController.h; sourceTree = "<group>"; };
+		FR_715088161304 /* STPSource+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSource+Private.h"; sourceTree = "<group>"; };
+		FR_715819450244 /* STPShippingAddressViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingAddressViewController.h; sourceTree = "<group>"; };
+		FR_716313626667 /* NSString+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+Stripe.h"; sourceTree = "<group>"; };
+		FR_716391505040 /* stp_card_applepay@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_applepay@3x.png"; sourceTree = "<group>"; };
+		FR_720475461729 /* STPBankAccountParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPBankAccountParams+Private.h"; sourceTree = "<group>"; };
+		FR_721129734544 /* STPDelegateProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDelegateProxy.h; sourceTree = "<group>"; };
+		FR_721448149799 /* stp_card_error.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_error.png; sourceTree = "<group>"; };
+		FR_723543549131 /* STPSourceRedirect+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceRedirect+Private.h"; sourceTree = "<group>"; };
+		FR_724259384552 /* STPSourceRedirect+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceRedirect+Private.h"; sourceTree = "<group>"; };
+		FR_725361281093 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		FR_727217733032 /* Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Stripe.h; sourceTree = "<group>"; };
+		FR_729185093187 /* STPValidatedTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPValidatedTextField.h; sourceTree = "<group>"; };
+		FR_731137829020 /* libstrings-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libstrings-ext-bin.a"; sourceTree = "<group>"; };
+		FR_732165764070 /* STPCoreTableViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreTableViewController+Private.h"; sourceTree = "<group>"; };
+		FR_734554573488 /* UrlGetViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UrlGetViewController.m; sourceTree = "<group>"; };
+		FR_734989487303 /* UITableViewCell+Stripe_Borders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UITableViewCell+Stripe_Borders.h"; sourceTree = "<group>"; };
+		FR_735360084506 /* PINCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCaching.h; sourceTree = "<group>"; };
+		FR_737093675579 /* STPSourceParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceParams.h; sourceTree = "<group>"; };
+		FR_737821215910 /* stp_card_unionpay_template_zh@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_zh@3x.png"; sourceTree = "<group>"; };
+		FR_737907561380 /* UIViewController+Stripe_ParentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_ParentViewController.h"; sourceTree = "<group>"; };
+		FR_738136358357 /* stp_card_diners_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners_template@2x.png"; sourceTree = "<group>"; };
+		FR_738661589644 /* UrlGetViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UrlGetViewController.h; sourceTree = "<group>"; };
+		FR_739176942134 /* stp_icon_add.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_icon_add.png; sourceTree = "<group>"; };
+		FR_743842026332 /* GoogleAuthUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleAuthUtilities.framework; path = Vendor/GoogleAuthUtilities/Frameworks/frameworks/GoogleAuthUtilities.framework; sourceTree = "<group>"; };
+		FR_747080657190 /* NSDecimalNumber+Stripe_Currency.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDecimalNumber+Stripe_Currency.h"; sourceTree = "<group>"; };
+		FR_748329317110 /* STPPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethod.h; sourceTree = "<group>"; };
+		FR_749349441066 /* STPSourceVerification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceVerification.h; sourceTree = "<group>"; };
+		FR_749553059542 /* NSBundle+Stripe_AppName.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+Stripe_AppName.h"; sourceTree = "<group>"; };
+		FR_753120224409 /* UrlGetViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UrlGetViewController.xib; sourceTree = "<group>"; };
+		FR_753262157515 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		FR_753343340710 /* STPPaymentMethodsViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethodsViewController+Private.h"; sourceTree = "<group>"; };
+		FR_754763453812 /* stp_card_cvc_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc_amex@2x.png"; sourceTree = "<group>"; };
+		FR_755922952676 /* stp_card_jcb_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb_template@2x.png"; sourceTree = "<group>"; };
+		FR_757956135481 /* ios-app.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_758612271558 /* stp_card_amex_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex_template@2x.png"; sourceTree = "<group>"; };
+		FR_760476646265 /* STPPaymentCardTextField+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentCardTextField+Private.h"; sourceTree = "<group>"; };
+		FR_763790828482 /* STPValidatedTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPValidatedTextField.m; sourceTree = "<group>"; };
+		FR_767805223807 /* Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.plug-in"; path = "Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_768379248407 /* STPAddressViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressViewModel.h; sourceTree = "<group>"; };
+		FR_768476324412 /* STPToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPToken.h; sourceTree = "<group>"; };
+		FR_768992176715 /* STPBackendAPIAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBackendAPIAdapter.h; sourceTree = "<group>"; };
+		FR_769504085116 /* STPAPIClient+ApplePay.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPAPIClient+ApplePay.m"; sourceTree = "<group>"; };
+		FR_770241236915 /* stp_card_cvc_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc_amex@3x.png"; sourceTree = "<group>"; };
+		FR_771342212418 /* STPSourceReceiver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceReceiver.h; sourceTree = "<group>"; };
+		FR_772315109974 /* stp_card_visa_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa_template@3x.png"; sourceTree = "<group>"; };
+		FR_773149577891 /* Tests2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests2.m; sourceTree = "<group>"; };
+		FR_773846360911 /* STPConnectAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPConnectAccountParams.h; sourceTree = "<group>"; };
+		FR_776459644262 /* Fabric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
+		FR_779248810941 /* stp_card_jcb_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_jcb_template.png; sourceTree = "<group>"; };
+		FR_779344507530 /* GoogleSymbolUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleSymbolUtilities.framework; path = Vendor/GoogleSymbolUtilities/Frameworks/frameworks/GoogleSymbolUtilities.framework; sourceTree = "<group>"; };
+		FR_781843868845 /* stp_card_unionpay_template_zh@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_zh@2x.png"; sourceTree = "<group>"; };
+		FR_787984517909 /* NSArray+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSArray+Stripe.h"; sourceTree = "<group>"; };
+		FR_791769030009 /* STPAspects.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAspects.h; sourceTree = "<group>"; };
+		FR_792688469879 /* STPMultipartFormDataPart.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPMultipartFormDataPart.m; sourceTree = "<group>"; };
+		FR_793899192763 /* STPUserInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPUserInformation.m; sourceTree = "<group>"; };
+		FR_798914995582 /* STPBundleLocator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBundleLocator.m; sourceTree = "<group>"; };
+		FR_799082704884 /* STPPaymentMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsViewController.h; sourceTree = "<group>"; };
+		FR_800273678048 /* StripeError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StripeError.m; sourceTree = "<group>"; };
+		FR_801026079927 /* STPPaymentCardTextFieldCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldCell.h; sourceTree = "<group>"; };
+		FR_802267686739 /* STPShippingMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodTableViewCell.h; sourceTree = "<group>"; };
+		FR_804401515869 /* stp_card_error@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error@3x.png"; sourceTree = "<group>"; };
+		FR_805065086362 /* STPWeakStrongMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPWeakStrongMacros.h; sourceTree = "<group>"; };
+		FR_805430750713 /* STPCardIOProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardIOProxy.m; sourceTree = "<group>"; };
+		FR_807037820303 /* STPAPIClient+ApplePay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+ApplePay.h"; sourceTree = "<group>"; };
+		FR_807603038020 /* stp_card_visa@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa@2x.png"; sourceTree = "<group>"; };
+		FR_808247114849 /* STPSourceRedirect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceRedirect.h; sourceTree = "<group>"; };
+		FR_809108791963 /* STPPaymentActivityIndicatorView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentActivityIndicatorView.h; sourceTree = "<group>"; };
+		FR_809630086871 /* STPCoreViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreViewController+Private.h"; sourceTree = "<group>"; };
+		FR_810335568173 /* stp_card_form_back@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_back@2x.png"; sourceTree = "<group>"; };
+		FR_813264579658 /* STPColorUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPColorUtils.m; sourceTree = "<group>"; };
+		FR_814877671763 /* PINOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperation.h; sourceTree = "<group>"; };
+		FR_818473893886 /* ios-app-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "ios-app-bin.a"; path = "libios-app-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_818474340164 /* stp_card_discover@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover@2x.png"; sourceTree = "<group>"; };
+		FR_819768356424 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		FR_821033470551 /* STPSourceReceiver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceReceiver.h; sourceTree = "<group>"; };
+		FR_825181478485 /* STPPaymentActivityIndicatorView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentActivityIndicatorView.h; sourceTree = "<group>"; };
+		FR_825690379672 /* stp_shipping_form@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_shipping_form@3x.png"; sourceTree = "<group>"; };
+		FR_826898134611 /* STPTelemetryClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTelemetryClient.h; sourceTree = "<group>"; };
+		FR_827299014426 /* STPSourceSEPADebitDetails.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceSEPADebitDetails.m; sourceTree = "<group>"; };
+		FR_827618709703 /* stp_card_discover_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_discover_template.png; sourceTree = "<group>"; };
+		FR_828376497251 /* STPCardValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardValidator.m; sourceTree = "<group>"; };
+		FR_830637254163 /* STPAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddress.h; sourceTree = "<group>"; };
+		FR_831107356712 /* STPBankAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccountParams.h; sourceTree = "<group>"; };
+		FR_838695088836 /* UIView+Stripe_SafeAreaBounds.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+Stripe_SafeAreaBounds.m"; sourceTree = "<group>"; };
+		FR_840244369229 /* AppIntent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppIntent.m; sourceTree = "<group>"; };
+		FR_842212741120 /* strings-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "strings-ext-bin.a"; path = "libstrings-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_843671643897 /* STPCardBrand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardBrand.h; sourceTree = "<group>"; };
+		FR_844946125614 /* Stripe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "Stripe-ios-9.0.a"; path = "libStripe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_845488816582 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		FR_847634122805 /* STPAPIClient+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+Private.h"; sourceTree = "<group>"; };
+		FR_847858510902 /* UINavigationBar+Stripe_Theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+Stripe_Theme.h"; sourceTree = "<group>"; };
+		FR_848452328362 /* STPToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPToken.h; sourceTree = "<group>"; };
+		FR_851662726671 /* stp_icon_checkmark@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_checkmark@2x.png"; sourceTree = "<group>"; };
+		FR_853966787131 /* STPAPIRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIRequest.h; sourceTree = "<group>"; };
+		FR_855134969525 /* STPTelemetryClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPTelemetryClient.m; sourceTree = "<group>"; };
+		FR_855762236329 /* HeaderLib-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "HeaderLib-ios-12.0.a"; path = "libHeaderLib-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_856633702404 /* STPAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddress.h; sourceTree = "<group>"; };
+		FR_857961905734 /* stp_icon_add@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_add@2x.png"; sourceTree = "<group>"; };
+		FR_858321172415 /* empty-main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "empty-main.m"; sourceTree = "<group>"; };
+		FR_859214955617 /* STPFile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFile.m; sourceTree = "<group>"; };
+		FR_859246040826 /* STPBankAccountParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPBankAccountParams+Private.h"; sourceTree = "<group>"; };
+		FR_860483718504 /* GoogleAppIndexingResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleAppIndexingResources.bundle; sourceTree = "<group>"; };
+		FR_861265882976 /* UIViewController+Stripe_NavigationItemProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_NavigationItemProxy.h"; sourceTree = "<group>"; };
+		FR_863786754985 /* UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_863899671502 /* STPAPIRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIRequest.h; sourceTree = "<group>"; };
+		FR_864958197976 /* STPEphemeralKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKey.h; sourceTree = "<group>"; };
+		FR_865157427735 /* STPPaymentMethodsInternalViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodsInternalViewController.m; sourceTree = "<group>"; };
+		FR_865857012183 /* STPSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSource.h; sourceTree = "<group>"; };
+		FR_868093412922 /* STPPaymentConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentConfiguration+Private.h"; sourceTree = "<group>"; };
+		FR_871480364449 /* STPBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBlocks.h; sourceTree = "<group>"; };
+		FR_872295844282 /* STPSourceParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceParams+Private.h"; sourceTree = "<group>"; };
+		FR_874886281442 /* PINCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINCache.m; sourceTree = "<group>"; };
+		FR_878039505509 /* stp_card_mastercard_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_mastercard_template.png; sourceTree = "<group>"; };
+		FR_879111094388 /* STPSource+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSource+Private.h"; sourceTree = "<group>"; };
+		FR_879635869993 /* UIViewController+Stripe_Promises.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_Promises.m"; sourceTree = "<group>"; };
+		FR_879680789012 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_880704464323 /* STPSourceCardDetails+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceCardDetails+Private.h"; sourceTree = "<group>"; };
+		FR_884447368899 /* stp_card_unionpay_template_en@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_en@3x.png"; sourceTree = "<group>"; };
+		FR_886839681304 /* stp_card_diners@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners@3x.png"; sourceTree = "<group>"; };
+		FR_887939645205 /* STPPaymentCardTextFieldCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextFieldCell.m; sourceTree = "<group>"; };
+		FR_888484860318 /* PINMemoryCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINMemoryCache.h; sourceTree = "<group>"; };
+		FR_890897390711 /* AppJerry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppJerry.m; sourceTree = "<group>"; };
+		FR_897166241393 /* STPEphemeralKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKey.h; sourceTree = "<group>"; };
+		FR_900054750708 /* STPBINRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBINRange.h; sourceTree = "<group>"; };
+		FR_901652225192 /* STPPaymentMethodsInternalViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsInternalViewController.h; sourceTree = "<group>"; };
+		FR_903513735268 /* STPPaymentCardTextFieldCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldCell.h; sourceTree = "<group>"; };
+		FR_903718557818 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.plug-in"; path = "Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_906505729587 /* UrlGetClasses-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; name = "UrlGetClasses-ios-12.0.a"; path = "libUrlGetClasses-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_906691198581 /* STPPaymentContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContext.h; sourceTree = "<group>"; };
+		FR_908317792274 /* STPAPIClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAPIClient.m; sourceTree = "<group>"; };
+		FR_910846099975 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_915238346456 /* STPMultipartFormDataPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataPart.h; sourceTree = "<group>"; };
+		FR_916661342534 /* UIViewController+Stripe_NavigationItemProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_NavigationItemProxy.m"; sourceTree = "<group>"; };
+		FR_918038203573 /* stp_icon_checkmark.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_icon_checkmark.png; sourceTree = "<group>"; };
+		FR_920849002660 /* STPPaymentConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentConfiguration.m; sourceTree = "<group>"; };
+		FR_921522766901 /* stp_card_jcb_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb_template@3x.png"; sourceTree = "<group>"; };
+		FR_922234055079 /* STPSourceVerification.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceVerification.m; sourceTree = "<group>"; };
+		FR_933371169343 /* UIViewController+Stripe_KeyboardAvoiding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_KeyboardAvoiding.h"; sourceTree = "<group>"; };
+		FR_947823834394 /* stp_card_unionpay_zh@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_zh@2x.png"; sourceTree = "<group>"; };
+		FR_952027055371 /* libUrlGetClasses-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libUrlGetClasses-ios-12.0.a"; sourceTree = "<group>"; };
+		FR_960264344136 /* PINOperationQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationQueue.h; sourceTree = "<group>"; };
+		FR_968277723020 /* libios-app-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-app-bin.a"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		FBP_24378941017 /* Frameworks */ = {
+		FBP_10706608252 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_591758609732 /* libios-ext-bin.a in Frameworks */,
+				BF_366356063932 /* libstrings-ext-bin.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_31419184477 /* Frameworks */ = {
+		FBP_16210182567 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_789294932168 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
-				BF_741290718883 /* libPINCache-Core-ios-9.0.a in Frameworks */,
-				BF_764139746955 /* libStripe-ios-9.0.a in Frameworks */,
-				BF_695166312425 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
-				BF_465924387016 /* GoogleSymbolUtilities.framework in Frameworks */,
-				BF_202713209090 /* libPINOperation-ios-9.0.a in Frameworks */,
-				BF_885742776305 /* GoogleAuthUtilities.framework in Frameworks */,
-				BF_626697178248 /* GoogleAppIndexing.framework in Frameworks */,
-				BF_339948089738 /* GoogleNetworkingUtilities.framework in Frameworks */,
+				BF_917870419091 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
+				BF_644495441626 /* libStripe-ios-9.0.a in Frameworks */,
+				BF_561780859195 /* libPINCache-Core-ios-9.0.a in Frameworks */,
+				BF_917711275756 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
+				BF_566061458534 /* GoogleNetworkingUtilities.framework in Frameworks */,
+				BF_152880658474 /* GoogleAppIndexing.framework in Frameworks */,
+				BF_462176714151 /* libPINOperation-ios-9.0.a in Frameworks */,
+				BF_416017100058 /* GoogleSymbolUtilities.framework in Frameworks */,
+				BF_610466688322 /* GoogleAuthUtilities.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_36181441897 /* Frameworks */ = {
+		FBP_20536363493 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_756048036715 /* libsiri-ext-bin.a in Frameworks */,
+				BF_818590191865 /* libios-ext-bin.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_44300245758 /* Frameworks */ = {
+		FBP_28774711835 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_614157202241 /* libPINCache-Arc-exception-safe-ios-11.3.a in Frameworks */,
-				BF_211849370502 /* GoogleSymbolUtilities.framework in Frameworks */,
-				BF_298426479289 /* GoogleAppIndexing.framework in Frameworks */,
-				BF_300982148222 /* GoogleNetworkingUtilities.framework in Frameworks */,
-				BF_184627840073 /* libPINOperation-ios-11.3.a in Frameworks */,
-				BF_831697474059 /* libPINCache-Core-ios-11.3.a in Frameworks */,
-				BF_471167991953 /* libUrlGetClasses-ios-11.3.a in Frameworks */,
-				BF_693631994031 /* GoogleAuthUtilities.framework in Frameworks */,
-				BF_176492720158 /* libios-app-bin.a in Frameworks */,
-				BF_644423025658 /* libStripe-ios-11.3.a in Frameworks */,
+				BF_555268818033 /* libsiri-ext-bin.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_58354672782 /* Frameworks */ = {
+		FBP_39458662484 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_794972634449 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
-				BF_333697809308 /* libPINCache-Core-ios-9.0.a in Frameworks */,
-				BF_730994754938 /* libStripe-ios-9.0.a in Frameworks */,
-				BF_780353267060 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
-				BF_342698057840 /* GoogleSymbolUtilities.framework in Frameworks */,
-				BF_878073784080 /* libPINOperation-ios-9.0.a in Frameworks */,
-				BF_580343450772 /* GoogleAuthUtilities.framework in Frameworks */,
-				BF_164244000470 /* GoogleAppIndexing.framework in Frameworks */,
-				BF_891178962083 /* GoogleNetworkingUtilities.framework in Frameworks */,
+				BF_549127057796 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
+				BF_685348128266 /* libStripe-ios-9.0.a in Frameworks */,
+				BF_745257428742 /* libPINCache-Core-ios-9.0.a in Frameworks */,
+				BF_626857746750 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
+				BF_264598445944 /* GoogleNetworkingUtilities.framework in Frameworks */,
+				BF_250725326080 /* GoogleAppIndexing.framework in Frameworks */,
+				BF_850628345573 /* libPINOperation-ios-9.0.a in Frameworks */,
+				BF_903765825652 /* GoogleSymbolUtilities.framework in Frameworks */,
+				BF_629239440212 /* GoogleAuthUtilities.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_87012950138 /* Frameworks */ = {
+		FBP_75795613548 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_903449840898 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
-				BF_571681387310 /* libPINCache-Core-ios-9.0.a in Frameworks */,
-				BF_405126167311 /* libStripe-ios-9.0.a in Frameworks */,
-				BF_650211204451 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
-				BF_255445591562 /* GoogleSymbolUtilities.framework in Frameworks */,
-				BF_875649997485 /* libPINOperation-ios-9.0.a in Frameworks */,
-				BF_737682176383 /* GoogleAuthUtilities.framework in Frameworks */,
-				BF_340672610509 /* GoogleAppIndexing.framework in Frameworks */,
-				BF_344635626378 /* GoogleNetworkingUtilities.framework in Frameworks */,
+				BF_885114134832 /* libPINCache-Arc-exception-safe-ios-12.0.a in Frameworks */,
+				BF_785207536242 /* libios-app-bin.a in Frameworks */,
+				BF_227521460820 /* GoogleNetworkingUtilities.framework in Frameworks */,
+				BF_207133615015 /* libStripe-ios-12.0.a in Frameworks */,
+				BF_909873506410 /* GoogleAuthUtilities.framework in Frameworks */,
+				BF_521256516347 /* libUrlGetClasses-ios-12.0.a in Frameworks */,
+				BF_689981672024 /* GoogleSymbolUtilities.framework in Frameworks */,
+				BF_561826517078 /* libPINOperation-ios-12.0.a in Frameworks */,
+				BF_435911882500 /* libPINCache-Core-ios-12.0.a in Frameworks */,
+				BF_147754211592 /* GoogleAppIndexing.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_91038982921 /* Frameworks */ = {
+		FBP_86378675498 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_722312868055 /* libstrings-ext-bin.a in Frameworks */,
+				BF_618163706615 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
+				BF_146371965091 /* libStripe-ios-9.0.a in Frameworks */,
+				BF_666902952524 /* libPINCache-Core-ios-9.0.a in Frameworks */,
+				BF_593076128533 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
+				BF_903654427761 /* GoogleNetworkingUtilities.framework in Frameworks */,
+				BF_740939883811 /* GoogleAppIndexing.framework in Frameworks */,
+				BF_232882297758 /* libPINOperation-ios-9.0.a in Frameworks */,
+				BF_583882935065 /* GoogleSymbolUtilities.framework in Frameworks */,
+				BF_483233437923 /* GoogleAuthUtilities.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		G_1032369705962 /* UnitTests */ = {
+		G_1111035576003 /* Images */ = {
 			isa = PBXGroup;
 			children = (
-				FR_166622418620 /* Tests.m */,
-				FR_447194245190 /* Tests2.m */,
+				FR_140562483639 /* stp_card_amex_template.png */,
+				FR_758612271558 /* stp_card_amex_template@2x.png */,
+				FR_468113573340 /* stp_card_amex_template@3x.png */,
+				FR_542306643416 /* stp_card_amex.png */,
+				FR_556956092926 /* stp_card_amex@2x.png */,
+				FR_295663962341 /* stp_card_amex@3x.png */,
+				FR_200668121419 /* stp_card_applepay.png */,
+				FR_196593282791 /* stp_card_applepay@2x.png */,
+				FR_716391505040 /* stp_card_applepay@3x.png */,
+				FR_134719527222 /* stp_card_cvc_amex.png */,
+				FR_754763453812 /* stp_card_cvc_amex@2x.png */,
+				FR_770241236915 /* stp_card_cvc_amex@3x.png */,
+				FR_454721095065 /* stp_card_cvc.png */,
+				FR_324415420402 /* stp_card_cvc@2x.png */,
+				FR_353412325098 /* stp_card_cvc@3x.png */,
+				FR_608901290361 /* stp_card_diners_template.png */,
+				FR_738136358357 /* stp_card_diners_template@2x.png */,
+				FR_421043145734 /* stp_card_diners_template@3x.png */,
+				FR_524791267555 /* stp_card_diners.png */,
+				FR_107323960575 /* stp_card_diners@2x.png */,
+				FR_886839681304 /* stp_card_diners@3x.png */,
+				FR_827618709703 /* stp_card_discover_template.png */,
+				FR_142523824475 /* stp_card_discover_template@2x.png */,
+				FR_705928698620 /* stp_card_discover_template@3x.png */,
+				FR_475562073492 /* stp_card_discover.png */,
+				FR_818474340164 /* stp_card_discover@2x.png */,
+				FR_363658341124 /* stp_card_discover@3x.png */,
+				FR_453324145384 /* stp_card_error_amex.png */,
+				FR_574597020760 /* stp_card_error_amex@2x.png */,
+				FR_456109311282 /* stp_card_error_amex@3x.png */,
+				FR_721448149799 /* stp_card_error.png */,
+				FR_260626407590 /* stp_card_error@2x.png */,
+				FR_804401515869 /* stp_card_error@3x.png */,
+				FR_363247867339 /* stp_card_form_back.png */,
+				FR_810335568173 /* stp_card_form_back@2x.png */,
+				FR_325521637118 /* stp_card_form_back@3x.png */,
+				FR_387226535794 /* stp_card_form_front.png */,
+				FR_484208255089 /* stp_card_form_front@2x.png */,
+				FR_324426164016 /* stp_card_form_front@3x.png */,
+				FR_779248810941 /* stp_card_jcb_template.png */,
+				FR_755922952676 /* stp_card_jcb_template@2x.png */,
+				FR_921522766901 /* stp_card_jcb_template@3x.png */,
+				FR_242554983927 /* stp_card_jcb.png */,
+				FR_492175780721 /* stp_card_jcb@2x.png */,
+				FR_453447722637 /* stp_card_jcb@3x.png */,
+				FR_878039505509 /* stp_card_mastercard_template.png */,
+				FR_232572251428 /* stp_card_mastercard_template@2x.png */,
+				FR_465416715992 /* stp_card_mastercard_template@3x.png */,
+				FR_423603962795 /* stp_card_mastercard.png */,
+				FR_470930712391 /* stp_card_mastercard@2x.png */,
+				FR_127475428263 /* stp_card_mastercard@3x.png */,
+				FR_340610195773 /* stp_card_unionpay_en.png */,
+				FR_205650942905 /* stp_card_unionpay_en@2x.png */,
+				FR_362535988676 /* stp_card_unionpay_en@3x.png */,
+				FR_393687196501 /* stp_card_unionpay_template_en.png */,
+				FR_542047769331 /* stp_card_unionpay_template_en@2x.png */,
+				FR_884447368899 /* stp_card_unionpay_template_en@3x.png */,
+				FR_443910781375 /* stp_card_unionpay_template_zh.png */,
+				FR_781843868845 /* stp_card_unionpay_template_zh@2x.png */,
+				FR_737821215910 /* stp_card_unionpay_template_zh@3x.png */,
+				FR_128201504065 /* stp_card_unionpay_zh.png */,
+				FR_947823834394 /* stp_card_unionpay_zh@2x.png */,
+				FR_212508126291 /* stp_card_unionpay_zh@3x.png */,
+				FR_622754080338 /* stp_card_unknown.png */,
+				FR_435282719354 /* stp_card_unknown@2x.png */,
+				FR_183338914811 /* stp_card_unknown@3x.png */,
+				FR_171399986210 /* stp_card_visa_template.png */,
+				FR_233098522244 /* stp_card_visa_template@2x.png */,
+				FR_772315109974 /* stp_card_visa_template@3x.png */,
+				FR_336676787389 /* stp_card_visa.png */,
+				FR_807603038020 /* stp_card_visa@2x.png */,
+				FR_394612788029 /* stp_card_visa@3x.png */,
+				FR_739176942134 /* stp_icon_add.png */,
+				FR_857961905734 /* stp_icon_add@2x.png */,
+				FR_481907633182 /* stp_icon_add@3x.png */,
+				FR_918038203573 /* stp_icon_checkmark.png */,
+				FR_851662726671 /* stp_icon_checkmark@2x.png */,
+				FR_649006375359 /* stp_icon_checkmark@3x.png */,
+				FR_153688961655 /* stp_shipping_form.png */,
+				FR_596924801474 /* stp_shipping_form@2x.png */,
+				FR_825690379672 /* stp_shipping_form@3x.png */,
+				FR_265863572154 /* stp_test_upload_image.jpeg */,
 			);
-			path = UnitTests;
+			path = Images;
 			sourceTree = "<group>";
 		};
-		G_1087341578693 /* PINCache */ = {
+		G_1132957408482 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				G_1528248800572 /* Source */,
-				G_2656848232791 /* pod_support */,
-			);
-			path = PINCache;
-			sourceTree = "<group>";
-		};
-		G_1437296305341 /* XCHammerAssets */ = {
-			isa = PBXGroup;
-			children = (
-				FR_104204687231 /* Stub.m */,
-			);
-			path = XCHammerAssets;
-			sourceTree = "<group>";
-		};
-		G_1528248800572 /* Source */ = {
-			isa = PBXGroup;
-			children = (
-				FR_201151680337 /* PINCache.h */,
-				"FR_201151680337-1" /* PINCache.m */,
-				FR_192292988800 /* PINCacheMacros.h */,
-				FR_642952555060 /* PINCacheObjectSubscripting.h */,
-				FR_476338718337 /* PINCaching.h */,
-				"FR_611231413868-1" /* PINDiskCache.h */,
-				FR_611231413868 /* PINDiskCache.m */,
-				FR_479483572541 /* PINMemoryCache.h */,
-				"FR_479483572541-1" /* PINMemoryCache.m */,
-			);
-			path = Source;
-			sourceTree = "<group>";
-		};
-		G_1726445755096 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				"FR_501274904079-1" /* AppIntent.h */,
-				FR_501274904079 /* AppIntent.m */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
-		G_1763201774618 /* StringsExtension */ = {
-			isa = PBXGroup;
-			children = (
-				G_4489656136222 /* Resources */,
-				G_4350420135899 /* Sources */,
-			);
-			path = StringsExtension;
-			sourceTree = "<group>";
-		};
-		G_1884487984427 /* HeaderLib */ = {
-			isa = PBXGroup;
-			children = (
-				FR_729302817175 /* HeaderLib.hpp */,
-			);
-			path = HeaderLib;
-			sourceTree = "<group>";
-		};
-		G_1952740716080 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				FR_353990188355 /* GoogleAppIndexing.framework */,
-				FR_358060139028 /* GoogleAuthUtilities.framework */,
-				FR_536943478702 /* GoogleNetworkingUtilities.framework */,
-				FR_577405838685 /* GoogleSymbolUtilities.framework */,
-				FR_413373192620 /* libPINCache-Arc-exception-safe-ios-11.3.a */,
-				FR_205813692671 /* libPINCache-Arc-exception-safe-ios-9.0.a */,
-				FR_683369487726 /* libPINCache-Core-ios-11.3.a */,
-				FR_595618312739 /* libPINCache-Core-ios-9.0.a */,
-				FR_578888125127 /* libPINOperation-ios-11.3.a */,
-				FR_742895067730 /* libPINOperation-ios-9.0.a */,
-				FR_334313231181 /* libStripe-ios-11.3.a */,
-				FR_518266894407 /* libStripe-ios-9.0.a */,
-				FR_262777658410 /* libUrlGetClasses-ios-11.3.a */,
-				FR_147245088243 /* libUrlGetClasses-ios-9.0.a */,
-				FR_610748361952 /* libios-app-bin.a */,
-				FR_107900841834 /* libios-ext-bin.a */,
-				FR_169594879022 /* libsiri-ext-bin.a */,
-				FR_666369934619 /* libstrings-ext-bin.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		G_2193221592566 /* GoogleAppIndexing */ = {
-			isa = PBXGroup;
-			children = (
-				G_6558703128995 /* Resources */,
-			);
-			path = GoogleAppIndexing;
-			sourceTree = "<group>";
-		};
-		G_2656848232791 /* pod_support */ = {
-			isa = PBXGroup;
-			children = (
-				G_5357193827637 /* Headers */,
-			);
-			path = pod_support;
-			sourceTree = "<group>";
-		};
-		G_2659861901976 /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				G_4547529336777 /* Public */,
-			);
-			path = Headers;
-			sourceTree = "<group>";
-		};
-		G_2673067410495 /* Stripe */ = {
-			isa = PBXGroup;
-			children = (
-				G_8795405194687 /* PublicHeaders */,
-				G_5106238260050 /* Resources */,
-				FR_448345672017 /* FABKitProtocol.h */,
-				FR_694358125905 /* Fabric+FABKits.h */,
-				FR_824435249884 /* Fabric.h */,
-				"FR_857114782727-1" /* NSArray+Stripe.h */,
-				FR_857114782727 /* NSArray+Stripe.m */,
-				FR_319111102880 /* NSBundle+Stripe_AppName.h */,
-				"FR_319111102880-1" /* NSBundle+Stripe_AppName.m */,
-				"FR_856763993418-1" /* NSCharacterSet+Stripe.h */,
-				FR_856763993418 /* NSCharacterSet+Stripe.m */,
-				FR_485300186976 /* NSDecimalNumber+Stripe_Currency.h */,
-				FR_485300186977 /* NSDecimalNumber+Stripe_Currency.m */,
-				FR_161131115028 /* NSDictionary+Stripe.h */,
-				"FR_161131115028-1" /* NSDictionary+Stripe.m */,
-				FR_136387137481 /* NSError+Stripe.h */,
-				"FR_136387137481-1" /* NSError+Stripe.m */,
-				FR_829657687624 /* NSMutableURLRequest+Stripe.h */,
-				FR_829657687628 /* NSMutableURLRequest+Stripe.m */,
-				FR_383186939534 /* NSString+Stripe.h */,
-				"FR_383186939534-1" /* NSString+Stripe.m */,
-				FR_490229470460 /* NSURLComponents+Stripe.h */,
-				"FR_490229470460-1" /* NSURLComponents+Stripe.m */,
-				"FR_114615500587-1" /* PKPayment+Stripe.h */,
-				FR_114615500587 /* PKPayment+Stripe.m */,
-				"FR_344823093939-1" /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */,
-				FR_344823093939 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */,
-				FR_308451946297 /* STPAPIClient+ApplePay.m */,
-				FR_871742726913 /* STPAPIClient+Private.h */,
-				FR_729837640388 /* STPAPIClient.m */,
-				FR_744571361438 /* STPAPIRequest.h */,
-				"FR_744571361438-1" /* STPAPIRequest.m */,
-				FR_244377844184 /* STPAddCardViewController+Private.h */,
-				FR_670019473135 /* STPAddCardViewController.m */,
-				FR_207298251625 /* STPAddress.m */,
-				FR_221232691705 /* STPAddressFieldTableViewCell.h */,
-				FR_221232691707 /* STPAddressFieldTableViewCell.m */,
-				FR_650044337253 /* STPAddressViewModel.h */,
-				"FR_650044337253-1" /* STPAddressViewModel.m */,
-				"FR_140569352166-1" /* STPAnalyticsClient.h */,
-				FR_140569352166 /* STPAnalyticsClient.m */,
-				FR_543365396645 /* STPApplePayPaymentMethod.m */,
-				"FR_225093974291-1" /* STPAspects.h */,
-				FR_225093974291 /* STPAspects.m */,
-				"FR_670697261324-1" /* STPBINRange.h */,
-				FR_670697261324 /* STPBINRange.m */,
-				FR_520364995872 /* STPBankAccount.m */,
-				FR_237398221790 /* STPBankAccountParams+Private.h */,
-				FR_740003049424 /* STPBankAccountParams.m */,
-				"FR_433875149495-1" /* STPBundleLocator.h */,
-				FR_433875149495 /* STPBundleLocator.m */,
-				FR_473219612446 /* STPCard+Private.h */,
-				FR_371561332475 /* STPCard.m */,
-				FR_803655950633 /* STPCardIOProxy.h */,
-				"FR_803655950633-1" /* STPCardIOProxy.m */,
-				FR_983798454349 /* STPCardParams.m */,
-				FR_716273040248 /* STPCardValidator.m */,
-				FR_383188188562 /* STPCategoryLoader.h */,
-				"FR_383188188562-1" /* STPCategoryLoader.m */,
-				"FR_573822806939-1" /* STPColorUtils.h */,
-				FR_573822806939 /* STPColorUtils.m */,
-				FR_795421255062 /* STPConnectAccountParams.m */,
-				FR_813949290948 /* STPCoreScrollViewController+Private.h */,
-				FR_651201787786 /* STPCoreScrollViewController.m */,
-				FR_175169517365 /* STPCoreTableViewController+Private.h */,
-				FR_175464452737 /* STPCoreTableViewController.m */,
-				FR_563291007487 /* STPCoreViewController+Private.h */,
-				FR_547792905644 /* STPCoreViewController.m */,
-				FR_440606856915 /* STPCustomer+Private.h */,
-				"FR_180708382140-1" /* STPCustomer+SourceTuple.h */,
-				FR_180708382140 /* STPCustomer+SourceTuple.m */,
-				FR_775444959222 /* STPCustomer.m */,
-				FR_764679247202 /* STPCustomerContext.m */,
-				FR_240384147847 /* STPDelegateProxy.h */,
-				FR_240384147848 /* STPDelegateProxy.m */,
-				FR_863295554989 /* STPDispatchFunctions.h */,
-				FR_863295555018 /* STPDispatchFunctions.m */,
-				FR_820602908989 /* STPEmailAddressValidator.h */,
-				FR_820602908988 /* STPEmailAddressValidator.m */,
-				"FR_118429332705-1" /* STPEphemeralKey.h */,
-				FR_118429332705 /* STPEphemeralKey.m */,
-				"FR_170908667679-1" /* STPEphemeralKeyManager.h */,
-				FR_170908667679 /* STPEphemeralKeyManager.m */,
-				FR_627505725116 /* STPFile+Private.h */,
-				FR_227675484416 /* STPFile.m */,
-				"FR_375651978668-1" /* STPFormEncoder.h */,
-				FR_375651978668 /* STPFormEncoder.m */,
-				FR_118015691316 /* STPFormTextField.h */,
-				"FR_118015691316-1" /* STPFormTextField.m */,
-				FR_234015152924 /* STPImageLibrary+Private.h */,
-				FR_314016843022 /* STPImageLibrary.m */,
-				FR_986136575822 /* STPInternalAPIResponseDecodable.h */,
-				FR_863581397541 /* STPLegalEntityParams.m */,
-				FR_374398035812 /* STPLocalizationUtils.h */,
-				FR_374398035813 /* STPLocalizationUtils.m */,
-				FR_344043994904 /* STPMultipartFormDataEncoder.h */,
-				FR_344043994903 /* STPMultipartFormDataEncoder.m */,
-				"FR_430199726738-1" /* STPMultipartFormDataPart.h */,
-				FR_430199726738 /* STPMultipartFormDataPart.m */,
-				FR_847087900331 /* STPPaymentActivityIndicatorView.m */,
-				FR_680787884007 /* STPPaymentCardTextField+Private.h */,
-				FR_438132085983 /* STPPaymentCardTextField.m */,
-				FR_786851096828 /* STPPaymentCardTextFieldCell.h */,
-				FR_786851096829 /* STPPaymentCardTextFieldCell.m */,
-				FR_352992724052 /* STPPaymentCardTextFieldViewModel.h */,
-				FR_352992722793 /* STPPaymentCardTextFieldViewModel.m */,
-				FR_226012233892 /* STPPaymentConfiguration+Private.h */,
-				FR_454291026560 /* STPPaymentConfiguration.m */,
-				FR_544868232734 /* STPPaymentContext+Private.h */,
-				FR_466427502225 /* STPPaymentContext.m */,
-				FR_393824443137 /* STPPaymentContextAmountModel.h */,
-				FR_393824443136 /* STPPaymentContextAmountModel.m */,
-				FR_426141564195 /* STPPaymentMethodTableViewCell.h */,
-				FR_426141564192 /* STPPaymentMethodTableViewCell.m */,
-				"FR_318471428702-1" /* STPPaymentMethodTuple.h */,
-				FR_318471428702 /* STPPaymentMethodTuple.m */,
-				FR_303088832029 /* STPPaymentMethodsInternalViewController.h */,
-				FR_303088826339 /* STPPaymentMethodsInternalViewController.m */,
-				FR_600589277732 /* STPPaymentMethodsViewController+Private.h */,
-				FR_394482207665 /* STPPaymentMethodsViewController.m */,
-				FR_149668560898 /* STPPaymentResult.m */,
-				"FR_845699426889-1" /* STPPhoneNumberValidator.h */,
-				FR_845699426889 /* STPPhoneNumberValidator.m */,
-				"FR_181346025846-1" /* STPPostalCodeValidator.h */,
-				FR_181346025846 /* STPPostalCodeValidator.m */,
-				FR_177669650679 /* STPPromise.h */,
-				"FR_177669650679-1" /* STPPromise.m */,
-				FR_522111507539 /* STPRedirectContext.m */,
-				FR_888449823097 /* STPSectionHeaderView.h */,
-				"FR_888449823097-1" /* STPSectionHeaderView.m */,
-				FR_744666232521 /* STPShippingAddressViewController.m */,
-				FR_805980394109 /* STPShippingMethodTableViewCell.h */,
-				FR_805980394107 /* STPShippingMethodTableViewCell.m */,
-				FR_190239098217 /* STPShippingMethodsViewController.h */,
-				FR_190239098214 /* STPShippingMethodsViewController.m */,
-				FR_327069580859 /* STPSource+Private.h */,
-				FR_235441027813 /* STPSource.m */,
-				FR_537648693821 /* STPSourceCardDetails+Private.h */,
-				FR_689735932342 /* STPSourceCardDetails.m */,
-				FR_761061955139 /* STPSourceOwner.m */,
-				FR_778931539736 /* STPSourceParams+Private.h */,
-				FR_748997447722 /* STPSourceParams.m */,
-				FR_747790741358 /* STPSourcePoller.h */,
-				"FR_747790741358-1" /* STPSourcePoller.m */,
-				FR_793128565775 /* STPSourceReceiver.m */,
-				FR_891417925643 /* STPSourceRedirect+Private.h */,
-				FR_770817608373 /* STPSourceRedirect.m */,
-				FR_639248881296 /* STPSourceSEPADebitDetails.m */,
-				FR_774763671036 /* STPSourceVerification+Private.h */,
-				FR_431507780270 /* STPSourceVerification.m */,
-				FR_401789639718 /* STPStringUtils.h */,
-				"FR_401789639718-1" /* STPStringUtils.m */,
-				FR_793362014210 /* STPSwitchTableViewCell.h */,
-				"FR_793362014210-1" /* STPSwitchTableViewCell.m */,
-				"FR_836284080868-1" /* STPTelemetryClient.h */,
-				FR_836284080868 /* STPTelemetryClient.m */,
-				FR_218958582687 /* STPTheme.m */,
-				FR_538535395111 /* STPToken.m */,
-				"FR_417020094137-1" /* STPURLCallbackHandler.h */,
-				FR_417020094137 /* STPURLCallbackHandler.m */,
-				FR_634891479805 /* STPUserInformation.m */,
-				FR_397431763487 /* STPValidatedTextField.h */,
-				"FR_397431763487-1" /* STPValidatedTextField.m */,
-				FR_203274481819 /* STPWeakStrongMacros.h */,
-				FR_276366160308 /* StripeError.m */,
-				FR_266252253452 /* UIBarButtonItem+Stripe.h */,
-				"FR_266252253452-1" /* UIBarButtonItem+Stripe.m */,
-				FR_171962769898 /* UIImage+Stripe.h */,
-				"FR_171962769898-1" /* UIImage+Stripe.m */,
-				FR_486615080111 /* UINavigationBar+Stripe_Theme.m */,
-				FR_746622612454 /* UINavigationController+Stripe_Completion.h */,
-				FR_746622613527 /* UINavigationController+Stripe_Completion.m */,
-				FR_882551670748 /* UITableViewCell+Stripe_Borders.h */,
-				FR_882551670747 /* UITableViewCell+Stripe_Borders.m */,
-				FR_851062106152 /* UIToolbar+Stripe_InputAccessory.h */,
-				FR_851062106151 /* UIToolbar+Stripe_InputAccessory.m */,
-				FR_270060349354 /* UIView+Stripe_FirstResponder.h */,
-				"FR_270060349354-1" /* UIView+Stripe_FirstResponder.m */,
-				FR_394531061746 /* UIView+Stripe_SafeAreaBounds.h */,
-				"FR_394531061746-1" /* UIView+Stripe_SafeAreaBounds.m */,
-				FR_784978929968 /* UIViewController+Stripe_KeyboardAvoiding.h */,
-				FR_784978928035 /* UIViewController+Stripe_KeyboardAvoiding.m */,
-				"FR_451065136063-1" /* UIViewController+Stripe_NavigationItemProxy.h */,
-				FR_451065136063 /* UIViewController+Stripe_NavigationItemProxy.m */,
-				"FR_866814615747-1" /* UIViewController+Stripe_ParentViewController.h */,
-				FR_866814615747 /* UIViewController+Stripe_ParentViewController.m */,
-				FR_904866835750 /* UIViewController+Stripe_Promises.h */,
-				FR_904866835747 /* UIViewController+Stripe_Promises.m */,
-			);
-			path = Stripe;
-			sourceTree = "<group>";
-		};
-		G_2699493850274 /* UrlGet */ = {
-			isa = PBXGroup;
-			children = (
-				FR_841504889253 /* AppDelegate.h */,
-				FR_841504889387 /* AppDelegate.m */,
-				FR_454823234837 /* NoArc.m */,
-				FR_282022996649 /* Some.cc */,
-				FR_272405693051 /* Some.hpp */,
-				FR_100219285940 /* UrlGet-Info.plist */,
-				FR_761662219184 /* UrlGetViewController.h */,
-				"FR_761662219184-1" /* UrlGetViewController.m */,
-				FR_887010092861 /* UrlGetViewController.xib */,
-				FR_388157799616 /* main.m */,
-			);
-			path = UrlGet;
-			sourceTree = "<group>";
-		};
-		G_3432844277138 /* Stripe */ = {
-			isa = PBXGroup;
-			children = (
-				G_2673067410495 /* Stripe */,
-				G_5035179540425 /* pod_support */,
-			);
-			path = Stripe;
-			sourceTree = "<group>";
-		};
-		G_4015250067530 /* PINOperation */ = {
-			isa = PBXGroup;
-			children = (
-				G_6309115779713 /* Source */,
-				G_7029414687469 /* pod_support */,
-			);
-			path = PINOperation;
-			sourceTree = "<group>";
-		};
-		G_4350420135899 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				FR_720345196462 /* AppJerry.h */,
-				"FR_720345196462-1" /* AppJerry.m */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
-		G_4418938681710 /* ShareExtension */ = {
-			isa = PBXGroup;
-			children = (
-				FR_914453841196 /* ShareExtension-Info.plist */,
-			);
-			path = ShareExtension;
-			sourceTree = "<group>";
-		};
-		G_4430024575855 /* ios-app */ = {
-			isa = PBXGroup;
-			children = (
-				G_1884487984427 /* HeaderLib */,
-				G_4418938681710 /* ShareExtension */,
-				G_8746163756724 /* SiriExtension */,
-				G_1763201774618 /* StringsExtension */,
-				G_1032369705962 /* UnitTests */,
-				G_2699493850274 /* UrlGet */,
-				FR_221764191289 /* Diags.xcconfig */,
-				FR_838972687587 /* empty-main.m */,
-			);
-			path = "ios-app";
-			sourceTree = "<group>";
-		};
-		G_4489656136222 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				G_8945623286968 /* Localization */,
-				FR_575999326641 /* StringsExtension-Info.plist */,
+				G_1111035576003 /* Images */,
+				G_3643327322604 /* Localizations */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		G_4547529336777 /* Public */ = {
+		G_1187345590366 /* pod_support */ = {
 			isa = PBXGroup;
 			children = (
-				G_6697764287486 /* PINOperation */,
-			);
-			path = Public;
-			sourceTree = "<group>";
-		};
-		G_4793969390202 /* Vendor */ = {
-			isa = PBXGroup;
-			children = (
-				G_2193221592566 /* GoogleAppIndexing */,
-				G_1087341578693 /* PINCache */,
-				G_4015250067530 /* PINOperation */,
-				G_3432844277138 /* Stripe */,
-			);
-			path = Vendor;
-			sourceTree = "<group>";
-		};
-		G_5035179540425 /* pod_support */ = {
-			isa = PBXGroup;
-			children = (
-				G_5165721655557 /* Headers */,
+				G_4013559502754 /* Headers */,
 			);
 			path = pod_support;
 			sourceTree = "<group>";
 		};
-		G_5106238260050 /* Resources */ = {
+		G_1483785753565 /* UrlGet.xcodeproj */ = {
 			isa = PBXGroup;
 			children = (
-				G_8972043729317 /* Images */,
-				G_6159393876080 /* Localizations */,
+				G_6346944914571 /* XCHammerAssets */,
 			);
-			path = Resources;
+			path = UrlGet.xcodeproj;
 			sourceTree = "<group>";
 		};
-		G_5114366727170 /* Public */ = {
+		G_1529740786880 /* Localization */ = {
 			isa = PBXGroup;
 			children = (
-				G_5493855104854 /* PINCache */,
-			);
-			path = Public;
-			sourceTree = "<group>";
-		};
-		G_5165721655557 /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				G_8601076638037 /* Public */,
-			);
-			path = Headers;
-			sourceTree = "<group>";
-		};
-		G_5357193827637 /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				G_5114366727170 /* Public */,
-			);
-			path = Headers;
-			sourceTree = "<group>";
-		};
-		G_5493855104854 /* PINCache */ = {
-			isa = PBXGroup;
-			children = (
-				FR_525936809580 /* PINCache.h */,
-				FR_674978004924 /* PINCacheMacros.h */,
-				FR_744357543627 /* PINCacheObjectSubscripting.h */,
-				FR_680138288521 /* PINCaching.h */,
-				FR_584380253982 /* PINDiskCache.h */,
-				FR_328574352852 /* PINMemoryCache.h */,
-			);
-			path = PINCache;
-			sourceTree = "<group>";
-		};
-		G_5677173492125 /* Stripe */ = {
-			isa = PBXGroup;
-			children = (
-				FR_387477859828 /* FABKitProtocol.h */,
-				FR_387879201639 /* Fabric+FABKits.h */,
-				FR_772386701230 /* Fabric.h */,
-				FR_697115907292 /* FauxPasAnnotations.h */,
-				FR_699522203998 /* NSArray+Stripe.h */,
-				FR_367740908522 /* NSBundle+Stripe_AppName.h */,
-				FR_436439106628 /* NSCharacterSet+Stripe.h */,
-				FR_747893419826 /* NSDecimalNumber+Stripe_Currency.h */,
-				FR_683299749236 /* NSDictionary+Stripe.h */,
-				FR_303363389556 /* NSError+Stripe.h */,
-				FR_617610467620 /* NSMutableURLRequest+Stripe.h */,
-				FR_546285993684 /* NSString+Stripe.h */,
-				FR_100119553883 /* NSURLComponents+Stripe.h */,
-				FR_168416049633 /* PKPayment+Stripe.h */,
-				FR_515110400273 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */,
-				FR_739869940011 /* STPAPIClient+ApplePay.h */,
-				FR_752684654079 /* STPAPIClient+Private.h */,
-				FR_514597362078 /* STPAPIClient.h */,
-				FR_504279331501 /* STPAPIRequest.h */,
-				FR_454126136560 /* STPAPIResponseDecodable.h */,
-				FR_737799052203 /* STPAddCardViewController+Private.h */,
-				FR_618474416247 /* STPAddCardViewController.h */,
-				FR_823402288931 /* STPAddress.h */,
-				FR_691297741334 /* STPAddressFieldTableViewCell.h */,
-				FR_346842595418 /* STPAddressViewModel.h */,
-				FR_411337456535 /* STPAnalyticsClient.h */,
-				FR_193256557604 /* STPApplePayPaymentMethod.h */,
-				FR_606586344904 /* STPAspects.h */,
-				FR_631274162632 /* STPBINRange.h */,
-				FR_411830352510 /* STPBackendAPIAdapter.h */,
-				FR_135608655768 /* STPBankAccount.h */,
-				FR_282440445482 /* STPBankAccountParams+Private.h */,
-				FR_778052571267 /* STPBankAccountParams.h */,
-				FR_544048132697 /* STPBlocks.h */,
-				FR_392500181869 /* STPBundleLocator.h */,
-				FR_655732831542 /* STPCard+Private.h */,
-				FR_309446203354 /* STPCard.h */,
-				FR_416552303869 /* STPCardBrand.h */,
-				FR_720729207925 /* STPCardIOProxy.h */,
-				FR_555038450084 /* STPCardParams.h */,
-				FR_518632870935 /* STPCardValidationState.h */,
-				FR_141732336605 /* STPCardValidator.h */,
-				FR_385860430238 /* STPCategoryLoader.h */,
-				FR_493781913276 /* STPColorUtils.h */,
-				FR_911085306196 /* STPConnectAccountParams.h */,
-				FR_149344760381 /* STPCoreScrollViewController+Private.h */,
-				FR_506863260541 /* STPCoreScrollViewController.h */,
-				FR_779405691145 /* STPCoreTableViewController+Private.h */,
-				FR_212529072788 /* STPCoreTableViewController.h */,
-				FR_727895182634 /* STPCoreViewController+Private.h */,
-				FR_905090839392 /* STPCoreViewController.h */,
-				FR_519916175206 /* STPCustomer+Private.h */,
-				FR_271701757351 /* STPCustomer+SourceTuple.h */,
-				FR_897080895086 /* STPCustomer.h */,
-				FR_388629378203 /* STPCustomerContext.h */,
-				FR_809418927836 /* STPDelegateProxy.h */,
-				FR_891431900870 /* STPDispatchFunctions.h */,
-				FR_657046115910 /* STPEmailAddressValidator.h */,
-				FR_200260125720 /* STPEphemeralKey.h */,
-				FR_215562581198 /* STPEphemeralKeyManager.h */,
-				FR_468896292749 /* STPEphemeralKeyProvider.h */,
-				FR_862049125356 /* STPFile+Private.h */,
-				FR_903454413342 /* STPFile.h */,
-				FR_380861112100 /* STPFormEncodable.h */,
-				FR_135654520087 /* STPFormEncoder.h */,
-				FR_920174354034 /* STPFormTextField.h */,
-				FR_838755216449 /* STPImageLibrary+Private.h */,
-				FR_573665251373 /* STPImageLibrary.h */,
-				FR_398400160687 /* STPInternalAPIResponseDecodable.h */,
-				FR_697405215088 /* STPLegalEntityParams.h */,
-				FR_865850458143 /* STPLocalizationUtils.h */,
-				FR_266195411392 /* STPMultipartFormDataEncoder.h */,
-				FR_311576797096 /* STPMultipartFormDataPart.h */,
-				FR_573019928512 /* STPPaymentActivityIndicatorView.h */,
-				FR_376986173380 /* STPPaymentCardTextField+Private.h */,
-				FR_564276906433 /* STPPaymentCardTextField.h */,
-				FR_504172386443 /* STPPaymentCardTextFieldCell.h */,
-				FR_790877768775 /* STPPaymentCardTextFieldViewModel.h */,
-				FR_763956267392 /* STPPaymentConfiguration+Private.h */,
-				FR_301377298368 /* STPPaymentConfiguration.h */,
-				FR_616663993966 /* STPPaymentContext+Private.h */,
-				FR_302600842104 /* STPPaymentContext.h */,
-				FR_661735356868 /* STPPaymentContextAmountModel.h */,
-				FR_606866437089 /* STPPaymentMethod.h */,
-				FR_529018358997 /* STPPaymentMethodTableViewCell.h */,
-				FR_709442092021 /* STPPaymentMethodTuple.h */,
-				FR_697092322085 /* STPPaymentMethodsInternalViewController.h */,
-				FR_203734164041 /* STPPaymentMethodsViewController+Private.h */,
-				FR_305934251603 /* STPPaymentMethodsViewController.h */,
-				FR_609969202553 /* STPPaymentResult.h */,
-				FR_760644560579 /* STPPhoneNumberValidator.h */,
-				FR_210015125307 /* STPPostalCodeValidator.h */,
-				FR_560961278475 /* STPPromise.h */,
-				FR_460374501185 /* STPRedirectContext.h */,
-				FR_284380484049 /* STPSectionHeaderView.h */,
-				FR_661294188967 /* STPShippingAddressViewController.h */,
-				FR_651430382944 /* STPShippingMethodTableViewCell.h */,
-				FR_669064331373 /* STPShippingMethodsViewController.h */,
-				FR_275055915589 /* STPSource+Private.h */,
-				FR_489565775328 /* STPSource.h */,
-				FR_708756170642 /* STPSourceCardDetails+Private.h */,
-				FR_160370391416 /* STPSourceCardDetails.h */,
-				FR_326429966766 /* STPSourceEnums.h */,
-				FR_326473329617 /* STPSourceOwner.h */,
-				FR_341536377834 /* STPSourceParams+Private.h */,
-				FR_828800361135 /* STPSourceParams.h */,
-				FR_828784758374 /* STPSourcePoller.h */,
-				FR_407393141614 /* STPSourceProtocol.h */,
-				FR_349373308093 /* STPSourceReceiver.h */,
-				FR_808039309519 /* STPSourceRedirect+Private.h */,
-				FR_357921302656 /* STPSourceRedirect.h */,
-				FR_283825756115 /* STPSourceSEPADebitDetails.h */,
-				FR_347917955852 /* STPSourceVerification+Private.h */,
-				FR_458863902474 /* STPSourceVerification.h */,
-				FR_895047324232 /* STPStringUtils.h */,
-				FR_756124038298 /* STPSwitchTableViewCell.h */,
-				FR_859356790791 /* STPTelemetryClient.h */,
-				FR_780452303071 /* STPTheme.h */,
-				FR_582257680537 /* STPToken.h */,
-				FR_676905157532 /* STPURLCallbackHandler.h */,
-				FR_582943901244 /* STPUserInformation.h */,
-				FR_365229780069 /* STPValidatedTextField.h */,
-				FR_117348292070 /* STPWeakStrongMacros.h */,
-				FR_714908972385 /* Stripe.h */,
-				FR_618722400902 /* StripeError.h */,
-				FR_753050319742 /* UIBarButtonItem+Stripe.h */,
-				FR_307274708587 /* UIImage+Stripe.h */,
-				FR_713747347031 /* UINavigationBar+Stripe_Theme.h */,
-				FR_179612585631 /* UINavigationController+Stripe_Completion.h */,
-				FR_474473428077 /* UITableViewCell+Stripe_Borders.h */,
-				FR_265776775943 /* UIToolbar+Stripe_InputAccessory.h */,
-				FR_474857769163 /* UIView+Stripe_FirstResponder.h */,
-				FR_641873512346 /* UIView+Stripe_SafeAreaBounds.h */,
-				FR_573089660403 /* UIViewController+Stripe_KeyboardAvoiding.h */,
-				FR_791050653111 /* UIViewController+Stripe_NavigationItemProxy.h */,
-				FR_731018226313 /* UIViewController+Stripe_ParentViewController.h */,
-				FR_953710188013 /* UIViewController+Stripe_Promises.h */,
-			);
-			path = Stripe;
-			sourceTree = "<group>";
-		};
-		G_6159393876080 /* Localizations */ = {
-			isa = PBXGroup;
-			children = (
-				VG_549793573278 /* Localizable.strings */,
-			);
-			path = Localizations;
-			sourceTree = "<group>";
-		};
-		G_6309115779713 /* Source */ = {
-			isa = PBXGroup;
-			children = (
-				FR_736834917512 /* PINOperation.h */,
-				FR_100956106933 /* PINOperationGroup.h */,
-				FR_100956106934 /* PINOperationGroup.m */,
-				FR_635484072488 /* PINOperationMacros.h */,
-				FR_898827650356 /* PINOperationQueue.h */,
-				"FR_898827650356-1" /* PINOperationQueue.m */,
-				FR_118440206517 /* PINOperationTypes.h */,
-			);
-			path = Source;
-			sourceTree = "<group>";
-		};
-		G_6558703128995 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				FR_351883541716 /* GoogleAppIndexingResources.bundle */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		G_6697764287486 /* PINOperation */ = {
-			isa = PBXGroup;
-			children = (
-				FR_523050043014 /* PINOperation.h */,
-				FR_150667978887 /* PINOperationGroup.h */,
-				FR_883876637273 /* PINOperationMacros.h */,
-				FR_835891206247 /* PINOperationQueue.h */,
-				FR_159160499476 /* PINOperationTypes.h */,
-			);
-			path = PINOperation;
-			sourceTree = "<group>";
-		};
-		G_7029414687469 /* pod_support */ = {
-			isa = PBXGroup;
-			children = (
-				G_2659861901976 /* Headers */,
-			);
-			path = pod_support;
-			sourceTree = "<group>";
-		};
-		G_7104109163762 /* Localization */ = {
-			isa = PBXGroup;
-			children = (
-				VG_167175369874 /* AppIntentVocabulary.plist */,
+				VG_557820679266 /* AppIntentVocabulary.plist */,
 			);
 			path = Localization;
 			sourceTree = "<group>";
 		};
-		G_7535749096061 /* Resources */ = {
+		G_2082592226908 /* Stripe */ = {
 			isa = PBXGroup;
 			children = (
-				G_7104109163762 /* Localization */,
-				FR_609723908966 /* SiriExtension-Info.plist */,
+				FR_263771945362 /* FABKitProtocol.h */,
+				FR_776459644262 /* Fabric.h */,
+				FR_485689218719 /* Fabric+FABKits.h */,
+				FR_310737407634 /* FauxPasAnnotations.h */,
+				FR_787984517909 /* NSArray+Stripe.h */,
+				FR_408343592509 /* NSBundle+Stripe_AppName.h */,
+				FR_426656857393 /* NSCharacterSet+Stripe.h */,
+				FR_176587841763 /* NSDecimalNumber+Stripe_Currency.h */,
+				FR_668317149915 /* NSDictionary+Stripe.h */,
+				FR_657128263749 /* NSError+Stripe.h */,
+				FR_670837697807 /* NSMutableURLRequest+Stripe.h */,
+				FR_716313626667 /* NSString+Stripe.h */,
+				FR_480653613414 /* NSURLComponents+Stripe.h */,
+				FR_591392785580 /* PKPayment+Stripe.h */,
+				FR_416711012558 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */,
+				FR_296560133436 /* STPAddCardViewController.h */,
+				FR_502474434784 /* STPAddCardViewController+Private.h */,
+				FR_856633702404 /* STPAddress.h */,
+				FR_276281345727 /* STPAddressFieldTableViewCell.h */,
+				FR_700370057985 /* STPAddressViewModel.h */,
+				FR_252761981132 /* STPAnalyticsClient.h */,
+				FR_465632152352 /* STPAPIClient.h */,
+				FR_807037820303 /* STPAPIClient+ApplePay.h */,
+				FR_701197038044 /* STPAPIClient+Private.h */,
+				FR_853966787131 /* STPAPIRequest.h */,
+				FR_107405673473 /* STPAPIResponseDecodable.h */,
+				FR_369657259990 /* STPApplePayPaymentMethod.h */,
+				FR_791769030009 /* STPAspects.h */,
+				FR_768992176715 /* STPBackendAPIAdapter.h */,
+				FR_381541692670 /* STPBankAccount.h */,
+				FR_831107356712 /* STPBankAccountParams.h */,
+				FR_859246040826 /* STPBankAccountParams+Private.h */,
+				FR_404009520577 /* STPBINRange.h */,
+				FR_871480364449 /* STPBlocks.h */,
+				FR_637247309669 /* STPBundleLocator.h */,
+				FR_667277485416 /* STPCard.h */,
+				FR_609262385738 /* STPCard+Private.h */,
+				FR_676661417209 /* STPCardBrand.h */,
+				FR_407411144964 /* STPCardIOProxy.h */,
+				FR_600578543769 /* STPCardParams.h */,
+				FR_498316524810 /* STPCardValidationState.h */,
+				FR_308536515212 /* STPCardValidator.h */,
+				FR_568593882583 /* STPCategoryLoader.h */,
+				FR_701086246168 /* STPColorUtils.h */,
+				FR_413807607925 /* STPConnectAccountParams.h */,
+				FR_711918819728 /* STPCoreScrollViewController.h */,
+				FR_251439661499 /* STPCoreScrollViewController+Private.h */,
+				FR_654509270410 /* STPCoreTableViewController.h */,
+				FR_732165764070 /* STPCoreTableViewController+Private.h */,
+				FR_106165532869 /* STPCoreViewController.h */,
+				FR_809630086871 /* STPCoreViewController+Private.h */,
+				FR_668070994301 /* STPCustomer.h */,
+				FR_597436128584 /* STPCustomer+Private.h */,
+				FR_567993355124 /* STPCustomer+SourceTuple.h */,
+				FR_455055307449 /* STPCustomerContext.h */,
+				FR_652176105039 /* STPDelegateProxy.h */,
+				FR_680182050104 /* STPDispatchFunctions.h */,
+				FR_388659491173 /* STPEmailAddressValidator.h */,
+				FR_897166241393 /* STPEphemeralKey.h */,
+				FR_593739516315 /* STPEphemeralKeyManager.h */,
+				FR_496554446077 /* STPEphemeralKeyProvider.h */,
+				FR_392574313117 /* STPFile.h */,
+				FR_358655835312 /* STPFile+Private.h */,
+				FR_494798662852 /* STPFormEncodable.h */,
+				FR_187518438601 /* STPFormEncoder.h */,
+				FR_153226209751 /* STPFormTextField.h */,
+				FR_563808066373 /* STPImageLibrary.h */,
+				FR_591183502734 /* STPImageLibrary+Private.h */,
+				FR_583778395098 /* STPInternalAPIResponseDecodable.h */,
+				FR_459027505856 /* STPLegalEntityParams.h */,
+				FR_387408549256 /* STPLocalizationUtils.h */,
+				FR_391708229706 /* STPMultipartFormDataEncoder.h */,
+				FR_500693267193 /* STPMultipartFormDataPart.h */,
+				FR_809108791963 /* STPPaymentActivityIndicatorView.h */,
+				FR_112095401783 /* STPPaymentCardTextField.h */,
+				FR_760476646265 /* STPPaymentCardTextField+Private.h */,
+				FR_903513735268 /* STPPaymentCardTextFieldCell.h */,
+				FR_157587722902 /* STPPaymentCardTextFieldViewModel.h */,
+				FR_306688222964 /* STPPaymentConfiguration.h */,
+				FR_868093412922 /* STPPaymentConfiguration+Private.h */,
+				FR_906691198581 /* STPPaymentContext.h */,
+				FR_187663198768 /* STPPaymentContext+Private.h */,
+				FR_428794804154 /* STPPaymentContextAmountModel.h */,
+				FR_748329317110 /* STPPaymentMethod.h */,
+				FR_360464332296 /* STPPaymentMethodsInternalViewController.h */,
+				FR_162423673141 /* STPPaymentMethodsViewController.h */,
+				FR_501344631583 /* STPPaymentMethodsViewController+Private.h */,
+				FR_410962885406 /* STPPaymentMethodTableViewCell.h */,
+				FR_489307065831 /* STPPaymentMethodTuple.h */,
+				FR_633919745139 /* STPPaymentResult.h */,
+				FR_456708297239 /* STPPhoneNumberValidator.h */,
+				FR_563104549644 /* STPPostalCodeValidator.h */,
+				FR_706359988177 /* STPPromise.h */,
+				FR_666150738023 /* STPRedirectContext.h */,
+				FR_481660996906 /* STPSectionHeaderView.h */,
+				FR_715819450244 /* STPShippingAddressViewController.h */,
+				FR_289951473723 /* STPShippingMethodsViewController.h */,
+				FR_184535322115 /* STPShippingMethodTableViewCell.h */,
+				FR_865857012183 /* STPSource.h */,
+				FR_879111094388 /* STPSource+Private.h */,
+				FR_254186187103 /* STPSourceCardDetails.h */,
+				FR_880704464323 /* STPSourceCardDetails+Private.h */,
+				FR_709146189722 /* STPSourceEnums.h */,
+				FR_241491748011 /* STPSourceOwner.h */,
+				FR_737093675579 /* STPSourceParams.h */,
+				FR_872295844282 /* STPSourceParams+Private.h */,
+				FR_649967179890 /* STPSourcePoller.h */,
+				FR_368887152771 /* STPSourceProtocol.h */,
+				FR_821033470551 /* STPSourceReceiver.h */,
+				FR_808247114849 /* STPSourceRedirect.h */,
+				FR_723543549131 /* STPSourceRedirect+Private.h */,
+				FR_314640988313 /* STPSourceSEPADebitDetails.h */,
+				FR_216387680131 /* STPSourceVerification.h */,
+				FR_257482490656 /* STPSourceVerification+Private.h */,
+				FR_574570312868 /* STPStringUtils.h */,
+				FR_446067735536 /* STPSwitchTableViewCell.h */,
+				FR_222347419161 /* STPTelemetryClient.h */,
+				FR_100918364096 /* STPTheme.h */,
+				FR_768476324412 /* STPToken.h */,
+				FR_592260627016 /* STPURLCallbackHandler.h */,
+				FR_195508064871 /* STPUserInformation.h */,
+				FR_285793989872 /* STPValidatedTextField.h */,
+				FR_233085860418 /* STPWeakStrongMacros.h */,
+				FR_692503360915 /* Stripe.h */,
+				FR_213034861182 /* StripeError.h */,
+				FR_111986568000 /* UIBarButtonItem+Stripe.h */,
+				FR_499312825618 /* UIImage+Stripe.h */,
+				FR_847858510902 /* UINavigationBar+Stripe_Theme.h */,
+				FR_498549693882 /* UINavigationController+Stripe_Completion.h */,
+				FR_734989487303 /* UITableViewCell+Stripe_Borders.h */,
+				FR_172958393529 /* UIToolbar+Stripe_InputAccessory.h */,
+				FR_170596598734 /* UIView+Stripe_FirstResponder.h */,
+				FR_708327290125 /* UIView+Stripe_SafeAreaBounds.h */,
+				FR_555089210878 /* UIViewController+Stripe_KeyboardAvoiding.h */,
+				FR_675363467066 /* UIViewController+Stripe_NavigationItemProxy.h */,
+				FR_737907561380 /* UIViewController+Stripe_ParentViewController.h */,
+				FR_335537886290 /* UIViewController+Stripe_Promises.h */,
+			);
+			path = Stripe;
+			sourceTree = "<group>";
+		};
+		G_2116257231555 /* UrlGet */ = {
+			isa = PBXGroup;
+			children = (
+				FR_819768356424 /* AppDelegate.h */,
+				FR_253734139691 /* AppDelegate.m */,
+				FR_845488816582 /* main.m */,
+				FR_547151370574 /* NoArc.m */,
+				FR_167666946058 /* Some.cc */,
+				FR_180206282362 /* Some.hpp */,
+				FR_174283433844 /* UrlGet-Info.plist */,
+				FR_738661589644 /* UrlGetViewController.h */,
+				FR_734554573488 /* UrlGetViewController.m */,
+				FR_753120224409 /* UrlGetViewController.xib */,
+			);
+			path = UrlGet;
+			sourceTree = "<group>";
+		};
+		G_2359438238356 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				G_2082592226908 /* Stripe */,
+			);
+			path = Public;
+			sourceTree = "<group>";
+		};
+		G_2396029160764 /* HeaderLib */ = {
+			isa = PBXGroup;
+			children = (
+				FR_379671331039 /* HeaderLib.hpp */,
+			);
+			path = HeaderLib;
+			sourceTree = "<group>";
+		};
+		G_3099399763346 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				FR_614447531043 /* AppJerry.h */,
+				FR_890897390711 /* AppJerry.m */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		G_3280466234709 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				FR_578847093777 /* AppIntent.h */,
+				FR_840244369229 /* AppIntent.m */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		G_3643327322604 /* Localizations */ = {
+			isa = PBXGroup;
+			children = (
+				VG_879680789012 /* Localizable.strings */,
+			);
+			path = Localizations;
+			sourceTree = "<group>";
+		};
+		G_3706305035049 /* PINOperation */ = {
+			isa = PBXGroup;
+			children = (
+				G_1187345590366 /* pod_support */,
+				G_8160812051622 /* Source */,
+			);
+			path = PINOperation;
+			sourceTree = "<group>";
+		};
+		G_3916061463242 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				FR_102943442467 /* StringsExtension-Info.plist */,
+				G_7953114968431 /* Localization */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		G_8448771205358 = {
+		G_4013559502754 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				G_1952740716080 /* Frameworks */,
-				G_8620238527590 /* Products */,
-				G_9514399547648 /* UrlGet.xcodeproj */,
-				G_4793969390202 /* Vendor */,
-				G_4430024575855 /* ios-app */,
+				G_8959664874258 /* Public */,
+			);
+			path = Headers;
+			sourceTree = "<group>";
+		};
+		G_4327770919765 /* Stripe */ = {
+			isa = PBXGroup;
+			children = (
+				FR_459256248737 /* FABKitProtocol.h */,
+				FR_704198783520 /* Fabric.h */,
+				FR_227516787760 /* Fabric+FABKits.h */,
+				FR_130046752603 /* NSArray+Stripe.h */,
+				FR_270361851280 /* NSArray+Stripe.m */,
+				FR_749553059542 /* NSBundle+Stripe_AppName.h */,
+				FR_599031596757 /* NSBundle+Stripe_AppName.m */,
+				FR_623324372480 /* NSCharacterSet+Stripe.h */,
+				FR_275560902555 /* NSCharacterSet+Stripe.m */,
+				FR_747080657190 /* NSDecimalNumber+Stripe_Currency.h */,
+				FR_299376274777 /* NSDecimalNumber+Stripe_Currency.m */,
+				FR_240832335761 /* NSDictionary+Stripe.h */,
+				FR_322145952019 /* NSDictionary+Stripe.m */,
+				FR_354724297581 /* NSError+Stripe.h */,
+				FR_434788842793 /* NSError+Stripe.m */,
+				FR_469496801272 /* NSMutableURLRequest+Stripe.h */,
+				FR_246982922734 /* NSMutableURLRequest+Stripe.m */,
+				FR_470744425341 /* NSString+Stripe.h */,
+				FR_281431888822 /* NSString+Stripe.m */,
+				FR_134445234443 /* NSURLComponents+Stripe.h */,
+				FR_508900331586 /* NSURLComponents+Stripe.m */,
+				FR_332315537569 /* PKPayment+Stripe.h */,
+				FR_469267514516 /* PKPayment+Stripe.m */,
+				FR_620301149926 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */,
+				FR_166918657392 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */,
+				FR_248304595826 /* STPAddCardViewController.m */,
+				FR_395102338138 /* STPAddCardViewController+Private.h */,
+				FR_623895726528 /* STPAddress.m */,
+				FR_328254709834 /* STPAddressFieldTableViewCell.h */,
+				FR_479371064013 /* STPAddressFieldTableViewCell.m */,
+				FR_768379248407 /* STPAddressViewModel.h */,
+				FR_439275709173 /* STPAddressViewModel.m */,
+				FR_622439046503 /* STPAnalyticsClient.h */,
+				FR_249006138549 /* STPAnalyticsClient.m */,
+				FR_908317792274 /* STPAPIClient.m */,
+				FR_769504085116 /* STPAPIClient+ApplePay.m */,
+				FR_847634122805 /* STPAPIClient+Private.h */,
+				FR_863899671502 /* STPAPIRequest.h */,
+				FR_119461237896 /* STPAPIRequest.m */,
+				FR_321591135654 /* STPApplePayPaymentMethod.m */,
+				FR_592944512740 /* STPAspects.h */,
+				FR_344626064168 /* STPAspects.m */,
+				FR_687805612898 /* STPBankAccount.m */,
+				FR_429071574776 /* STPBankAccountParams.m */,
+				FR_720475461729 /* STPBankAccountParams+Private.h */,
+				FR_900054750708 /* STPBINRange.h */,
+				FR_413991883976 /* STPBINRange.m */,
+				FR_420736451946 /* STPBundleLocator.h */,
+				FR_798914995582 /* STPBundleLocator.m */,
+				FR_376164653878 /* STPCard.m */,
+				FR_281566021398 /* STPCard+Private.h */,
+				FR_437919225479 /* STPCardIOProxy.h */,
+				FR_805430750713 /* STPCardIOProxy.m */,
+				FR_240970093763 /* STPCardParams.m */,
+				FR_828376497251 /* STPCardValidator.m */,
+				FR_124543526378 /* STPCategoryLoader.h */,
+				FR_494301659888 /* STPCategoryLoader.m */,
+				FR_420487677011 /* STPColorUtils.h */,
+				FR_813264579658 /* STPColorUtils.m */,
+				FR_572796611138 /* STPConnectAccountParams.m */,
+				FR_311622561615 /* STPCoreScrollViewController.m */,
+				FR_165114611545 /* STPCoreScrollViewController+Private.h */,
+				FR_502904508636 /* STPCoreTableViewController.m */,
+				FR_618638349731 /* STPCoreTableViewController+Private.h */,
+				FR_174620530590 /* STPCoreViewController.m */,
+				FR_591666596335 /* STPCoreViewController+Private.h */,
+				FR_362637812812 /* STPCustomer.m */,
+				FR_285060110180 /* STPCustomer+Private.h */,
+				FR_443953828808 /* STPCustomer+SourceTuple.h */,
+				FR_679404232338 /* STPCustomer+SourceTuple.m */,
+				FR_582745043417 /* STPCustomerContext.m */,
+				FR_721129734544 /* STPDelegateProxy.h */,
+				FR_410892256394 /* STPDelegateProxy.m */,
+				FR_651847570475 /* STPDispatchFunctions.h */,
+				FR_214160927202 /* STPDispatchFunctions.m */,
+				FR_688739162706 /* STPEmailAddressValidator.h */,
+				FR_657711760784 /* STPEmailAddressValidator.m */,
+				FR_864958197976 /* STPEphemeralKey.h */,
+				FR_401046103149 /* STPEphemeralKey.m */,
+				FR_634151600220 /* STPEphemeralKeyManager.h */,
+				FR_110318688237 /* STPEphemeralKeyManager.m */,
+				FR_859214955617 /* STPFile.m */,
+				FR_547023080128 /* STPFile+Private.h */,
+				FR_287240998336 /* STPFormEncoder.h */,
+				FR_166695994825 /* STPFormEncoder.m */,
+				FR_468517384487 /* STPFormTextField.h */,
+				FR_185670732342 /* STPFormTextField.m */,
+				FR_413023481354 /* STPImageLibrary.m */,
+				FR_182438507920 /* STPImageLibrary+Private.h */,
+				FR_145688362384 /* STPInternalAPIResponseDecodable.h */,
+				FR_399283558766 /* STPLegalEntityParams.m */,
+				FR_172739966665 /* STPLocalizationUtils.h */,
+				FR_529784366644 /* STPLocalizationUtils.m */,
+				FR_464681328909 /* STPMultipartFormDataEncoder.h */,
+				FR_695779107005 /* STPMultipartFormDataEncoder.m */,
+				FR_915238346456 /* STPMultipartFormDataPart.h */,
+				FR_792688469879 /* STPMultipartFormDataPart.m */,
+				FR_352033123735 /* STPPaymentActivityIndicatorView.m */,
+				FR_197802340500 /* STPPaymentCardTextField.m */,
+				FR_112556541763 /* STPPaymentCardTextField+Private.h */,
+				FR_801026079927 /* STPPaymentCardTextFieldCell.h */,
+				FR_887939645205 /* STPPaymentCardTextFieldCell.m */,
+				FR_117244705373 /* STPPaymentCardTextFieldViewModel.h */,
+				FR_583395561891 /* STPPaymentCardTextFieldViewModel.m */,
+				FR_920849002660 /* STPPaymentConfiguration.m */,
+				FR_413649058186 /* STPPaymentConfiguration+Private.h */,
+				FR_427454786804 /* STPPaymentContext.m */,
+				FR_651211894634 /* STPPaymentContext+Private.h */,
+				FR_463415628327 /* STPPaymentContextAmountModel.h */,
+				FR_505294580563 /* STPPaymentContextAmountModel.m */,
+				FR_901652225192 /* STPPaymentMethodsInternalViewController.h */,
+				FR_865157427735 /* STPPaymentMethodsInternalViewController.m */,
+				FR_341953782072 /* STPPaymentMethodsViewController.m */,
+				FR_753343340710 /* STPPaymentMethodsViewController+Private.h */,
+				FR_225976546120 /* STPPaymentMethodTableViewCell.h */,
+				FR_711629859574 /* STPPaymentMethodTableViewCell.m */,
+				FR_169041491584 /* STPPaymentMethodTuple.h */,
+				FR_370123180763 /* STPPaymentMethodTuple.m */,
+				FR_314953714155 /* STPPaymentResult.m */,
+				FR_438694548221 /* STPPhoneNumberValidator.h */,
+				FR_523478154706 /* STPPhoneNumberValidator.m */,
+				FR_583674497367 /* STPPostalCodeValidator.h */,
+				FR_709946777976 /* STPPostalCodeValidator.m */,
+				FR_353249173463 /* STPPromise.h */,
+				FR_218112984498 /* STPPromise.m */,
+				FR_628989537343 /* STPRedirectContext.m */,
+				FR_284420664639 /* STPSectionHeaderView.h */,
+				FR_176089150530 /* STPSectionHeaderView.m */,
+				FR_114090975619 /* STPShippingAddressViewController.m */,
+				FR_164344606297 /* STPShippingMethodsViewController.h */,
+				FR_236953861390 /* STPShippingMethodsViewController.m */,
+				FR_802267686739 /* STPShippingMethodTableViewCell.h */,
+				FR_166620028473 /* STPShippingMethodTableViewCell.m */,
+				FR_189036277762 /* STPSource.m */,
+				FR_715088161304 /* STPSource+Private.h */,
+				FR_179040801106 /* STPSourceCardDetails.m */,
+				FR_637121338601 /* STPSourceCardDetails+Private.h */,
+				FR_457060453990 /* STPSourceOwner.m */,
+				FR_386854374165 /* STPSourceParams.m */,
+				FR_201763267702 /* STPSourceParams+Private.h */,
+				FR_328352920299 /* STPSourcePoller.h */,
+				FR_508923610275 /* STPSourcePoller.m */,
+				FR_477141207452 /* STPSourceReceiver.m */,
+				FR_483144838889 /* STPSourceRedirect.m */,
+				FR_724259384552 /* STPSourceRedirect+Private.h */,
+				FR_827299014426 /* STPSourceSEPADebitDetails.m */,
+				FR_922234055079 /* STPSourceVerification.m */,
+				FR_702731086180 /* STPSourceVerification+Private.h */,
+				FR_217618539785 /* STPStringUtils.h */,
+				FR_689122585293 /* STPStringUtils.m */,
+				FR_589726050819 /* STPSwitchTableViewCell.h */,
+				FR_493570425693 /* STPSwitchTableViewCell.m */,
+				FR_826898134611 /* STPTelemetryClient.h */,
+				FR_855134969525 /* STPTelemetryClient.m */,
+				FR_678946834674 /* STPTheme.m */,
+				FR_629980649685 /* STPToken.m */,
+				FR_336262010096 /* STPURLCallbackHandler.h */,
+				FR_293229987775 /* STPURLCallbackHandler.m */,
+				FR_793899192763 /* STPUserInformation.m */,
+				FR_729185093187 /* STPValidatedTextField.h */,
+				FR_763790828482 /* STPValidatedTextField.m */,
+				FR_805065086362 /* STPWeakStrongMacros.h */,
+				FR_800273678048 /* StripeError.m */,
+				FR_657975526681 /* UIBarButtonItem+Stripe.h */,
+				FR_660486720752 /* UIBarButtonItem+Stripe.m */,
+				FR_223874375474 /* UIImage+Stripe.h */,
+				FR_183755575988 /* UIImage+Stripe.m */,
+				FR_509452004334 /* UINavigationBar+Stripe_Theme.m */,
+				FR_170614256090 /* UINavigationController+Stripe_Completion.h */,
+				FR_664471815887 /* UINavigationController+Stripe_Completion.m */,
+				FR_441651685045 /* UITableViewCell+Stripe_Borders.h */,
+				FR_503123501592 /* UITableViewCell+Stripe_Borders.m */,
+				FR_563361406910 /* UIToolbar+Stripe_InputAccessory.h */,
+				FR_594159834513 /* UIToolbar+Stripe_InputAccessory.m */,
+				FR_468805634066 /* UIView+Stripe_FirstResponder.h */,
+				FR_235596592030 /* UIView+Stripe_FirstResponder.m */,
+				FR_703828678216 /* UIView+Stripe_SafeAreaBounds.h */,
+				FR_838695088836 /* UIView+Stripe_SafeAreaBounds.m */,
+				FR_933371169343 /* UIViewController+Stripe_KeyboardAvoiding.h */,
+				FR_569620833385 /* UIViewController+Stripe_KeyboardAvoiding.m */,
+				FR_861265882976 /* UIViewController+Stripe_NavigationItemProxy.h */,
+				FR_916661342534 /* UIViewController+Stripe_NavigationItemProxy.m */,
+				FR_690817139963 /* UIViewController+Stripe_ParentViewController.h */,
+				FR_535994124885 /* UIViewController+Stripe_ParentViewController.m */,
+				FR_193926384296 /* UIViewController+Stripe_Promises.h */,
+				FR_879635869993 /* UIViewController+Stripe_Promises.m */,
+				G_6758049211909 /* PublicHeaders */,
+				G_1132957408482 /* Resources */,
+			);
+			path = Stripe;
+			sourceTree = "<group>";
+		};
+		G_4459673665917 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				FR_860483718504 /* GoogleAppIndexingResources.bundle */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		G_4622518111477 /* ShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				FR_115263350237 /* ShareExtension-Info.plist */,
+			);
+			path = ShareExtension;
+			sourceTree = "<group>";
+		};
+		G_4717179668344 /* UnitTests */ = {
+			isa = PBXGroup;
+			children = (
+				FR_411547927351 /* Tests.m */,
+				FR_773149577891 /* Tests2.m */,
+			);
+			path = UnitTests;
+			sourceTree = "<group>";
+		};
+		G_4757866348192 /* PINOperation */ = {
+			isa = PBXGroup;
+			children = (
+				FR_814877671763 /* PINOperation.h */,
+				FR_218663833597 /* PINOperationGroup.h */,
+				FR_210368222096 /* PINOperationMacros.h */,
+				FR_190995174488 /* PINOperationQueue.h */,
+				FR_224088827831 /* PINOperationTypes.h */,
+			);
+			path = PINOperation;
+			sourceTree = "<group>";
+		};
+		G_5053086023715 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FR_321038524600 /* HeaderLib-ios-9.0.a */,
+				FR_855762236329 /* HeaderLib-ios-12.0.a */,
+				FR_700633204216 /* ios-app-Bazel.app */,
+				FR_818473893886 /* ios-app-bin.a */,
+				FR_757956135481 /* ios-app.app */,
+				FR_655977824079 /* ios-ext-bin.a */,
+				FR_656630461598 /* PINCache-Arc-exception-safe-ios-9.0.a */,
+				FR_131920372131 /* PINCache-Arc-exception-safe-ios-12.0.a */,
+				FR_466327725618 /* PINCache-Core-ios-9.0.a */,
+				FR_232037670091 /* PINCache-Core-ios-12.0.a */,
+				FR_677790726659 /* PINOperation-ios-9.0.a */,
+				FR_575785382123 /* PINOperation-ios-12.0.a */,
+				FR_424996891355 /* share-extension-Bazel.appex */,
+				FR_205363634933 /* share-extension.appex */,
+				FR_576098273475 /* siri-ext-bin.a */,
+				FR_287747118355 /* siri-extension.appex */,
+				FR_842212741120 /* strings-ext-bin.a */,
+				FR_107066082523 /* strings-extension.appex */,
+				FR_844946125614 /* Stripe-ios-9.0.a */,
+				FR_664069285608 /* Stripe-ios-12.0.a */,
+				FR_903718557818 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */,
+				FR_767805223807 /* Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle */,
+				FR_863786754985 /* UITests.xctest */,
+				FR_162101825678 /* UnitTests.xctest */,
+				FR_394586624846 /* UnitTestsWithHost.xctest */,
+				FR_196725857447 /* UrlGetClasses-ios-9.0.a */,
+				FR_906505729587 /* UrlGetClasses-ios-12.0.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		G_5056339259752 /* pod_support */ = {
+			isa = PBXGroup;
+			children = (
+				G_6832249640849 /* Headers */,
+			);
+			path = pod_support;
+			sourceTree = "<group>";
+		};
+		G_5111359365212 /* GoogleAppIndexing */ = {
+			isa = PBXGroup;
+			children = (
+				G_4459673665917 /* Resources */,
+			);
+			path = GoogleAppIndexing;
+			sourceTree = "<group>";
+		};
+		G_5410946260562 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				G_5522281906005 /* PINCache */,
+			);
+			path = Public;
+			sourceTree = "<group>";
+		};
+		G_5411121097194 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				FR_138502338795 /* PINCache.h */,
+				FR_874886281442 /* PINCache.m */,
+				FR_703899038574 /* PINCacheMacros.h */,
+				FR_106153810107 /* PINCacheObjectSubscripting.h */,
+				FR_735360084506 /* PINCaching.h */,
+				FR_170769962236 /* PINDiskCache.h */,
+				FR_143673724944 /* PINDiskCache.m */,
+				FR_600019716014 /* PINMemoryCache.h */,
+				FR_310086671711 /* PINMemoryCache.m */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
+		G_5439863094082 /* PINCache */ = {
+			isa = PBXGroup;
+			children = (
+				G_6509183069096 /* pod_support */,
+				G_5411121097194 /* Source */,
+			);
+			path = PINCache;
+			sourceTree = "<group>";
+		};
+		G_5522281906005 /* PINCache */ = {
+			isa = PBXGroup;
+			children = (
+				FR_227724747281 /* PINCache.h */,
+				FR_495367858217 /* PINCacheMacros.h */,
+				FR_621675436412 /* PINCacheObjectSubscripting.h */,
+				FR_493757317549 /* PINCaching.h */,
+				FR_530544298450 /* PINDiskCache.h */,
+				FR_888484860318 /* PINMemoryCache.h */,
+			);
+			path = PINCache;
+			sourceTree = "<group>";
+		};
+		G_5739609273065 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				FR_497557335011 /* SiriExtension-Info.plist */,
+				G_1529740786880 /* Localization */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		G_5970325316122 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				FR_437723492681 /* GoogleAppIndexing.framework */,
+				FR_743842026332 /* GoogleAuthUtilities.framework */,
+				FR_604030021498 /* GoogleNetworkingUtilities.framework */,
+				FR_779344507530 /* GoogleSymbolUtilities.framework */,
+				FR_968277723020 /* libios-app-bin.a */,
+				FR_258616937111 /* libios-ext-bin.a */,
+				FR_551274171982 /* libPINCache-Arc-exception-safe-ios-9.0.a */,
+				FR_292167901401 /* libPINCache-Arc-exception-safe-ios-12.0.a */,
+				FR_481672282565 /* libPINCache-Core-ios-9.0.a */,
+				FR_618988043579 /* libPINCache-Core-ios-12.0.a */,
+				FR_353316542796 /* libPINOperation-ios-9.0.a */,
+				FR_424267095963 /* libPINOperation-ios-12.0.a */,
+				FR_674603271118 /* libsiri-ext-bin.a */,
+				FR_731137829020 /* libstrings-ext-bin.a */,
+				FR_115569304376 /* libStripe-ios-9.0.a */,
+				FR_458251636042 /* libStripe-ios-12.0.a */,
+				FR_321171250374 /* libUrlGetClasses-ios-9.0.a */,
+				FR_952027055371 /* libUrlGetClasses-ios-12.0.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		G_6001289307113 /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				G_5111359365212 /* GoogleAppIndexing */,
+				G_5439863094082 /* PINCache */,
+				G_3706305035049 /* PINOperation */,
+				G_8669332660719 /* Stripe */,
+			);
+			path = Vendor;
+			sourceTree = "<group>";
+		};
+		G_6283197169528 /* SiriExtension */ = {
+			isa = PBXGroup;
+			children = (
+				G_5739609273065 /* Resources */,
+				G_3280466234709 /* Sources */,
+			);
+			path = SiriExtension;
+			sourceTree = "<group>";
+		};
+		G_6346944914571 /* XCHammerAssets */ = {
+			isa = PBXGroup;
+			children = (
+				FR_668440300851 /* Stub.m */,
+			);
+			path = XCHammerAssets;
+			sourceTree = "<group>";
+		};
+		G_6509183069096 /* pod_support */ = {
+			isa = PBXGroup;
+			children = (
+				G_8262185590823 /* Headers */,
+			);
+			path = pod_support;
+			sourceTree = "<group>";
+		};
+		G_6758049211909 /* PublicHeaders */ = {
+			isa = PBXGroup;
+			children = (
+				FR_250934899452 /* FauxPasAnnotations.h */,
+				FR_605183289017 /* STPAddCardViewController.h */,
+				FR_830637254163 /* STPAddress.h */,
+				FR_320799198594 /* STPAPIClient.h */,
+				FR_199387754190 /* STPAPIClient+ApplePay.h */,
+				FR_679084602979 /* STPAPIResponseDecodable.h */,
+				FR_171679345202 /* STPApplePayPaymentMethod.h */,
+				FR_133576635973 /* STPBackendAPIAdapter.h */,
+				FR_240590486966 /* STPBankAccount.h */,
+				FR_359239314212 /* STPBankAccountParams.h */,
+				FR_190999170508 /* STPBlocks.h */,
+				FR_119185384321 /* STPCard.h */,
+				FR_843671643897 /* STPCardBrand.h */,
+				FR_380855240261 /* STPCardParams.h */,
+				FR_647615708741 /* STPCardValidationState.h */,
+				FR_635783061927 /* STPCardValidator.h */,
+				FR_773846360911 /* STPConnectAccountParams.h */,
+				FR_214570034228 /* STPCoreScrollViewController.h */,
+				FR_622146132147 /* STPCoreTableViewController.h */,
+				FR_228923531634 /* STPCoreViewController.h */,
+				FR_390537239017 /* STPCustomer.h */,
+				FR_639161976165 /* STPCustomerContext.h */,
+				FR_529604170619 /* STPEphemeralKeyProvider.h */,
+				FR_441979129851 /* STPFile.h */,
+				FR_150902497411 /* STPFormEncodable.h */,
+				FR_386885018930 /* STPImageLibrary.h */,
+				FR_431919160946 /* STPLegalEntityParams.h */,
+				FR_825181478485 /* STPPaymentActivityIndicatorView.h */,
+				FR_401159209257 /* STPPaymentCardTextField.h */,
+				FR_124520506223 /* STPPaymentConfiguration.h */,
+				FR_443179884003 /* STPPaymentContext.h */,
+				FR_654192010378 /* STPPaymentMethod.h */,
+				FR_799082704884 /* STPPaymentMethodsViewController.h */,
+				FR_374236941753 /* STPPaymentResult.h */,
+				FR_160259185428 /* STPRedirectContext.h */,
+				FR_190529263507 /* STPShippingAddressViewController.h */,
+				FR_204424633043 /* STPSource.h */,
+				FR_462403503968 /* STPSourceCardDetails.h */,
+				FR_565065630971 /* STPSourceEnums.h */,
+				FR_437529102342 /* STPSourceOwner.h */,
+				FR_300701900501 /* STPSourceParams.h */,
+				FR_421045928597 /* STPSourceProtocol.h */,
+				FR_771342212418 /* STPSourceReceiver.h */,
+				FR_427684117497 /* STPSourceRedirect.h */,
+				FR_609302522033 /* STPSourceSEPADebitDetails.h */,
+				FR_749349441066 /* STPSourceVerification.h */,
+				FR_256578496436 /* STPTheme.h */,
+				FR_848452328362 /* STPToken.h */,
+				FR_623044591305 /* STPUserInformation.h */,
+				FR_727217733032 /* Stripe.h */,
+				FR_527811563431 /* StripeError.h */,
+				FR_310141525667 /* UINavigationBar+Stripe_Theme.h */,
+			);
+			path = PublicHeaders;
+			sourceTree = "<group>";
+		};
+		G_6832249640849 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				G_2359438238356 /* Public */,
+			);
+			path = Headers;
+			sourceTree = "<group>";
+		};
+		G_7579561354812 /* ios-app */ = {
+			isa = PBXGroup;
+			children = (
+				FR_116888961223 /* Diags.xcconfig */,
+				FR_858321172415 /* empty-main.m */,
+				FR_684008688115 /* Fancy.m */,
+				G_2396029160764 /* HeaderLib */,
+				G_4622518111477 /* ShareExtension */,
+				G_6283197169528 /* SiriExtension */,
+				G_9082154448797 /* StringsExtension */,
+				G_4717179668344 /* UnitTests */,
+				G_2116257231555 /* UrlGet */,
+			);
+			path = "ios-app";
+			sourceTree = "<group>";
+		};
+		G_7953114968431 /* Localization */ = {
+			isa = PBXGroup;
+			children = (
+				VG_753262157515 /* InfoPlist.strings */,
+			);
+			path = Localization;
+			sourceTree = "<group>";
+		};
+		G_8160812051622 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				FR_656725481201 /* PINOperation.h */,
+				FR_152553107307 /* PINOperationGroup.h */,
+				FR_279289880954 /* PINOperationGroup.m */,
+				FR_603110710953 /* PINOperationMacros.h */,
+				FR_960264344136 /* PINOperationQueue.h */,
+				FR_373510968019 /* PINOperationQueue.m */,
+				FR_684714893235 /* PINOperationTypes.h */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
+		G_8262185590823 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				G_5410946260562 /* Public */,
+			);
+			path = Headers;
+			sourceTree = "<group>";
+		};
+		G_8595232905817 = {
+			isa = PBXGroup;
+			children = (
+				G_7579561354812 /* ios-app */,
+				G_1483785753565 /* UrlGet.xcodeproj */,
+				G_6001289307113 /* Vendor */,
+				G_5970325316122 /* Frameworks */,
+				G_5053086023715 /* Products */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
 			tabWidth = 4;
 			usesTabs = 0;
 		};
-		G_8601076638037 /* Public */ = {
+		G_8669332660719 /* Stripe */ = {
 			isa = PBXGroup;
 			children = (
-				G_5677173492125 /* Stripe */,
+				G_5056339259752 /* pod_support */,
+				G_4327770919765 /* Stripe */,
+			);
+			path = Stripe;
+			sourceTree = "<group>";
+		};
+		G_8959664874258 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				G_4757866348192 /* PINOperation */,
 			);
 			path = Public;
 			sourceTree = "<group>";
 		};
-		G_8620238527590 /* Products */ = {
+		G_9082154448797 /* StringsExtension */ = {
 			isa = PBXGroup;
 			children = (
-				FR_764575073058 /* HeaderLib-ios-11.3.a */,
-				FR_756408111234 /* HeaderLib-ios-9.0.a */,
-				FR_515018785028 /* PINCache-Arc-exception-safe-ios-11.3.a */,
-				FR_540393113192 /* PINCache-Arc-exception-safe-ios-9.0.a */,
-				FR_805275538402 /* PINCache-Core-ios-11.3.a */,
-				FR_686972168627 /* PINCache-Core-ios-9.0.a */,
-				FR_832542114231 /* PINOperation-ios-11.3.a */,
-				FR_776001027518 /* PINOperation-ios-9.0.a */,
-				FR_707080851040 /* Stripe-Stripe_Bundle_Stripe-ios-11.3.bundle */,
-				FR_524308052075 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */,
-				FR_196722873933 /* Stripe-ios-11.3.a */,
-				FR_813294530495 /* Stripe-ios-9.0.a */,
-				FR_870129501381 /* UITests.xctest */,
-				FR_314191844776 /* UnitTests.xctest */,
-				FR_583546727827 /* UnitTestsWithHost.xctest */,
-				FR_460131545307 /* UrlGetClasses-ios-11.3.a */,
-				FR_175704718595 /* UrlGetClasses-ios-9.0.a */,
-				FR_179453799913 /* ios-app-Bazel.app */,
-				FR_875549008649 /* ios-app-bin.a */,
-				FR_443002457585 /* ios-app.app */,
-				FR_637944311431 /* ios-ext-bin.a */,
-				FR_593532437987 /* share-extension-Bazel.appex */,
-				FR_243789410170 /* share-extension.appex */,
-				FR_253406074136 /* siri-ext-bin.a */,
-				FR_361814418977 /* siri-extension.appex */,
-				FR_745612128133 /* strings-ext-bin.a */,
-				FR_910389829219 /* strings-extension.appex */,
+				G_3916061463242 /* Resources */,
+				G_3099399763346 /* Sources */,
 			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		G_8746163756724 /* SiriExtension */ = {
-			isa = PBXGroup;
-			children = (
-				G_7535749096061 /* Resources */,
-				G_1726445755096 /* Sources */,
-			);
-			path = SiriExtension;
-			sourceTree = "<group>";
-		};
-		G_8795405194687 /* PublicHeaders */ = {
-			isa = PBXGroup;
-			children = (
-				FR_357507703280 /* FauxPasAnnotations.h */,
-				FR_138203417337 /* STPAPIClient+ApplePay.h */,
-				FR_381304510417 /* STPAPIClient.h */,
-				FR_884927251036 /* STPAPIResponseDecodable.h */,
-				FR_290482945381 /* STPAddCardViewController.h */,
-				FR_501678888554 /* STPAddress.h */,
-				FR_211137171978 /* STPApplePayPaymentMethod.h */,
-				FR_688345473974 /* STPBackendAPIAdapter.h */,
-				FR_777337581099 /* STPBankAccount.h */,
-				FR_238855777613 /* STPBankAccountParams.h */,
-				FR_679194175341 /* STPBlocks.h */,
-				FR_711062668967 /* STPCard.h */,
-				FR_887633340860 /* STPCardBrand.h */,
-				FR_331004124905 /* STPCardParams.h */,
-				FR_159129633610 /* STPCardValidationState.h */,
-				FR_553085332782 /* STPCardValidator.h */,
-				FR_147204469035 /* STPConnectAccountParams.h */,
-				FR_900194878155 /* STPCoreScrollViewController.h */,
-				FR_484428159681 /* STPCoreTableViewController.h */,
-				FR_912348913657 /* STPCoreViewController.h */,
-				FR_507863811111 /* STPCustomer.h */,
-				FR_662890025590 /* STPCustomerContext.h */,
-				FR_878727202200 /* STPEphemeralKeyProvider.h */,
-				FR_711084170905 /* STPFile.h */,
-				FR_287994782021 /* STPFormEncodable.h */,
-				FR_704991007882 /* STPImageLibrary.h */,
-				FR_113418609357 /* STPLegalEntityParams.h */,
-				FR_296053825144 /* STPPaymentActivityIndicatorView.h */,
-				FR_609916384487 /* STPPaymentCardTextField.h */,
-				FR_536748644256 /* STPPaymentConfiguration.h */,
-				FR_264154326158 /* STPPaymentContext.h */,
-				FR_123089320494 /* STPPaymentMethod.h */,
-				FR_545855187610 /* STPPaymentMethodsViewController.h */,
-				FR_169157621063 /* STPPaymentResult.h */,
-				FR_233450545627 /* STPRedirectContext.h */,
-				FR_699697656028 /* STPShippingAddressViewController.h */,
-				FR_319645862806 /* STPSource.h */,
-				FR_754231351934 /* STPSourceCardDetails.h */,
-				FR_613113088567 /* STPSourceEnums.h */,
-				FR_612435877299 /* STPSourceOwner.h */,
-				FR_638194865189 /* STPSourceParams.h */,
-				FR_777944667952 /* STPSourceProtocol.h */,
-				FR_613101804389 /* STPSourceReceiver.h */,
-				FR_889566942228 /* STPSourceRedirect.h */,
-				FR_113779000903 /* STPSourceSEPADebitDetails.h */,
-				FR_169948489485 /* STPSourceVerification.h */,
-				FR_549563930037 /* STPTheme.h */,
-				FR_551038918304 /* STPToken.h */,
-				FR_519940329301 /* STPUserInformation.h */,
-				FR_761930139089 /* Stripe.h */,
-				FR_239638141147 /* StripeError.h */,
-				FR_480331574684 /* UINavigationBar+Stripe_Theme.h */,
-			);
-			path = PublicHeaders;
-			sourceTree = "<group>";
-		};
-		G_8945623286968 /* Localization */ = {
-			isa = PBXGroup;
-			children = (
-				VG_827262883523 /* InfoPlist.strings */,
-			);
-			path = Localization;
-			sourceTree = "<group>";
-		};
-		G_8972043729317 /* Images */ = {
-			isa = PBXGroup;
-			children = (
-				FR_390212303514 /* stp_card_amex.png */,
-				FR_691812537693 /* stp_card_amex@2x.png */,
-				FR_838405705884 /* stp_card_amex@3x.png */,
-				FR_222214992417 /* stp_card_amex_template.png */,
-				FR_766919050802 /* stp_card_amex_template@2x.png */,
-				FR_766928612639 /* stp_card_amex_template@3x.png */,
-				FR_153681520641 /* stp_card_applepay.png */,
-				FR_458974510861 /* stp_card_applepay@2x.png */,
-				FR_866423752002 /* stp_card_applepay@3x.png */,
-				FR_275604636587 /* stp_card_cvc.png */,
-				FR_202016520148 /* stp_card_cvc@2x.png */,
-				FR_150617010141 /* stp_card_cvc@3x.png */,
-				FR_648806668237 /* stp_card_cvc_amex.png */,
-				FR_441695822925 /* stp_card_cvc_amex@2x.png */,
-				FR_916856507218 /* stp_card_cvc_amex@3x.png */,
-				FR_315436813377 /* stp_card_diners.png */,
-				FR_499280427849 /* stp_card_diners@2x.png */,
-				FR_786618818576 /* stp_card_diners@3x.png */,
-				FR_341722897024 /* stp_card_diners_template.png */,
-				FR_329418993821 /* stp_card_diners_template@2x.png */,
-				FR_329419374230 /* stp_card_diners_template@3x.png */,
-				FR_485714325221 /* stp_card_discover.png */,
-				FR_867716578881 /* stp_card_discover@2x.png */,
-				FR_460546061817 /* stp_card_discover@3x.png */,
-				FR_732161840902 /* stp_card_discover_template.png */,
-				FR_162583091328 /* stp_card_discover_template@2x.png */,
-				FR_162624925573 /* stp_card_discover_template@3x.png */,
-				FR_550412986688 /* stp_card_error.png */,
-				FR_849166683791 /* stp_card_error@2x.png */,
-				FR_550565498786 /* stp_card_error@3x.png */,
-				FR_728079807747 /* stp_card_error_amex.png */,
-				FR_684957154701 /* stp_card_error_amex@2x.png */,
-				FR_684957151634 /* stp_card_error_amex@3x.png */,
-				FR_581387210768 /* stp_card_form_back.png */,
-				FR_471192665951 /* stp_card_form_back@2x.png */,
-				FR_435082555494 /* stp_card_form_back@3x.png */,
-				FR_597218262530 /* stp_card_form_front.png */,
-				FR_767601579243 /* stp_card_form_front@2x.png */,
-				FR_767601582739 /* stp_card_form_front@3x.png */,
-				FR_739797562620 /* stp_card_jcb.png */,
-				FR_498036443375 /* stp_card_jcb@2x.png */,
-				FR_554896677909 /* stp_card_jcb@3x.png */,
-				FR_584192437806 /* stp_card_jcb_template.png */,
-				FR_348062819194 /* stp_card_jcb_template@2x.png */,
-				FR_348062610832 /* stp_card_jcb_template@3x.png */,
-				FR_819492685632 /* stp_card_mastercard.png */,
-				FR_160191367084 /* stp_card_mastercard@2x.png */,
-				FR_160191336416 /* stp_card_mastercard@3x.png */,
-				FR_719224241995 /* stp_card_mastercard_template.png */,
-				FR_914737022420 /* stp_card_mastercard_template@2x.png */,
-				FR_914734393950 /* stp_card_mastercard_template@3x.png */,
-				FR_256481006549 /* stp_card_unionpay_en.png */,
-				FR_119347408405 /* stp_card_unionpay_en@2x.png */,
-				FR_119347389557 /* stp_card_unionpay_en@3x.png */,
-				FR_607555391478 /* stp_card_unionpay_template_en.png */,
-				FR_440272897295 /* stp_card_unionpay_template_en@2x.png */,
-				FR_436922295096 /* stp_card_unionpay_template_en@3x.png */,
-				FR_607867791021 /* stp_card_unionpay_template_zh.png */,
-				FR_438213232580 /* stp_card_unionpay_template_zh@2x.png */,
-				FR_438548292773 /* stp_card_unionpay_template_zh@3x.png */,
-				FR_351629510243 /* stp_card_unionpay_zh.png */,
-				FR_127100545188 /* stp_card_unionpay_zh@2x.png */,
-				FR_127100525052 /* stp_card_unionpay_zh@3x.png */,
-				FR_458081448840 /* stp_card_unknown.png */,
-				FR_653524283850 /* stp_card_unknown@2x.png */,
-				FR_313827850627 /* stp_card_unknown@3x.png */,
-				FR_620185860855 /* stp_card_visa.png */,
-				FR_464213115625 /* stp_card_visa@2x.png */,
-				FR_616218057689 /* stp_card_visa@3x.png */,
-				FR_535609714789 /* stp_card_visa_template.png */,
-				FR_161685209527 /* stp_card_visa_template@2x.png */,
-				FR_161686194489 /* stp_card_visa_template@3x.png */,
-				FR_446151064510 /* stp_icon_add.png */,
-				FR_701860410388 /* stp_icon_add@2x.png */,
-				FR_644827855298 /* stp_icon_add@3x.png */,
-				FR_213958106393 /* stp_icon_checkmark.png */,
-				FR_462265337593 /* stp_icon_checkmark@2x.png */,
-				FR_454974753213 /* stp_icon_checkmark@3x.png */,
-				FR_720396073744 /* stp_shipping_form.png */,
-				FR_166108154819 /* stp_shipping_form@2x.png */,
-				FR_587518550104 /* stp_shipping_form@3x.png */,
-				FR_791168379253 /* stp_test_upload_image.jpeg */,
-			);
-			path = Images;
-			sourceTree = "<group>";
-		};
-		G_9514399547648 /* UrlGet.xcodeproj */ = {
-			isa = PBXGroup;
-			children = (
-				G_1437296305341 /* XCHammerAssets */,
-			);
-			path = UrlGet.xcodeproj;
+			path = StringsExtension;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXLegacyTarget section */
-		LT_100178272237 /* ResetLLDBInit */ = {
+		LT_535582595715 /* ResetLLDBInit */ = {
 			isa = PBXLegacyTarget;
 			buildArgumentsString = "-c 'echo \"settings clear target.source-map\" > ~/.lldbinit-tulsiproj'";
-			buildConfigurationList = CL_100178272237 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */;
+			buildConfigurationList = CL_535582595715 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */;
 			buildPhases = (
-				SBP_10017827223 /* Sources */,
+				SBP_53558259571 /* Sources */,
 			);
 			buildToolPath = /bin/bash;
-			buildWorkingDirectory = /Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet;
+			buildWorkingDirectory = "/Users/jerry/Projects/xchammer-github/sample/UrlGet";
 			dependencies = (
 			);
 			name = ResetLLDBInit;
 			passBuildSettingsInEnvironment = 1;
 			productName = ResetLLDBInit;
 		};
-		LT_173102942353 /* GeneratedFiles */ = {
+		LT_629454187867 /* UpdateXcodeProject */ = {
 			isa = PBXLegacyTarget;
-			buildArgumentsString = "-c '[[ \"$(ACTION)\" == \"clean\" ]] && (/Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet/tools/bazelwrapper clean) || (/Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/retry.sh /Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet/tools/bazelwrapper build --experimental_show_artifacts //ios-app:strings-extension_entitlements //ios-app:siri-extension_entitlements //ios-app:share-extension_entitlements //ios-app:ios-app_entitlements //Vendor/PINOperation:PINOperation_module_map_module_map_file //Vendor/PINCache:PINCache_module_map_module_map_file //Vendor/GoogleSymbolUtilities:GoogleSymbolUtilities_module_map_module_map_file //Vendor/GoogleNetworkingUtilities:GoogleNetworkingUtilities_module_map_module_map_file //Vendor/GoogleAuthUtilities:GoogleAuthUtilities_module_map_module_map_file //Vendor/GoogleAppIndexing:GoogleAppIndexing_module_map_module_map_file //UrlGet.xcodeproj/XCHammerAssets:ios-app-siri-extension_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-share-extension_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-ios-app_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-strings-extension_entitlements)'";
-			buildConfigurationList = CL_173102942353 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */;
+			buildArgumentsString = "-c /Users/jerry/Projects/xchammer-github/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/updateXcodeProj.sh";
+			buildConfigurationList = CL_629454187867 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */;
 			buildPhases = (
-				SBP_17310294235 /* Sources */,
+				SBP_62945418786 /* Sources */,
 			);
 			buildToolPath = /bin/bash;
-			buildWorkingDirectory = /Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet;
-			dependencies = (
-			);
-			name = GeneratedFiles;
-			passBuildSettingsInEnvironment = 1;
-			productName = GeneratedFiles;
-		};
-		LT_183987345262 /* UpdateXcodeProject */ = {
-			isa = PBXLegacyTarget;
-			buildArgumentsString = "-c /Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/updateXcodeProj.sh";
-			buildConfigurationList = CL_183987345262 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */;
-			buildPhases = (
-				SBP_18398734526 /* Sources */,
-			);
-			buildToolPath = /bin/bash;
-			buildWorkingDirectory = /Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet;
+			buildWorkingDirectory = "/Users/jerry/Projects/xchammer-github/sample/UrlGet";
 			dependencies = (
 			);
 			name = UpdateXcodeProject;
 			passBuildSettingsInEnvironment = 1;
 			productName = UpdateXcodeProject;
 		};
+		LT_879714440108 /* GeneratedFiles */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "-c '[[ \"$(ACTION)\" == \"clean\" ]] && (/Users/jerry/Projects/xchammer-github/sample/UrlGet/tools/bazelwrapper clean) || (/Users/jerry/Projects/xchammer-github/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/retry.sh /Users/jerry/Projects/xchammer-github/sample/UrlGet/tools/bazelwrapper build --experimental_show_artifacts //UrlGet.xcodeproj/XCHammerAssets:ios-app-share-extension_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-strings-extension_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-siri-extension_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-ios-app_entitlements)'";
+			buildConfigurationList = CL_879714440108 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */;
+			buildPhases = (
+				SBP_87971444010 /* Sources */,
+			);
+			buildToolPath = /bin/bash;
+			buildWorkingDirectory = "/Users/jerry/Projects/xchammer-github/sample/UrlGet";
+			dependencies = (
+			);
+			name = GeneratedFiles;
+			passBuildSettingsInEnvironment = 1;
+			productName = GeneratedFiles;
+		};
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
-		NT_175704718595 /* UrlGetClasses-ios-9.0 */ = {
+		NT_107066082523 /* strings-extension */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_175704718595 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-9.0" */;
+			buildConfigurationList = CL_107066082523 /* Build configuration list for PBXNativeTarget "strings-extension" */;
 			buildPhases = (
-				SBP_17570471859 /* Sources */,
-				RBP_17570471859 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "UrlGetClasses-ios-9.0";
-			productName = "UrlGetClasses-ios-9.0";
-			productReference = FR_175704718595 /* UrlGetClasses-ios-9.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_179453799913 /* ios-app-Bazel */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_179453799913 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */;
-			buildPhases = (
-				SSBP_8118918997 /* Bazel build */,
-				SBP_17945379991 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ios-app-Bazel";
-			productName = "ios-app-Bazel";
-			productReference = FR_179453799913 /* ios-app-Bazel.app */;
-			productType = "com.apple.product-type.application";
-		};
-		NT_196722873933 /* Stripe-ios-11.3 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_196722873933 /* Build configuration list for PBXNativeTarget "Stripe-ios-11.3" */;
-			buildPhases = (
-				SBP_19672287393 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Stripe-ios-11.3";
-			productName = "Stripe-ios-11.3";
-			productReference = FR_196722873933 /* Stripe-ios-11.3.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_243789410170 /* share-extension */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_243789410170 /* Build configuration list for PBXNativeTarget "share-extension" */;
-			buildPhases = (
-				SBP_24378941017 /* Sources */,
-				RBP_24378941017 /* Resources */,
-				FBP_24378941017 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "share-extension";
-			productName = "share-extension";
-			productReference = FR_243789410170 /* share-extension.appex */;
-			productType = "com.apple.product-type.app-extension";
-		};
-		NT_253406074136 /* siri-ext-bin */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_253406074136 /* Build configuration list for PBXNativeTarget "siri-ext-bin" */;
-			buildPhases = (
-				SBP_25340607413 /* Sources */,
-				RBP_25340607413 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "siri-ext-bin";
-			productName = "siri-ext-bin";
-			productReference = FR_253406074136 /* siri-ext-bin.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_314191844776 /* UnitTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_314191844776 /* Build configuration list for PBXNativeTarget "UnitTests" */;
-			buildPhases = (
-				SBP_31419184477 /* Sources */,
-				RBP_31419184477 /* Resources */,
-				FBP_31419184477 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = UnitTests;
-			productName = UnitTests;
-			productReference = FR_314191844776 /* UnitTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		NT_361814418977 /* siri-extension */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_361814418977 /* Build configuration list for PBXNativeTarget "siri-extension" */;
-			buildPhases = (
-				SBP_36181441897 /* Sources */,
-				RBP_36181441897 /* Resources */,
-				FBP_36181441897 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "siri-extension";
-			productName = "siri-extension";
-			productReference = FR_361814418977 /* siri-extension.appex */;
-			productType = "com.apple.product-type.app-extension";
-		};
-		NT_443002457585 /* ios-app */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_443002457585 /* Build configuration list for PBXNativeTarget "ios-app" */;
-			buildPhases = (
-				SBP_44300245758 /* Sources */,
-				RBP_44300245758 /* Resources */,
-				FBP_44300245758 /* Frameworks */,
-				CFBP_6358864645 /* CopyFiles */,
-				SSBP_6558405859 /* Process IPA */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_535733985110 /* PBXTargetDependency */,
-				TD_555833782667 /* PBXTargetDependency */,
-				TD_747346155877 /* PBXTargetDependency */,
-			);
-			name = "ios-app";
-			productName = "ios-app";
-			productReference = FR_443002457585 /* ios-app.app */;
-			productType = "com.apple.product-type.application";
-		};
-		NT_460131545307 /* UrlGetClasses-ios-11.3 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_460131545307 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-11.3" */;
-			buildPhases = (
-				SBP_46013154530 /* Sources */,
-				RBP_46013154530 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "UrlGetClasses-ios-11.3";
-			productName = "UrlGetClasses-ios-11.3";
-			productReference = FR_460131545307 /* UrlGetClasses-ios-11.3.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_515018785028 /* PINCache-Arc-exception-safe-ios-11.3 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_515018785028 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-11.3" */;
-			buildPhases = (
-				SBP_51501878502 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "PINCache-Arc-exception-safe-ios-11.3";
-			productName = "PINCache-Arc-exception-safe-ios-11.3";
-			productReference = FR_515018785028 /* PINCache-Arc-exception-safe-ios-11.3.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_524308052075 /* Stripe-Stripe_Bundle_Stripe-ios-9.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_524308052075 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-9.0" */;
-			buildPhases = (
-				SBP_52430805207 /* Sources */,
-				RBP_52430805207 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Stripe-Stripe_Bundle_Stripe-ios-9.0";
-			productName = "Stripe-Stripe_Bundle_Stripe-ios-9.0";
-			productReference = FR_524308052075 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */;
-			productType = "com.apple.product-type.bundle";
-		};
-		NT_540393113192 /* PINCache-Arc-exception-safe-ios-9.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_540393113192 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-9.0" */;
-			buildPhases = (
-				SBP_54039311319 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "PINCache-Arc-exception-safe-ios-9.0";
-			productName = "PINCache-Arc-exception-safe-ios-9.0";
-			productReference = FR_540393113192 /* PINCache-Arc-exception-safe-ios-9.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_583546727827 /* UnitTestsWithHost */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_583546727827 /* Build configuration list for PBXNativeTarget "UnitTestsWithHost" */;
-			buildPhases = (
-				SBP_58354672782 /* Sources */,
-				RBP_58354672782 /* Resources */,
-				FBP_58354672782 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_729310227567 /* PBXTargetDependency */,
-			);
-			name = UnitTestsWithHost;
-			productName = UnitTestsWithHost;
-			productReference = FR_583546727827 /* UnitTestsWithHost.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		NT_593532437987 /* share-extension-Bazel */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_593532437987 /* Build configuration list for PBXNativeTarget "share-extension-Bazel" */;
-			buildPhases = (
-				SSBP_6545361203 /* Bazel build */,
-				SBP_59353243798 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "share-extension-Bazel";
-			productName = "share-extension-Bazel";
-			productReference = FR_593532437987 /* share-extension-Bazel.appex */;
-			productType = "com.apple.product-type.app-extension";
-		};
-		NT_637944311431 /* ios-ext-bin */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_637944311431 /* Build configuration list for PBXNativeTarget "ios-ext-bin" */;
-			buildPhases = (
-				SBP_63794431143 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ios-ext-bin";
-			productName = "ios-ext-bin";
-			productReference = FR_637944311431 /* ios-ext-bin.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_686972168627 /* PINCache-Core-ios-9.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_686972168627 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-9.0" */;
-			buildPhases = (
-				SBP_68697216862 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "PINCache-Core-ios-9.0";
-			productName = "PINCache-Core-ios-9.0";
-			productReference = FR_686972168627 /* PINCache-Core-ios-9.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_707080851040 /* Stripe-Stripe_Bundle_Stripe-ios-11.3 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_707080851040 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-11.3" */;
-			buildPhases = (
-				SBP_70708085104 /* Sources */,
-				RBP_70708085104 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Stripe-Stripe_Bundle_Stripe-ios-11.3";
-			productName = "Stripe-Stripe_Bundle_Stripe-ios-11.3";
-			productReference = FR_707080851040 /* Stripe-Stripe_Bundle_Stripe-ios-11.3.bundle */;
-			productType = "com.apple.product-type.bundle";
-		};
-		NT_745612128133 /* strings-ext-bin */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_745612128133 /* Build configuration list for PBXNativeTarget "strings-ext-bin" */;
-			buildPhases = (
-				SBP_74561212813 /* Sources */,
-				RBP_74561212813 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "strings-ext-bin";
-			productName = "strings-ext-bin";
-			productReference = FR_745612128133 /* strings-ext-bin.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_756408111234 /* HeaderLib-ios-9.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_756408111234 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-9.0" */;
-			buildPhases = (
-				SBP_75640811123 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "HeaderLib-ios-9.0";
-			productName = "HeaderLib-ios-9.0";
-			productReference = FR_756408111234 /* HeaderLib-ios-9.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_764575073058 /* HeaderLib-ios-11.3 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_764575073058 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-11.3" */;
-			buildPhases = (
-				SBP_76457507305 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "HeaderLib-ios-11.3";
-			productName = "HeaderLib-ios-11.3";
-			productReference = FR_764575073058 /* HeaderLib-ios-11.3.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_776001027518 /* PINOperation-ios-9.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_776001027518 /* Build configuration list for PBXNativeTarget "PINOperation-ios-9.0" */;
-			buildPhases = (
-				SBP_77600102751 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "PINOperation-ios-9.0";
-			productName = "PINOperation-ios-9.0";
-			productReference = FR_776001027518 /* PINOperation-ios-9.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_805275538402 /* PINCache-Core-ios-11.3 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_805275538402 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-11.3" */;
-			buildPhases = (
-				SBP_80527553840 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "PINCache-Core-ios-11.3";
-			productName = "PINCache-Core-ios-11.3";
-			productReference = FR_805275538402 /* PINCache-Core-ios-11.3.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_813294530495 /* Stripe-ios-9.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_813294530495 /* Build configuration list for PBXNativeTarget "Stripe-ios-9.0" */;
-			buildPhases = (
-				SBP_81329453049 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Stripe-ios-9.0";
-			productName = "Stripe-ios-9.0";
-			productReference = FR_813294530495 /* Stripe-ios-9.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_832542114231 /* PINOperation-ios-11.3 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_832542114231 /* Build configuration list for PBXNativeTarget "PINOperation-ios-11.3" */;
-			buildPhases = (
-				SBP_83254211423 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "PINOperation-ios-11.3";
-			productName = "PINOperation-ios-11.3";
-			productReference = FR_832542114231 /* PINOperation-ios-11.3.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_870129501381 /* UITests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_870129501381 /* Build configuration list for PBXNativeTarget "UITests" */;
-			buildPhases = (
-				SBP_87012950138 /* Sources */,
-				RBP_87012950138 /* Resources */,
-				FBP_87012950138 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_685884567289 /* PBXTargetDependency */,
-			);
-			name = UITests;
-			productName = UITests;
-			productReference = FR_870129501381 /* UITests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		NT_875549008649 /* ios-app-bin */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_875549008649 /* Build configuration list for PBXNativeTarget "ios-app-bin" */;
-			buildPhases = (
-				SBP_87554900864 /* Sources */,
-				RBP_87554900864 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ios-app-bin";
-			productName = "ios-app-bin";
-			productReference = FR_875549008649 /* ios-app-bin.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_910389829219 /* strings-extension */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_910389829219 /* Build configuration list for PBXNativeTarget "strings-extension" */;
-			buildPhases = (
-				SBP_91038982921 /* Sources */,
-				RBP_91038982921 /* Resources */,
-				FBP_91038982921 /* Frameworks */,
+				SBP_10706608252 /* Sources */,
+				RBP_10706608252 /* Resources */,
+				FBP_10706608252 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2579,101 +3543,533 @@
 			);
 			name = "strings-extension";
 			productName = "strings-extension";
-			productReference = FR_910389829219 /* strings-extension.appex */;
+			productReference = FR_107066082523 /* strings-extension.appex */;
 			productType = "com.apple.product-type.app-extension";
+		};
+		NT_131920372131 /* PINCache-Arc-exception-safe-ios-12.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_131920372131 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-12.0" */;
+			buildPhases = (
+				SBP_13192037213 /* Sources */,
+				CFBP_3613973714 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINCache-Arc-exception-safe-ios-12.0";
+			productName = "PINCache-Arc-exception-safe-ios-12.0";
+			productReference = FR_131920372131 /* PINCache-Arc-exception-safe-ios-12.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_162101825678 /* UnitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_162101825678 /* Build configuration list for PBXNativeTarget "UnitTests" */;
+			buildPhases = (
+				SBP_16210182567 /* Sources */,
+				RBP_16210182567 /* Resources */,
+				FBP_16210182567 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = UnitTests;
+			productName = UnitTests;
+			productReference = FR_162101825678 /* UnitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		NT_196725857447 /* UrlGetClasses-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_196725857447 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-9.0" */;
+			buildPhases = (
+				SBP_19672585744 /* Sources */,
+				RBP_19672585744 /* Resources */,
+				CFBP_7780861546 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "UrlGetClasses-ios-9.0";
+			productName = "UrlGetClasses-ios-9.0";
+			productReference = FR_196725857447 /* UrlGetClasses-ios-9.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_205363634933 /* share-extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_205363634933 /* Build configuration list for PBXNativeTarget "share-extension" */;
+			buildPhases = (
+				SBP_20536363493 /* Sources */,
+				RBP_20536363493 /* Resources */,
+				FBP_20536363493 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "share-extension";
+			productName = "share-extension";
+			productReference = FR_205363634933 /* share-extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		NT_232037670091 /* PINCache-Core-ios-12.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_232037670091 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-12.0" */;
+			buildPhases = (
+				SBP_23203767009 /* Sources */,
+				CFBP_7126762060 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINCache-Core-ios-12.0";
+			productName = "PINCache-Core-ios-12.0";
+			productReference = FR_232037670091 /* PINCache-Core-ios-12.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_287747118355 /* siri-extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_287747118355 /* Build configuration list for PBXNativeTarget "siri-extension" */;
+			buildPhases = (
+				SBP_28774711835 /* Sources */,
+				RBP_28774711835 /* Resources */,
+				FBP_28774711835 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "siri-extension";
+			productName = "siri-extension";
+			productReference = FR_287747118355 /* siri-extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		NT_321038524600 /* HeaderLib-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_321038524600 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-9.0" */;
+			buildPhases = (
+				SBP_32103852460 /* Sources */,
+				CFBP_3440035043 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "HeaderLib-ios-9.0";
+			productName = "HeaderLib-ios-9.0";
+			productReference = FR_321038524600 /* HeaderLib-ios-9.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_394586624846 /* UnitTestsWithHost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_394586624846 /* Build configuration list for PBXNativeTarget "UnitTestsWithHost" */;
+			buildPhases = (
+				SBP_39458662484 /* Sources */,
+				RBP_39458662484 /* Resources */,
+				FBP_39458662484 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TD_705726845901 /* PBXTargetDependency */,
+			);
+			name = UnitTestsWithHost;
+			productName = UnitTestsWithHost;
+			productReference = FR_394586624846 /* UnitTestsWithHost.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		NT_424996891355 /* share-extension-Bazel */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_424996891355 /* Build configuration list for PBXNativeTarget "share-extension-Bazel" */;
+			buildPhases = (
+				SSBP_8889053436 /* Bazel build */,
+				SBP_42499689135 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "share-extension-Bazel";
+			productName = "share-extension-Bazel";
+			productReference = FR_424996891355 /* share-extension-Bazel.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		NT_466327725618 /* PINCache-Core-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_466327725618 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-9.0" */;
+			buildPhases = (
+				SBP_46632772561 /* Sources */,
+				CFBP_6605403167 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINCache-Core-ios-9.0";
+			productName = "PINCache-Core-ios-9.0";
+			productReference = FR_466327725618 /* PINCache-Core-ios-9.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_575785382123 /* PINOperation-ios-12.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_575785382123 /* Build configuration list for PBXNativeTarget "PINOperation-ios-12.0" */;
+			buildPhases = (
+				SBP_57578538212 /* Sources */,
+				CFBP_3307452246 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINOperation-ios-12.0";
+			productName = "PINOperation-ios-12.0";
+			productReference = FR_575785382123 /* PINOperation-ios-12.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_576098273475 /* siri-ext-bin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_576098273475 /* Build configuration list for PBXNativeTarget "siri-ext-bin" */;
+			buildPhases = (
+				SBP_57609827347 /* Sources */,
+				RBP_57609827347 /* Resources */,
+				CFBP_7861390617 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "siri-ext-bin";
+			productName = "siri-ext-bin";
+			productReference = FR_576098273475 /* siri-ext-bin.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_655977824079 /* ios-ext-bin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_655977824079 /* Build configuration list for PBXNativeTarget "ios-ext-bin" */;
+			buildPhases = (
+				SBP_65597782407 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ios-ext-bin";
+			productName = "ios-ext-bin";
+			productReference = FR_655977824079 /* ios-ext-bin.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_656630461598 /* PINCache-Arc-exception-safe-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_656630461598 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-9.0" */;
+			buildPhases = (
+				SBP_65663046159 /* Sources */,
+				CFBP_2043682735 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINCache-Arc-exception-safe-ios-9.0";
+			productName = "PINCache-Arc-exception-safe-ios-9.0";
+			productReference = FR_656630461598 /* PINCache-Arc-exception-safe-ios-9.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_664069285608 /* Stripe-ios-12.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_664069285608 /* Build configuration list for PBXNativeTarget "Stripe-ios-12.0" */;
+			buildPhases = (
+				SBP_66406928560 /* Sources */,
+				CFBP_3825973267 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Stripe-ios-12.0";
+			productName = "Stripe-ios-12.0";
+			productReference = FR_664069285608 /* Stripe-ios-12.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_677790726659 /* PINOperation-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_677790726659 /* Build configuration list for PBXNativeTarget "PINOperation-ios-9.0" */;
+			buildPhases = (
+				SBP_67779072665 /* Sources */,
+				CFBP_4550878434 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINOperation-ios-9.0";
+			productName = "PINOperation-ios-9.0";
+			productReference = FR_677790726659 /* PINOperation-ios-9.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_700633204216 /* ios-app-Bazel */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_700633204216 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */;
+			buildPhases = (
+				SSBP_3346118699 /* Bazel build */,
+				SBP_70063320421 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ios-app-Bazel";
+			productName = "ios-app-Bazel";
+			productReference = FR_700633204216 /* ios-app-Bazel.app */;
+			productType = "com.apple.product-type.application";
+		};
+		NT_757956135481 /* ios-app */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_757956135481 /* Build configuration list for PBXNativeTarget "ios-app" */;
+			buildPhases = (
+				SBP_75795613548 /* Sources */,
+				RBP_75795613548 /* Resources */,
+				FBP_75795613548 /* Frameworks */,
+				CFBP_2000350847 /* Embed App Extensions */,
+				SSBP_8885571800 /* Process IPA */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TD_835876748852 /* PBXTargetDependency */,
+				TD_745023143073 /* PBXTargetDependency */,
+				TD_818879859525 /* PBXTargetDependency */,
+			);
+			name = "ios-app";
+			productName = "ios-app";
+			productReference = FR_757956135481 /* ios-app.app */;
+			productType = "com.apple.product-type.application";
+		};
+		NT_767805223807 /* Stripe-Stripe_Bundle_Stripe-ios-12.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_767805223807 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-12.0" */;
+			buildPhases = (
+				SBP_76780522380 /* Sources */,
+				RBP_76780522380 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Stripe-Stripe_Bundle_Stripe-ios-12.0";
+			productName = "Stripe-Stripe_Bundle_Stripe-ios-12.0";
+			productReference = FR_767805223807 /* Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		NT_818473893886 /* ios-app-bin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_818473893886 /* Build configuration list for PBXNativeTarget "ios-app-bin" */;
+			buildPhases = (
+				SBP_81847389388 /* Sources */,
+				RBP_81847389388 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ios-app-bin";
+			productName = "ios-app-bin";
+			productReference = FR_818473893886 /* ios-app-bin.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_842212741120 /* strings-ext-bin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_842212741120 /* Build configuration list for PBXNativeTarget "strings-ext-bin" */;
+			buildPhases = (
+				SBP_84221274112 /* Sources */,
+				RBP_84221274112 /* Resources */,
+				CFBP_4459384815 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "strings-ext-bin";
+			productName = "strings-ext-bin";
+			productReference = FR_842212741120 /* strings-ext-bin.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_844946125614 /* Stripe-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_844946125614 /* Build configuration list for PBXNativeTarget "Stripe-ios-9.0" */;
+			buildPhases = (
+				SBP_84494612561 /* Sources */,
+				CFBP_1548478967 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Stripe-ios-9.0";
+			productName = "Stripe-ios-9.0";
+			productReference = FR_844946125614 /* Stripe-ios-9.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_855762236329 /* HeaderLib-ios-12.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_855762236329 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-12.0" */;
+			buildPhases = (
+				SBP_85576223632 /* Sources */,
+				CFBP_5088663457 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "HeaderLib-ios-12.0";
+			productName = "HeaderLib-ios-12.0";
+			productReference = FR_855762236329 /* HeaderLib-ios-12.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_863786754985 /* UITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_863786754985 /* Build configuration list for PBXNativeTarget "UITests" */;
+			buildPhases = (
+				SBP_86378675498 /* Sources */,
+				RBP_86378675498 /* Resources */,
+				FBP_86378675498 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TD_779354981654 /* PBXTargetDependency */,
+			);
+			name = UITests;
+			productName = UITests;
+			productReference = FR_863786754985 /* UITests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		NT_903718557818 /* Stripe-Stripe_Bundle_Stripe-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_903718557818 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-9.0" */;
+			buildPhases = (
+				SBP_90371855781 /* Sources */,
+				RBP_90371855781 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Stripe-Stripe_Bundle_Stripe-ios-9.0";
+			productName = "Stripe-Stripe_Bundle_Stripe-ios-9.0";
+			productReference = FR_903718557818 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		NT_906505729587 /* UrlGetClasses-ios-12.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_906505729587 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-12.0" */;
+			buildPhases = (
+				SBP_90650572958 /* Sources */,
+				RBP_90650572958 /* Resources */,
+				CFBP_1192997001 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "UrlGetClasses-ios-12.0";
+			productName = "UrlGetClasses-ios-12.0";
+			productReference = FR_906505729587 /* UrlGetClasses-ios-12.0.a */;
+			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		P_4793904575952 /* Project object */ = {
+		P_4192881629041 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0930;
 				TargetAttributes = {
-					NT_175704718595 = {
+					NT_107066082523 = {
 						ProvisioningStyle = manual;
 					};
-					NT_179453799913 = {
+					NT_131920372131 = {
 						ProvisioningStyle = manual;
 					};
-					NT_196722873933 = {
+					NT_162101825678 = {
 						ProvisioningStyle = manual;
 					};
-					NT_243789410170 = {
+					NT_196725857447 = {
 						ProvisioningStyle = manual;
 					};
-					NT_253406074136 = {
+					NT_205363634933 = {
 						ProvisioningStyle = manual;
 					};
-					NT_314191844776 = {
+					NT_232037670091 = {
 						ProvisioningStyle = manual;
 					};
-					NT_361814418977 = {
+					NT_287747118355 = {
 						ProvisioningStyle = manual;
 					};
-					NT_443002457585 = {
+					NT_321038524600 = {
 						ProvisioningStyle = manual;
 					};
-					NT_460131545307 = {
+					NT_394586624846 = {
 						ProvisioningStyle = manual;
 					};
-					NT_515018785028 = {
+					NT_424996891355 = {
 						ProvisioningStyle = manual;
 					};
-					NT_524308052075 = {
+					NT_466327725618 = {
 						ProvisioningStyle = manual;
 					};
-					NT_540393113192 = {
+					NT_575785382123 = {
 						ProvisioningStyle = manual;
 					};
-					NT_583546727827 = {
+					NT_576098273475 = {
 						ProvisioningStyle = manual;
 					};
-					NT_593532437987 = {
+					NT_655977824079 = {
 						ProvisioningStyle = manual;
 					};
-					NT_637944311431 = {
+					NT_656630461598 = {
 						ProvisioningStyle = manual;
 					};
-					NT_686972168627 = {
+					NT_664069285608 = {
 						ProvisioningStyle = manual;
 					};
-					NT_707080851040 = {
+					NT_677790726659 = {
 						ProvisioningStyle = manual;
 					};
-					NT_745612128133 = {
+					NT_700633204216 = {
 						ProvisioningStyle = manual;
 					};
-					NT_756408111234 = {
+					NT_757956135481 = {
 						ProvisioningStyle = manual;
 					};
-					NT_764575073058 = {
+					NT_767805223807 = {
 						ProvisioningStyle = manual;
 					};
-					NT_776001027518 = {
+					NT_818473893886 = {
 						ProvisioningStyle = manual;
 					};
-					NT_805275538402 = {
+					NT_842212741120 = {
 						ProvisioningStyle = manual;
 					};
-					NT_813294530495 = {
+					NT_844946125614 = {
 						ProvisioningStyle = manual;
 					};
-					NT_832542114231 = {
+					NT_855762236329 = {
 						ProvisioningStyle = manual;
 					};
-					NT_870129501381 = {
+					NT_863786754985 = {
 						ProvisioningStyle = manual;
 					};
-					NT_875549008649 = {
+					NT_903718557818 = {
 						ProvisioningStyle = manual;
 					};
-					NT_910389829219 = {
+					NT_906505729587 = {
 						ProvisioningStyle = manual;
 					};
 				};
 			};
-			buildConfigurationList = CL_479390457595 /* Build configuration list for PBXProject "UrlGet" */;
+			buildConfigurationList = CL_419288162904 /* Build configuration list for PBXProject "UrlGet" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -2692,334 +4088,334 @@
 				"zh-Hans",
 				"zh-Hant",
 			);
-			mainGroup = G_8448771205358;
+			mainGroup = G_8595232905817;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				LT_173102942353 /* GeneratedFiles */,
-				NT_764575073058 /* HeaderLib-ios-11.3 */,
-				NT_756408111234 /* HeaderLib-ios-9.0 */,
-				NT_515018785028 /* PINCache-Arc-exception-safe-ios-11.3 */,
-				NT_540393113192 /* PINCache-Arc-exception-safe-ios-9.0 */,
-				NT_805275538402 /* PINCache-Core-ios-11.3 */,
-				NT_686972168627 /* PINCache-Core-ios-9.0 */,
-				NT_832542114231 /* PINOperation-ios-11.3 */,
-				NT_776001027518 /* PINOperation-ios-9.0 */,
-				LT_100178272237 /* ResetLLDBInit */,
-				NT_707080851040 /* Stripe-Stripe_Bundle_Stripe-ios-11.3 */,
-				NT_524308052075 /* Stripe-Stripe_Bundle_Stripe-ios-9.0 */,
-				NT_196722873933 /* Stripe-ios-11.3 */,
-				NT_813294530495 /* Stripe-ios-9.0 */,
-				NT_870129501381 /* UITests */,
-				NT_314191844776 /* UnitTests */,
-				NT_583546727827 /* UnitTestsWithHost */,
-				LT_183987345262 /* UpdateXcodeProject */,
-				NT_460131545307 /* UrlGetClasses-ios-11.3 */,
-				NT_175704718595 /* UrlGetClasses-ios-9.0 */,
-				NT_443002457585 /* ios-app */,
-				NT_179453799913 /* ios-app-Bazel */,
-				NT_875549008649 /* ios-app-bin */,
-				NT_637944311431 /* ios-ext-bin */,
-				NT_243789410170 /* share-extension */,
-				NT_593532437987 /* share-extension-Bazel */,
-				NT_253406074136 /* siri-ext-bin */,
-				NT_361814418977 /* siri-extension */,
-				NT_745612128133 /* strings-ext-bin */,
-				NT_910389829219 /* strings-extension */,
+				LT_879714440108 /* GeneratedFiles */,
+				NT_855762236329 /* HeaderLib-ios-12.0 */,
+				NT_321038524600 /* HeaderLib-ios-9.0 */,
+				NT_131920372131 /* PINCache-Arc-exception-safe-ios-12.0 */,
+				NT_656630461598 /* PINCache-Arc-exception-safe-ios-9.0 */,
+				NT_232037670091 /* PINCache-Core-ios-12.0 */,
+				NT_466327725618 /* PINCache-Core-ios-9.0 */,
+				NT_575785382123 /* PINOperation-ios-12.0 */,
+				NT_677790726659 /* PINOperation-ios-9.0 */,
+				LT_535582595715 /* ResetLLDBInit */,
+				NT_767805223807 /* Stripe-Stripe_Bundle_Stripe-ios-12.0 */,
+				NT_903718557818 /* Stripe-Stripe_Bundle_Stripe-ios-9.0 */,
+				NT_664069285608 /* Stripe-ios-12.0 */,
+				NT_844946125614 /* Stripe-ios-9.0 */,
+				NT_863786754985 /* UITests */,
+				NT_162101825678 /* UnitTests */,
+				NT_394586624846 /* UnitTestsWithHost */,
+				LT_629454187867 /* UpdateXcodeProject */,
+				NT_906505729587 /* UrlGetClasses-ios-12.0 */,
+				NT_196725857447 /* UrlGetClasses-ios-9.0 */,
+				NT_757956135481 /* ios-app */,
+				NT_700633204216 /* ios-app-Bazel */,
+				NT_818473893886 /* ios-app-bin */,
+				NT_655977824079 /* ios-ext-bin */,
+				NT_205363634933 /* share-extension */,
+				NT_424996891355 /* share-extension-Bazel */,
+				NT_576098273475 /* siri-ext-bin */,
+				NT_287747118355 /* siri-extension */,
+				NT_842212741120 /* strings-ext-bin */,
+				NT_107066082523 /* strings-extension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		RBP_17570471859 /* Resources */ = {
+		RBP_10706608252 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_379613470386 /* GoogleAppIndexingResources.bundle in Resources */,
-				BF_625777932861 /* UrlGetViewController.xib in Resources */,
+				BF_420301864162 /* InfoPlist.strings in Resources */,
+				BF_627155690991 /* StringsExtension-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_24378941017 /* Resources */ = {
+		RBP_16210182567 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_673487248208 /* ShareExtension-Info.plist in Resources */,
+				BF_825318156586 /* GoogleAppIndexingResources.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_25340607413 /* Resources */ = {
+		RBP_19672585744 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_227610620572 /* AppIntentVocabulary.plist in Resources */,
+				BF_498867406999 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_227579742807 /* UrlGetViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_31419184477 /* Resources */ = {
+		RBP_20536363493 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_524688171203 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_396790623337 /* ShareExtension-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_36181441897 /* Resources */ = {
+		RBP_28774711835 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_707044678539 /* AppIntentVocabulary.plist in Resources */,
-				BF_691914571811 /* SiriExtension-Info.plist in Resources */,
+				BF_638527070046 /* AppIntentVocabulary.plist in Resources */,
+				BF_895595545075 /* SiriExtension-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_44300245758 /* Resources */ = {
+		RBP_39458662484 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_529924854363 /* GoogleAppIndexingResources.bundle in Resources */,
-				BF_128560851764 /* ShareExtension-Info.plist in Resources */,
-				BF_668909179812 /* SiriExtension-Info.plist in Resources */,
-				BF_372859359289 /* StringsExtension-Info.plist in Resources */,
-				BF_951074971939 /* UrlGet-Info.plist in Resources */,
-				BF_632167503271 /* UrlGetViewController.xib in Resources */,
+				BF_630730911163 /* GoogleAppIndexingResources.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_46013154530 /* Resources */ = {
+		RBP_57609827347 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_471380831706 /* GoogleAppIndexingResources.bundle in Resources */,
-				BF_597354886609 /* UrlGetViewController.xib in Resources */,
+				BF_526637614106 /* AppIntentVocabulary.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_52430805207 /* Resources */ = {
+		RBP_75795613548 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_135181373888 /* Localizable.strings in Resources */,
-				BF_436043688776 /* stp_card_amex.png in Resources */,
-				BF_296262923336 /* stp_card_amex@2x.png in Resources */,
-				BF_357314905437 /* stp_card_amex@3x.png in Resources */,
-				BF_803250566133 /* stp_card_amex_template.png in Resources */,
-				BF_565454288660 /* stp_card_amex_template@2x.png in Resources */,
-				BF_164275633159 /* stp_card_amex_template@3x.png in Resources */,
-				BF_310147481663 /* stp_card_applepay.png in Resources */,
-				BF_125879088495 /* stp_card_applepay@2x.png in Resources */,
-				BF_103019698139 /* stp_card_applepay@3x.png in Resources */,
-				BF_150885512820 /* stp_card_cvc.png in Resources */,
-				BF_876890323199 /* stp_card_cvc@2x.png in Resources */,
-				BF_396367102140 /* stp_card_cvc@3x.png in Resources */,
-				BF_912080281901 /* stp_card_cvc_amex.png in Resources */,
-				BF_243636708199 /* stp_card_cvc_amex@2x.png in Resources */,
-				BF_788315800256 /* stp_card_cvc_amex@3x.png in Resources */,
-				BF_885899011351 /* stp_card_diners.png in Resources */,
-				BF_545657128345 /* stp_card_diners@2x.png in Resources */,
-				BF_588141243996 /* stp_card_diners@3x.png in Resources */,
-				BF_474989706909 /* stp_card_diners_template.png in Resources */,
-				BF_314158884179 /* stp_card_diners_template@2x.png in Resources */,
-				BF_512885476152 /* stp_card_diners_template@3x.png in Resources */,
-				BF_792540141787 /* stp_card_discover.png in Resources */,
-				BF_263148238203 /* stp_card_discover@2x.png in Resources */,
-				BF_363066368412 /* stp_card_discover@3x.png in Resources */,
-				BF_218677791532 /* stp_card_discover_template.png in Resources */,
-				BF_380829518120 /* stp_card_discover_template@2x.png in Resources */,
-				BF_570367328430 /* stp_card_discover_template@3x.png in Resources */,
-				BF_312420450925 /* stp_card_error.png in Resources */,
-				BF_536302022069 /* stp_card_error@2x.png in Resources */,
-				BF_719520352570 /* stp_card_error@3x.png in Resources */,
-				BF_680096215864 /* stp_card_error_amex.png in Resources */,
-				BF_120539862880 /* stp_card_error_amex@2x.png in Resources */,
-				BF_212485280648 /* stp_card_error_amex@3x.png in Resources */,
-				BF_778975644784 /* stp_card_form_back.png in Resources */,
-				BF_768185306849 /* stp_card_form_back@2x.png in Resources */,
-				BF_583178766090 /* stp_card_form_back@3x.png in Resources */,
-				BF_807240198227 /* stp_card_form_front.png in Resources */,
-				BF_651974698404 /* stp_card_form_front@2x.png in Resources */,
-				BF_447084161359 /* stp_card_form_front@3x.png in Resources */,
-				BF_344516029993 /* stp_card_jcb.png in Resources */,
-				BF_624533472251 /* stp_card_jcb@2x.png in Resources */,
-				BF_341351208907 /* stp_card_jcb@3x.png in Resources */,
-				BF_129899263403 /* stp_card_jcb_template.png in Resources */,
-				BF_575343219227 /* stp_card_jcb_template@2x.png in Resources */,
-				BF_304667849339 /* stp_card_jcb_template@3x.png in Resources */,
-				BF_278663538510 /* stp_card_mastercard.png in Resources */,
-				BF_754436355955 /* stp_card_mastercard@2x.png in Resources */,
-				BF_381896389344 /* stp_card_mastercard@3x.png in Resources */,
-				BF_797689592140 /* stp_card_mastercard_template.png in Resources */,
-				BF_627749579000 /* stp_card_mastercard_template@2x.png in Resources */,
-				BF_743467796528 /* stp_card_mastercard_template@3x.png in Resources */,
-				BF_868282965233 /* stp_card_unionpay_en.png in Resources */,
-				BF_566891501383 /* stp_card_unionpay_en@2x.png in Resources */,
-				BF_382809687329 /* stp_card_unionpay_en@3x.png in Resources */,
-				BF_208370307566 /* stp_card_unionpay_template_en.png in Resources */,
-				BF_492946219688 /* stp_card_unionpay_template_en@2x.png in Resources */,
-				BF_210290178530 /* stp_card_unionpay_template_en@3x.png in Resources */,
-				BF_358123724804 /* stp_card_unionpay_template_zh.png in Resources */,
-				BF_457943934341 /* stp_card_unionpay_template_zh@2x.png in Resources */,
-				BF_343953132595 /* stp_card_unionpay_template_zh@3x.png in Resources */,
-				BF_297270047166 /* stp_card_unionpay_zh.png in Resources */,
-				BF_590384333602 /* stp_card_unionpay_zh@2x.png in Resources */,
-				BF_195019623962 /* stp_card_unionpay_zh@3x.png in Resources */,
-				BF_624140904670 /* stp_card_unknown.png in Resources */,
-				BF_558507126140 /* stp_card_unknown@2x.png in Resources */,
-				BF_135378480492 /* stp_card_unknown@3x.png in Resources */,
-				BF_261510315068 /* stp_card_visa.png in Resources */,
-				BF_575244002306 /* stp_card_visa@2x.png in Resources */,
-				BF_170396008124 /* stp_card_visa@3x.png in Resources */,
-				BF_119119096972 /* stp_card_visa_template.png in Resources */,
-				BF_230346920582 /* stp_card_visa_template@2x.png in Resources */,
-				BF_123692580182 /* stp_card_visa_template@3x.png in Resources */,
-				BF_397345146558 /* stp_icon_add.png in Resources */,
-				BF_412364227267 /* stp_icon_add@2x.png in Resources */,
-				BF_211705597766 /* stp_icon_add@3x.png in Resources */,
-				BF_317838552798 /* stp_icon_checkmark.png in Resources */,
-				BF_709812349499 /* stp_icon_checkmark@2x.png in Resources */,
-				BF_550931196942 /* stp_icon_checkmark@3x.png in Resources */,
-				BF_408232004094 /* stp_shipping_form.png in Resources */,
-				BF_709965398842 /* stp_shipping_form@2x.png in Resources */,
-				BF_473725115787 /* stp_shipping_form@3x.png in Resources */,
-				BF_707958902606 /* stp_test_upload_image.jpeg in Resources */,
+				BF_425616635833 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_858489200029 /* ShareExtension-Info.plist in Resources */,
+				BF_412198890813 /* SiriExtension-Info.plist in Resources */,
+				BF_792879120425 /* StringsExtension-Info.plist in Resources */,
+				BF_996283831704 /* UrlGet-Info.plist in Resources */,
+				BF_535227545278 /* UrlGetViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_58354672782 /* Resources */ = {
+		RBP_76780522380 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_582530802914 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_194725058635 /* Localizable.strings in Resources */,
+				BF_877111062382 /* stp_card_amex.png in Resources */,
+				BF_308351168005 /* stp_card_amex@2x.png in Resources */,
+				BF_651489745922 /* stp_card_amex@3x.png in Resources */,
+				BF_761949389858 /* stp_card_amex_template.png in Resources */,
+				BF_423182950497 /* stp_card_amex_template@2x.png in Resources */,
+				BF_921545965922 /* stp_card_amex_template@3x.png in Resources */,
+				BF_280277985629 /* stp_card_applepay.png in Resources */,
+				BF_891699548570 /* stp_card_applepay@2x.png in Resources */,
+				BF_485648701398 /* stp_card_applepay@3x.png in Resources */,
+				BF_633003488668 /* stp_card_cvc.png in Resources */,
+				BF_661729225758 /* stp_card_cvc@2x.png in Resources */,
+				BF_631286616569 /* stp_card_cvc@3x.png in Resources */,
+				BF_120744269678 /* stp_card_cvc_amex.png in Resources */,
+				BF_695311822348 /* stp_card_cvc_amex@2x.png in Resources */,
+				BF_777934210855 /* stp_card_cvc_amex@3x.png in Resources */,
+				BF_804888977857 /* stp_card_diners.png in Resources */,
+				BF_559238596559 /* stp_card_diners@2x.png in Resources */,
+				BF_345158428908 /* stp_card_diners@3x.png in Resources */,
+				BF_529345976121 /* stp_card_diners_template.png in Resources */,
+				BF_864516097820 /* stp_card_diners_template@2x.png in Resources */,
+				BF_556264213146 /* stp_card_diners_template@3x.png in Resources */,
+				BF_722838844774 /* stp_card_discover.png in Resources */,
+				BF_848594506740 /* stp_card_discover@2x.png in Resources */,
+				BF_329788152376 /* stp_card_discover@3x.png in Resources */,
+				BF_499364212407 /* stp_card_discover_template.png in Resources */,
+				BF_907512446919 /* stp_card_discover_template@2x.png in Resources */,
+				BF_186780588036 /* stp_card_discover_template@3x.png in Resources */,
+				BF_727176482223 /* stp_card_error.png in Resources */,
+				BF_563667443364 /* stp_card_error@2x.png in Resources */,
+				BF_898026823466 /* stp_card_error@3x.png in Resources */,
+				BF_110879963190 /* stp_card_error_amex.png in Resources */,
+				BF_407711809898 /* stp_card_error_amex@2x.png in Resources */,
+				BF_161201956257 /* stp_card_error_amex@3x.png in Resources */,
+				BF_581636919195 /* stp_card_form_back.png in Resources */,
+				BF_167857380704 /* stp_card_form_back@2x.png in Resources */,
+				BF_214675800404 /* stp_card_form_back@3x.png in Resources */,
+				BF_542911731250 /* stp_card_form_front.png in Resources */,
+				BF_204376260226 /* stp_card_form_front@2x.png in Resources */,
+				BF_115916247363 /* stp_card_form_front@3x.png in Resources */,
+				BF_752543758240 /* stp_card_jcb.png in Resources */,
+				BF_276707441897 /* stp_card_jcb@2x.png in Resources */,
+				BF_311301233982 /* stp_card_jcb@3x.png in Resources */,
+				BF_491398236520 /* stp_card_jcb_template.png in Resources */,
+				BF_516085003785 /* stp_card_jcb_template@2x.png in Resources */,
+				BF_205626696615 /* stp_card_jcb_template@3x.png in Resources */,
+				BF_848211254093 /* stp_card_mastercard.png in Resources */,
+				BF_649733185797 /* stp_card_mastercard@2x.png in Resources */,
+				BF_107316023987 /* stp_card_mastercard@3x.png in Resources */,
+				BF_872366323585 /* stp_card_mastercard_template.png in Resources */,
+				BF_235691758803 /* stp_card_mastercard_template@2x.png in Resources */,
+				BF_612411344394 /* stp_card_mastercard_template@3x.png in Resources */,
+				BF_389131547685 /* stp_card_unionpay_en.png in Resources */,
+				BF_708665657427 /* stp_card_unionpay_en@2x.png in Resources */,
+				BF_302695802166 /* stp_card_unionpay_en@3x.png in Resources */,
+				BF_234885104089 /* stp_card_unionpay_template_en.png in Resources */,
+				BF_519578738523 /* stp_card_unionpay_template_en@2x.png in Resources */,
+				BF_400156068580 /* stp_card_unionpay_template_en@3x.png in Resources */,
+				BF_767770953726 /* stp_card_unionpay_template_zh.png in Resources */,
+				BF_183151058556 /* stp_card_unionpay_template_zh@2x.png in Resources */,
+				BF_136341807913 /* stp_card_unionpay_template_zh@3x.png in Resources */,
+				BF_688989087489 /* stp_card_unionpay_zh.png in Resources */,
+				BF_703160045272 /* stp_card_unionpay_zh@2x.png in Resources */,
+				BF_566136145133 /* stp_card_unionpay_zh@3x.png in Resources */,
+				BF_525736542296 /* stp_card_unknown.png in Resources */,
+				BF_579733271806 /* stp_card_unknown@2x.png in Resources */,
+				BF_248839685356 /* stp_card_unknown@3x.png in Resources */,
+				BF_537327529029 /* stp_card_visa.png in Resources */,
+				BF_311686438440 /* stp_card_visa@2x.png in Resources */,
+				BF_575594069114 /* stp_card_visa@3x.png in Resources */,
+				BF_865312341190 /* stp_card_visa_template.png in Resources */,
+				BF_736595894600 /* stp_card_visa_template@2x.png in Resources */,
+				BF_389783104759 /* stp_card_visa_template@3x.png in Resources */,
+				BF_360876168008 /* stp_icon_add.png in Resources */,
+				BF_343340901752 /* stp_icon_add@2x.png in Resources */,
+				BF_455904102704 /* stp_icon_add@3x.png in Resources */,
+				BF_472021374075 /* stp_icon_checkmark.png in Resources */,
+				BF_772256144782 /* stp_icon_checkmark@2x.png in Resources */,
+				BF_432388821541 /* stp_icon_checkmark@3x.png in Resources */,
+				BF_440806803592 /* stp_shipping_form.png in Resources */,
+				BF_170328062118 /* stp_shipping_form@2x.png in Resources */,
+				BF_352002510167 /* stp_shipping_form@3x.png in Resources */,
+				BF_415609941844 /* stp_test_upload_image.jpeg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_70708085104 /* Resources */ = {
+		RBP_81847389388 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_151757672103 /* Localizable.strings in Resources */,
-				BF_309570989202 /* stp_card_amex.png in Resources */,
-				BF_456142095854 /* stp_card_amex@2x.png in Resources */,
-				BF_320837076228 /* stp_card_amex@3x.png in Resources */,
-				BF_475917700354 /* stp_card_amex_template.png in Resources */,
-				BF_191206565194 /* stp_card_amex_template@2x.png in Resources */,
-				BF_138461404074 /* stp_card_amex_template@3x.png in Resources */,
-				BF_462455659113 /* stp_card_applepay.png in Resources */,
-				BF_305816078570 /* stp_card_applepay@2x.png in Resources */,
-				BF_592286488997 /* stp_card_applepay@3x.png in Resources */,
-				BF_809361463000 /* stp_card_cvc.png in Resources */,
-				BF_892241538456 /* stp_card_cvc@2x.png in Resources */,
-				BF_892762272109 /* stp_card_cvc@3x.png in Resources */,
-				BF_851253922391 /* stp_card_cvc_amex.png in Resources */,
-				BF_869586500948 /* stp_card_cvc_amex@2x.png in Resources */,
-				BF_221385638621 /* stp_card_cvc_amex@3x.png in Resources */,
-				BF_244355728562 /* stp_card_diners.png in Resources */,
-				BF_154672173585 /* stp_card_diners@2x.png in Resources */,
-				BF_167823982318 /* stp_card_diners@3x.png in Resources */,
-				BF_391600535834 /* stp_card_diners_template.png in Resources */,
-				BF_712602684753 /* stp_card_diners_template@2x.png in Resources */,
-				BF_716920207658 /* stp_card_diners_template@3x.png in Resources */,
-				BF_751727897601 /* stp_card_discover.png in Resources */,
-				BF_376657278382 /* stp_card_discover@2x.png in Resources */,
-				BF_765177499875 /* stp_card_discover@3x.png in Resources */,
-				BF_149555850306 /* stp_card_discover_template.png in Resources */,
-				BF_283769270364 /* stp_card_discover_template@2x.png in Resources */,
-				BF_363607041405 /* stp_card_discover_template@3x.png in Resources */,
-				BF_307222715199 /* stp_card_error.png in Resources */,
-				BF_310592570415 /* stp_card_error@2x.png in Resources */,
-				BF_225946189938 /* stp_card_error@3x.png in Resources */,
-				BF_214401364839 /* stp_card_error_amex.png in Resources */,
-				BF_799643590551 /* stp_card_error_amex@2x.png in Resources */,
-				BF_296805053083 /* stp_card_error_amex@3x.png in Resources */,
-				BF_250175477903 /* stp_card_form_back.png in Resources */,
-				BF_202421252734 /* stp_card_form_back@2x.png in Resources */,
-				BF_843248890798 /* stp_card_form_back@3x.png in Resources */,
-				BF_117209957966 /* stp_card_form_front.png in Resources */,
-				BF_264785220441 /* stp_card_form_front@2x.png in Resources */,
-				BF_135530049807 /* stp_card_form_front@3x.png in Resources */,
-				BF_786464893976 /* stp_card_jcb.png in Resources */,
-				BF_887553915782 /* stp_card_jcb@2x.png in Resources */,
-				BF_759468879883 /* stp_card_jcb@3x.png in Resources */,
-				BF_691269567943 /* stp_card_jcb_template.png in Resources */,
-				BF_540163603984 /* stp_card_jcb_template@2x.png in Resources */,
-				BF_144207460583 /* stp_card_jcb_template@3x.png in Resources */,
-				BF_775869817833 /* stp_card_mastercard.png in Resources */,
-				BF_551145990127 /* stp_card_mastercard@2x.png in Resources */,
-				BF_551106090485 /* stp_card_mastercard@3x.png in Resources */,
-				BF_696239529970 /* stp_card_mastercard_template.png in Resources */,
-				BF_859207755337 /* stp_card_mastercard_template@2x.png in Resources */,
-				BF_601678502290 /* stp_card_mastercard_template@3x.png in Resources */,
-				BF_341904587881 /* stp_card_unionpay_en.png in Resources */,
-				BF_431247232736 /* stp_card_unionpay_en@2x.png in Resources */,
-				BF_969469422979 /* stp_card_unionpay_en@3x.png in Resources */,
-				BF_182151248631 /* stp_card_unionpay_template_en.png in Resources */,
-				BF_888620683913 /* stp_card_unionpay_template_en@2x.png in Resources */,
-				BF_949644424763 /* stp_card_unionpay_template_en@3x.png in Resources */,
-				BF_290778906678 /* stp_card_unionpay_template_zh.png in Resources */,
-				BF_892886647641 /* stp_card_unionpay_template_zh@2x.png in Resources */,
-				BF_131628923074 /* stp_card_unionpay_template_zh@3x.png in Resources */,
-				BF_565142811584 /* stp_card_unionpay_zh.png in Resources */,
-				BF_412227068955 /* stp_card_unionpay_zh@2x.png in Resources */,
-				BF_485817685451 /* stp_card_unionpay_zh@3x.png in Resources */,
-				BF_726887199051 /* stp_card_unknown.png in Resources */,
-				BF_657456269763 /* stp_card_unknown@2x.png in Resources */,
-				BF_453613883928 /* stp_card_unknown@3x.png in Resources */,
-				BF_371536116472 /* stp_card_visa.png in Resources */,
-				BF_834502484694 /* stp_card_visa@2x.png in Resources */,
-				BF_785144964550 /* stp_card_visa@3x.png in Resources */,
-				BF_187128133490 /* stp_card_visa_template.png in Resources */,
-				BF_759141593816 /* stp_card_visa_template@2x.png in Resources */,
-				BF_724018934696 /* stp_card_visa_template@3x.png in Resources */,
-				BF_364718393009 /* stp_icon_add.png in Resources */,
-				BF_365968776464 /* stp_icon_add@2x.png in Resources */,
-				BF_768471797584 /* stp_icon_add@3x.png in Resources */,
-				BF_490736564052 /* stp_icon_checkmark.png in Resources */,
-				BF_795798416899 /* stp_icon_checkmark@2x.png in Resources */,
-				BF_238970309620 /* stp_icon_checkmark@3x.png in Resources */,
-				BF_523457148489 /* stp_shipping_form.png in Resources */,
-				BF_914665933472 /* stp_shipping_form@2x.png in Resources */,
-				BF_198135154768 /* stp_shipping_form@3x.png in Resources */,
-				BF_224019183693 /* stp_test_upload_image.jpeg in Resources */,
+				BF_174386052051 /* GoogleAppIndexingResources.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_74561212813 /* Resources */ = {
+		RBP_84221274112 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_360825627851 /* InfoPlist.strings in Resources */,
+				BF_609231923885 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_87012950138 /* Resources */ = {
+		RBP_86378675498 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_564964647160 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_436097312406 /* GoogleAppIndexingResources.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_87554900864 /* Resources */ = {
+		RBP_90371855781 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_234494727001 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_569143270790 /* Localizable.strings in Resources */,
+				BF_503397154927 /* stp_card_amex.png in Resources */,
+				BF_605459178514 /* stp_card_amex@2x.png in Resources */,
+				BF_777929815323 /* stp_card_amex@3x.png in Resources */,
+				BF_360817461512 /* stp_card_amex_template.png in Resources */,
+				BF_826111041639 /* stp_card_amex_template@2x.png in Resources */,
+				BF_706833575101 /* stp_card_amex_template@3x.png in Resources */,
+				BF_860109961268 /* stp_card_applepay.png in Resources */,
+				BF_273878717745 /* stp_card_applepay@2x.png in Resources */,
+				BF_883432793737 /* stp_card_applepay@3x.png in Resources */,
+				BF_437082473392 /* stp_card_cvc.png in Resources */,
+				BF_229030472669 /* stp_card_cvc@2x.png in Resources */,
+				BF_668302248372 /* stp_card_cvc@3x.png in Resources */,
+				BF_664767754488 /* stp_card_cvc_amex.png in Resources */,
+				BF_538380531367 /* stp_card_cvc_amex@2x.png in Resources */,
+				BF_867400988080 /* stp_card_cvc_amex@3x.png in Resources */,
+				BF_233834259796 /* stp_card_diners.png in Resources */,
+				BF_496697733442 /* stp_card_diners@2x.png in Resources */,
+				BF_752256144767 /* stp_card_diners@3x.png in Resources */,
+				BF_430562804116 /* stp_card_diners_template.png in Resources */,
+				BF_400157729166 /* stp_card_diners_template@2x.png in Resources */,
+				BF_498677365325 /* stp_card_diners_template@3x.png in Resources */,
+				BF_362052980185 /* stp_card_discover.png in Resources */,
+				BF_427155318619 /* stp_card_discover@2x.png in Resources */,
+				BF_358266653017 /* stp_card_discover@3x.png in Resources */,
+				BF_482938234912 /* stp_card_discover_template.png in Resources */,
+				BF_106880923726 /* stp_card_discover_template@2x.png in Resources */,
+				BF_792758988381 /* stp_card_discover_template@3x.png in Resources */,
+				BF_364834197722 /* stp_card_error.png in Resources */,
+				BF_458258120490 /* stp_card_error@2x.png in Resources */,
+				BF_796694256828 /* stp_card_error@3x.png in Resources */,
+				BF_403886376750 /* stp_card_error_amex.png in Resources */,
+				BF_712988642500 /* stp_card_error_amex@2x.png in Resources */,
+				BF_586217066392 /* stp_card_error_amex@3x.png in Resources */,
+				BF_424269191583 /* stp_card_form_back.png in Resources */,
+				BF_831515964199 /* stp_card_form_back@2x.png in Resources */,
+				BF_271545812902 /* stp_card_form_back@3x.png in Resources */,
+				BF_475143180585 /* stp_card_form_front.png in Resources */,
+				BF_645210569547 /* stp_card_form_front@2x.png in Resources */,
+				BF_327112620609 /* stp_card_form_front@3x.png in Resources */,
+				BF_455227481165 /* stp_card_jcb.png in Resources */,
+				BF_883920894635 /* stp_card_jcb@2x.png in Resources */,
+				BF_780796191582 /* stp_card_jcb@3x.png in Resources */,
+				BF_869835224510 /* stp_card_jcb_template.png in Resources */,
+				BF_893287338731 /* stp_card_jcb_template@2x.png in Resources */,
+				BF_446113441111 /* stp_card_jcb_template@3x.png in Resources */,
+				BF_706090148504 /* stp_card_mastercard.png in Resources */,
+				BF_807594298166 /* stp_card_mastercard@2x.png in Resources */,
+				BF_702518897872 /* stp_card_mastercard@3x.png in Resources */,
+				BF_517120243851 /* stp_card_mastercard_template.png in Resources */,
+				BF_859149025202 /* stp_card_mastercard_template@2x.png in Resources */,
+				BF_479590952822 /* stp_card_mastercard_template@3x.png in Resources */,
+				BF_889127824037 /* stp_card_unionpay_en.png in Resources */,
+				BF_556340857556 /* stp_card_unionpay_en@2x.png in Resources */,
+				BF_191691531945 /* stp_card_unionpay_en@3x.png in Resources */,
+				BF_131709469819 /* stp_card_unionpay_template_en.png in Resources */,
+				BF_722268048417 /* stp_card_unionpay_template_en@2x.png in Resources */,
+				BF_666590302924 /* stp_card_unionpay_template_en@3x.png in Resources */,
+				BF_512702965137 /* stp_card_unionpay_template_zh.png in Resources */,
+				BF_205465445125 /* stp_card_unionpay_template_zh@2x.png in Resources */,
+				BF_322266225629 /* stp_card_unionpay_template_zh@3x.png in Resources */,
+				BF_666488213915 /* stp_card_unionpay_zh.png in Resources */,
+				BF_717821120978 /* stp_card_unionpay_zh@2x.png in Resources */,
+				BF_930529541670 /* stp_card_unionpay_zh@3x.png in Resources */,
+				BF_738500385646 /* stp_card_unknown.png in Resources */,
+				BF_504315410621 /* stp_card_unknown@2x.png in Resources */,
+				BF_686732017306 /* stp_card_unknown@3x.png in Resources */,
+				BF_422184539559 /* stp_card_visa.png in Resources */,
+				BF_133579846289 /* stp_card_visa@2x.png in Resources */,
+				BF_373655580141 /* stp_card_visa@3x.png in Resources */,
+				BF_453090159483 /* stp_card_visa_template.png in Resources */,
+				BF_340463658665 /* stp_card_visa_template@2x.png in Resources */,
+				BF_135071580354 /* stp_card_visa_template@3x.png in Resources */,
+				BF_647726860901 /* stp_icon_add.png in Resources */,
+				BF_502579502558 /* stp_icon_add@2x.png in Resources */,
+				BF_537090058859 /* stp_icon_add@3x.png in Resources */,
+				BF_772244235996 /* stp_icon_checkmark.png in Resources */,
+				BF_875539600787 /* stp_icon_checkmark@2x.png in Resources */,
+				BF_201997171984 /* stp_icon_checkmark@3x.png in Resources */,
+				BF_487054552557 /* stp_shipping_form.png in Resources */,
+				BF_532506937214 /* stp_shipping_form@2x.png in Resources */,
+				BF_641558335001 /* stp_shipping_form@3x.png in Resources */,
+				BF_504006751447 /* stp_test_upload_image.jpeg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_91038982921 /* Resources */ = {
+		RBP_90650572958 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_353317260207 /* InfoPlist.strings in Resources */,
-				BF_643237519141 /* StringsExtension-Info.plist in Resources */,
+				BF_647324315494 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_228710689171 /* UrlGetViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		SSBP_6545361203 /* Bazel build */ = {
+		SSBP_3346118699 /* Bazel build */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3031,9 +4427,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export TULSI_USE_HAMMER_DEBUG_CONFIG=YES\n/Users/mzuccarino/code/mikezucc/xchammer/.build/debug/bazel_build.py //ios-app:share-extension --bazel /Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet/tools/bazelwrapper";
+			shellScript = "# We want to use this for remote caching..\nexport TULSI_USE_HAMMER_DEBUG_CONFIG=\"YES\"\necho \"Customizing Bazel invocation...\"\n/Users/jerry/Projects/xchammer-github/.build/debug/bazel_build.py //ios-app:ios-app --bazel /Users/jerry/Projects/xchammer-github/sample/UrlGet/tools/bazelwrapper\n\n";
 		};
-		SSBP_6558405859 /* Process IPA */ = {
+		SSBP_8885571800 /* Process IPA */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3045,9 +4441,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/Users/mzuccarino/code/mikezucc/xchammer/.build/debug/XCHammer process-ipa";
+			shellScript = "/Users/jerry/Projects/xchammer-github/.build/debug/XCHammer process-ipa";
 		};
-		SSBP_8118918997 /* Bazel build */ = {
+		SSBP_8889053436 /* Bazel build */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3059,533 +4455,768 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# We want to use this for remote caching..\nexport TULSI_USE_HAMMER_DEBUG_CONFIG=\"YES\"\necho \"Customizing Bazel invocation...\"\n/Users/mzuccarino/code/mikezucc/xchammer/.build/debug/bazel_build.py //ios-app:ios-app --bazel /Users/mzuccarino/code/mikezucc/xchammer/sample/UrlGet/tools/bazelwrapper\n\n";
+			shellScript = "export TULSI_USE_HAMMER_DEBUG_CONFIG=YES\n/Users/jerry/Projects/xchammer-github/.build/debug/bazel_build.py //ios-app:share-extension --bazel /Users/jerry/Projects/xchammer-github/sample/UrlGet/tools/bazelwrapper";
 		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		SBP_10017827223 /* Sources */ = {
+		SBP_10706608252 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_852318462908 /* Stub.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_13192037213 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_323275224816 /* PINDiskCache.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_16210182567 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_808246866099 /* Tests.m in Sources */,
+				BF_750902070972 /* Tests2.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_19672585744 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_778571260535 /* AppDelegate.m in Sources */,
+				BF_695686603777 /* NoArc.m in Sources */,
+				BF_531401913033 /* Some.cc in Sources */,
+				BF_178740885781 /* UrlGetViewController.m in Sources */,
+				BF_610177243136 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_20536363493 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_113443738270 /* Stub.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_23203767009 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_652915475726 /* PINCache.m in Sources */,
+				BF_301307915522 /* PINMemoryCache.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_28774711835 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_402485226064 /* Stub.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_32103852460 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_17310294235 /* Sources */ = {
+		SBP_39458662484 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_366909454330 /* Tests.m in Sources */,
+				BF_659943408471 /* Tests2.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_42499689135 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_17570471859 /* Sources */ = {
+		SBP_46632772561 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_513577914721 /* AppDelegate.m in Sources */,
-				BF_525198602071 /* NoArc.m in Sources */,
-				BF_123619201349 /* Some.cc in Sources */,
-				BF_671889331007 /* UrlGetViewController.m in Sources */,
-				BF_559895246776 /* main.m in Sources */,
+				BF_572579139440 /* PINCache.m in Sources */,
+				BF_149470713379 /* PINMemoryCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_17945379991 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_18398734526 /* Sources */ = {
+		SBP_53558259571 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_19672287393 /* Sources */ = {
+		SBP_57578538212 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_613056099577 /* NSArray+Stripe.m in Sources */,
-				BF_101090596531 /* NSBundle+Stripe_AppName.m in Sources */,
-				BF_849479514763 /* NSCharacterSet+Stripe.m in Sources */,
-				BF_638181999525 /* NSDecimalNumber+Stripe_Currency.m in Sources */,
-				BF_589173441158 /* NSDictionary+Stripe.m in Sources */,
-				BF_423050148924 /* NSError+Stripe.m in Sources */,
-				BF_504461851187 /* NSMutableURLRequest+Stripe.m in Sources */,
-				BF_122454680258 /* NSString+Stripe.m in Sources */,
-				BF_648083042725 /* NSURLComponents+Stripe.m in Sources */,
-				BF_737678661541 /* PKPayment+Stripe.m in Sources */,
-				BF_865102949522 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */,
-				BF_794704307481 /* STPAPIClient+ApplePay.m in Sources */,
-				BF_378840913279 /* STPAPIClient.m in Sources */,
-				BF_349880824923 /* STPAPIRequest.m in Sources */,
-				BF_367284426572 /* STPAddCardViewController.m in Sources */,
-				BF_842714463720 /* STPAddress.m in Sources */,
-				BF_861336833852 /* STPAddressFieldTableViewCell.m in Sources */,
-				BF_641847747226 /* STPAddressViewModel.m in Sources */,
-				BF_468726244056 /* STPAnalyticsClient.m in Sources */,
-				BF_285927550174 /* STPApplePayPaymentMethod.m in Sources */,
-				BF_647200911547 /* STPAspects.m in Sources */,
-				BF_693418203202 /* STPBINRange.m in Sources */,
-				BF_765712413593 /* STPBankAccount.m in Sources */,
-				BF_903899752134 /* STPBankAccountParams.m in Sources */,
-				BF_770908080194 /* STPBundleLocator.m in Sources */,
-				BF_751036638648 /* STPCard.m in Sources */,
-				BF_647333681922 /* STPCardIOProxy.m in Sources */,
-				BF_579672973360 /* STPCardParams.m in Sources */,
-				BF_306186377385 /* STPCardValidator.m in Sources */,
-				BF_316466910586 /* STPCategoryLoader.m in Sources */,
-				BF_263324905251 /* STPColorUtils.m in Sources */,
-				BF_798749616868 /* STPConnectAccountParams.m in Sources */,
-				BF_563013784716 /* STPCoreScrollViewController.m in Sources */,
-				BF_764589198900 /* STPCoreTableViewController.m in Sources */,
-				BF_594617974909 /* STPCoreViewController.m in Sources */,
-				BF_673363358977 /* STPCustomer+SourceTuple.m in Sources */,
-				BF_769011939867 /* STPCustomer.m in Sources */,
-				BF_362750078846 /* STPCustomerContext.m in Sources */,
-				BF_503400796960 /* STPDelegateProxy.m in Sources */,
-				BF_136123455694 /* STPDispatchFunctions.m in Sources */,
-				BF_515478026660 /* STPEmailAddressValidator.m in Sources */,
-				BF_103647375732 /* STPEphemeralKey.m in Sources */,
-				BF_223339887562 /* STPEphemeralKeyManager.m in Sources */,
-				BF_522935875969 /* STPFile.m in Sources */,
-				BF_381871517932 /* STPFormEncoder.m in Sources */,
-				BF_359877986903 /* STPFormTextField.m in Sources */,
-				BF_908168907899 /* STPImageLibrary.m in Sources */,
-				BF_170318754028 /* STPLegalEntityParams.m in Sources */,
-				BF_498128473604 /* STPLocalizationUtils.m in Sources */,
-				BF_365572872399 /* STPMultipartFormDataEncoder.m in Sources */,
-				BF_489787044526 /* STPMultipartFormDataPart.m in Sources */,
-				BF_662578892143 /* STPPaymentActivityIndicatorView.m in Sources */,
-				BF_729766328605 /* STPPaymentCardTextField.m in Sources */,
-				BF_343082518654 /* STPPaymentCardTextFieldCell.m in Sources */,
-				BF_116171698724 /* STPPaymentCardTextFieldViewModel.m in Sources */,
-				BF_129573605972 /* STPPaymentConfiguration.m in Sources */,
-				BF_914150910917 /* STPPaymentContext.m in Sources */,
-				BF_839039646076 /* STPPaymentContextAmountModel.m in Sources */,
-				BF_177540651906 /* STPPaymentMethodTableViewCell.m in Sources */,
-				BF_118399563058 /* STPPaymentMethodTuple.m in Sources */,
-				BF_735260424658 /* STPPaymentMethodsInternalViewController.m in Sources */,
-				BF_340860741059 /* STPPaymentMethodsViewController.m in Sources */,
-				BF_437340004481 /* STPPaymentResult.m in Sources */,
-				BF_672812697537 /* STPPhoneNumberValidator.m in Sources */,
-				BF_591718251943 /* STPPostalCodeValidator.m in Sources */,
-				BF_333370963763 /* STPPromise.m in Sources */,
-				BF_489322762158 /* STPRedirectContext.m in Sources */,
-				BF_276095752437 /* STPSectionHeaderView.m in Sources */,
-				BF_819923078927 /* STPShippingAddressViewController.m in Sources */,
-				BF_726182205540 /* STPShippingMethodTableViewCell.m in Sources */,
-				BF_449892321630 /* STPShippingMethodsViewController.m in Sources */,
-				BF_644483827733 /* STPSource.m in Sources */,
-				BF_214591006498 /* STPSourceCardDetails.m in Sources */,
-				BF_157414689128 /* STPSourceOwner.m in Sources */,
-				BF_444049534671 /* STPSourceParams.m in Sources */,
-				BF_555361758086 /* STPSourcePoller.m in Sources */,
-				BF_229174307200 /* STPSourceReceiver.m in Sources */,
-				BF_633647804116 /* STPSourceRedirect.m in Sources */,
-				BF_204553293200 /* STPSourceSEPADebitDetails.m in Sources */,
-				BF_453568682923 /* STPSourceVerification.m in Sources */,
-				BF_448507476666 /* STPStringUtils.m in Sources */,
-				BF_585378562575 /* STPSwitchTableViewCell.m in Sources */,
-				BF_566176482817 /* STPTelemetryClient.m in Sources */,
-				BF_624388286307 /* STPTheme.m in Sources */,
-				BF_716143536218 /* STPToken.m in Sources */,
-				BF_289584464573 /* STPURLCallbackHandler.m in Sources */,
-				BF_676108111271 /* STPUserInformation.m in Sources */,
-				BF_541601624736 /* STPValidatedTextField.m in Sources */,
-				BF_196243295751 /* StripeError.m in Sources */,
-				BF_527047701434 /* UIBarButtonItem+Stripe.m in Sources */,
-				BF_169258158277 /* UIImage+Stripe.m in Sources */,
-				BF_568508761573 /* UINavigationBar+Stripe_Theme.m in Sources */,
-				BF_750850029603 /* UINavigationController+Stripe_Completion.m in Sources */,
-				BF_778389135851 /* UITableViewCell+Stripe_Borders.m in Sources */,
-				BF_194808752686 /* UIToolbar+Stripe_InputAccessory.m in Sources */,
-				BF_248271752273 /* UIView+Stripe_FirstResponder.m in Sources */,
-				BF_492945389948 /* UIView+Stripe_SafeAreaBounds.m in Sources */,
-				BF_703680853725 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */,
-				BF_117078049933 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */,
-				BF_542676579977 /* UIViewController+Stripe_ParentViewController.m in Sources */,
-				BF_628380396410 /* UIViewController+Stripe_Promises.m in Sources */,
+				BF_262014197977 /* PINOperationGroup.m in Sources */,
+				BF_131266585648 /* PINOperationQueue.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_24378941017 /* Sources */ = {
+		SBP_57609827347 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_776995690719 /* Stub.m in Sources */,
+				BF_466358947901 /* AppIntent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_25340607413 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_718842850114 /* AppIntent.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_31419184477 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_574162666878 /* Tests.m in Sources */,
-				BF_632117953374 /* Tests2.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_36181441897 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_752333850625 /* Stub.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_44300245758 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_218428149371 /* Stub.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_46013154530 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_399571997734 /* AppDelegate.m in Sources */,
-				BF_657639625002 /* NoArc.m in Sources */,
-				BF_236406319029 /* Some.cc in Sources */,
-				BF_730930168105 /* UrlGetViewController.m in Sources */,
-				BF_260333157646 /* main.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_51501878502 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_750570579564 /* PINDiskCache.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_52430805207 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_734763667839 /* Stub.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_54039311319 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_388766661431 /* PINDiskCache.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_58354672782 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_418274553626 /* Tests.m in Sources */,
-				BF_158572982416 /* Tests2.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_59353243798 /* Sources */ = {
+		SBP_62945418786 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_63794431143 /* Sources */ = {
+		SBP_65597782407 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_279596883188 /* empty-main.m in Sources */,
+				BF_454182150390 /* empty-main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_68697216862 /* Sources */ = {
+		SBP_65663046159 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_362461023323 /* PINCache.m in Sources */,
-				BF_905507208473 /* PINMemoryCache.m in Sources */,
+				BF_857725329044 /* PINDiskCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_70708085104 /* Sources */ = {
+		SBP_66406928560 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_743198081299 /* Stub.m in Sources */,
+				BF_758552470194 /* NSArray+Stripe.m in Sources */,
+				BF_179371215461 /* NSBundle+Stripe_AppName.m in Sources */,
+				BF_117355793113 /* NSCharacterSet+Stripe.m in Sources */,
+				BF_410605641080 /* NSDecimalNumber+Stripe_Currency.m in Sources */,
+				BF_645844241746 /* NSDictionary+Stripe.m in Sources */,
+				BF_511683710040 /* NSError+Stripe.m in Sources */,
+				BF_740403725356 /* NSMutableURLRequest+Stripe.m in Sources */,
+				BF_606365642930 /* NSString+Stripe.m in Sources */,
+				BF_200803442114 /* NSURLComponents+Stripe.m in Sources */,
+				BF_639850709349 /* PKPayment+Stripe.m in Sources */,
+				BF_595197390143 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */,
+				BF_697824881552 /* STPAPIClient+ApplePay.m in Sources */,
+				BF_836435373461 /* STPAPIClient.m in Sources */,
+				BF_277915633922 /* STPAPIRequest.m in Sources */,
+				BF_814006962241 /* STPAddCardViewController.m in Sources */,
+				BF_155717795722 /* STPAddress.m in Sources */,
+				BF_186470418346 /* STPAddressFieldTableViewCell.m in Sources */,
+				BF_254250253346 /* STPAddressViewModel.m in Sources */,
+				BF_323560998381 /* STPAnalyticsClient.m in Sources */,
+				BF_893335691237 /* STPApplePayPaymentMethod.m in Sources */,
+				BF_797115579488 /* STPAspects.m in Sources */,
+				BF_559293705325 /* STPBINRange.m in Sources */,
+				BF_344187469442 /* STPBankAccount.m in Sources */,
+				BF_831427525575 /* STPBankAccountParams.m in Sources */,
+				BF_451265572771 /* STPBundleLocator.m in Sources */,
+				BF_428731482701 /* STPCard.m in Sources */,
+				BF_811211250455 /* STPCardIOProxy.m in Sources */,
+				BF_498764902292 /* STPCardParams.m in Sources */,
+				BF_255637005666 /* STPCardValidator.m in Sources */,
+				BF_792549583398 /* STPCategoryLoader.m in Sources */,
+				BF_443299014311 /* STPColorUtils.m in Sources */,
+				BF_747429969635 /* STPConnectAccountParams.m in Sources */,
+				BF_884282777467 /* STPCoreScrollViewController.m in Sources */,
+				BF_814292853267 /* STPCoreTableViewController.m in Sources */,
+				BF_666051195313 /* STPCoreViewController.m in Sources */,
+				BF_904714273747 /* STPCustomer+SourceTuple.m in Sources */,
+				BF_537511256999 /* STPCustomer.m in Sources */,
+				BF_575712853151 /* STPCustomerContext.m in Sources */,
+				BF_908648225751 /* STPDelegateProxy.m in Sources */,
+				BF_646424098992 /* STPDispatchFunctions.m in Sources */,
+				BF_593747456481 /* STPEmailAddressValidator.m in Sources */,
+				BF_562026224161 /* STPEphemeralKey.m in Sources */,
+				BF_299666730550 /* STPEphemeralKeyManager.m in Sources */,
+				BF_737431965053 /* STPFile.m in Sources */,
+				BF_447991924275 /* STPFormEncoder.m in Sources */,
+				BF_808217497340 /* STPFormTextField.m in Sources */,
+				BF_694131021614 /* STPImageLibrary.m in Sources */,
+				BF_350160722692 /* STPLegalEntityParams.m in Sources */,
+				BF_845335545682 /* STPLocalizationUtils.m in Sources */,
+				BF_876120395905 /* STPMultipartFormDataEncoder.m in Sources */,
+				BF_402241053725 /* STPMultipartFormDataPart.m in Sources */,
+				BF_430940717273 /* STPPaymentActivityIndicatorView.m in Sources */,
+				BF_648932273856 /* STPPaymentCardTextField.m in Sources */,
+				BF_318193899835 /* STPPaymentCardTextFieldCell.m in Sources */,
+				BF_223235247875 /* STPPaymentCardTextFieldViewModel.m in Sources */,
+				BF_119653876866 /* STPPaymentConfiguration.m in Sources */,
+				BF_304474317661 /* STPPaymentContext.m in Sources */,
+				BF_832200031424 /* STPPaymentContextAmountModel.m in Sources */,
+				BF_762148963754 /* STPPaymentMethodTableViewCell.m in Sources */,
+				BF_520486560930 /* STPPaymentMethodTuple.m in Sources */,
+				BF_706148594395 /* STPPaymentMethodsInternalViewController.m in Sources */,
+				BF_537734704667 /* STPPaymentMethodsViewController.m in Sources */,
+				BF_816470681529 /* STPPaymentResult.m in Sources */,
+				BF_416435839240 /* STPPhoneNumberValidator.m in Sources */,
+				BF_480254573427 /* STPPostalCodeValidator.m in Sources */,
+				BF_715699072640 /* STPPromise.m in Sources */,
+				BF_988355903664 /* STPRedirectContext.m in Sources */,
+				BF_596981788321 /* STPSectionHeaderView.m in Sources */,
+				BF_514808246518 /* STPShippingAddressViewController.m in Sources */,
+				BF_180634520283 /* STPShippingMethodTableViewCell.m in Sources */,
+				BF_908099116251 /* STPShippingMethodsViewController.m in Sources */,
+				BF_419060351838 /* STPSource.m in Sources */,
+				BF_797400080911 /* STPSourceCardDetails.m in Sources */,
+				BF_308754239008 /* STPSourceOwner.m in Sources */,
+				BF_905870717195 /* STPSourceParams.m in Sources */,
+				BF_228687791291 /* STPSourcePoller.m in Sources */,
+				BF_185028476423 /* STPSourceReceiver.m in Sources */,
+				BF_686832569531 /* STPSourceRedirect.m in Sources */,
+				BF_157677532165 /* STPSourceSEPADebitDetails.m in Sources */,
+				BF_531230473633 /* STPSourceVerification.m in Sources */,
+				BF_400652638065 /* STPStringUtils.m in Sources */,
+				BF_627940546410 /* STPSwitchTableViewCell.m in Sources */,
+				BF_266910441885 /* STPTelemetryClient.m in Sources */,
+				BF_182653551571 /* STPTheme.m in Sources */,
+				BF_659708573738 /* STPToken.m in Sources */,
+				BF_814474818515 /* STPURLCallbackHandler.m in Sources */,
+				BF_463366413936 /* STPUserInformation.m in Sources */,
+				BF_695835611478 /* STPValidatedTextField.m in Sources */,
+				BF_139000354086 /* StripeError.m in Sources */,
+				BF_898457484024 /* UIBarButtonItem+Stripe.m in Sources */,
+				BF_242731081458 /* UIImage+Stripe.m in Sources */,
+				BF_321663130447 /* UINavigationBar+Stripe_Theme.m in Sources */,
+				BF_247686977314 /* UINavigationController+Stripe_Completion.m in Sources */,
+				BF_538398697795 /* UITableViewCell+Stripe_Borders.m in Sources */,
+				BF_870268343510 /* UIToolbar+Stripe_InputAccessory.m in Sources */,
+				BF_680428845014 /* UIView+Stripe_FirstResponder.m in Sources */,
+				BF_449467972875 /* UIView+Stripe_SafeAreaBounds.m in Sources */,
+				BF_419231674646 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */,
+				BF_555538071810 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */,
+				BF_598450610068 /* UIViewController+Stripe_ParentViewController.m in Sources */,
+				BF_193712619951 /* UIViewController+Stripe_Promises.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_74561212813 /* Sources */ = {
+		SBP_67779072665 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_369875356536 /* AppJerry.m in Sources */,
+				BF_394155200732 /* PINOperationGroup.m in Sources */,
+				BF_889909272663 /* PINOperationQueue.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_75640811123 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_76457507305 /* Sources */ = {
+		SBP_70063320421 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_77600102751 /* Sources */ = {
+		SBP_75795613548 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_527046135878 /* PINOperationGroup.m in Sources */,
-				BF_917099122644 /* PINOperationQueue.m in Sources */,
+				BF_174486510611 /* Stub.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_80527553840 /* Sources */ = {
+		SBP_76780522380 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_854999455782 /* PINCache.m in Sources */,
-				BF_529356427113 /* PINMemoryCache.m in Sources */,
+				BF_127812358508 /* Stub.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_81329453049 /* Sources */ = {
+		SBP_81847389388 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_777042903596 /* NSArray+Stripe.m in Sources */,
-				BF_710724944264 /* NSBundle+Stripe_AppName.m in Sources */,
-				BF_801730223798 /* NSCharacterSet+Stripe.m in Sources */,
-				BF_106143354257 /* NSDecimalNumber+Stripe_Currency.m in Sources */,
-				BF_279020500217 /* NSDictionary+Stripe.m in Sources */,
-				BF_622220407417 /* NSError+Stripe.m in Sources */,
-				BF_172554538252 /* NSMutableURLRequest+Stripe.m in Sources */,
-				BF_788247927438 /* NSString+Stripe.m in Sources */,
-				BF_113208380786 /* NSURLComponents+Stripe.m in Sources */,
-				BF_382005665511 /* PKPayment+Stripe.m in Sources */,
-				BF_749423264532 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */,
-				BF_433098327180 /* STPAPIClient+ApplePay.m in Sources */,
-				BF_101852689553 /* STPAPIClient.m in Sources */,
-				BF_696341792458 /* STPAPIRequest.m in Sources */,
-				BF_461338526634 /* STPAddCardViewController.m in Sources */,
-				BF_910614995151 /* STPAddress.m in Sources */,
-				BF_317591589294 /* STPAddressFieldTableViewCell.m in Sources */,
-				BF_383261352520 /* STPAddressViewModel.m in Sources */,
-				BF_452758362099 /* STPAnalyticsClient.m in Sources */,
-				BF_578541352057 /* STPApplePayPaymentMethod.m in Sources */,
-				BF_574178145405 /* STPAspects.m in Sources */,
-				BF_704390356650 /* STPBINRange.m in Sources */,
-				BF_545260635462 /* STPBankAccount.m in Sources */,
-				BF_737308335445 /* STPBankAccountParams.m in Sources */,
-				BF_771252936417 /* STPBundleLocator.m in Sources */,
-				BF_608151538300 /* STPCard.m in Sources */,
-				BF_214005761075 /* STPCardIOProxy.m in Sources */,
-				BF_370608658701 /* STPCardParams.m in Sources */,
-				BF_532444640647 /* STPCardValidator.m in Sources */,
-				BF_540876532481 /* STPCategoryLoader.m in Sources */,
-				BF_660644608808 /* STPColorUtils.m in Sources */,
-				BF_670384869498 /* STPConnectAccountParams.m in Sources */,
-				BF_454318076844 /* STPCoreScrollViewController.m in Sources */,
-				BF_556944891381 /* STPCoreTableViewController.m in Sources */,
-				BF_424540904917 /* STPCoreViewController.m in Sources */,
-				BF_457382615413 /* STPCustomer+SourceTuple.m in Sources */,
-				BF_470929899408 /* STPCustomer.m in Sources */,
-				BF_638318951126 /* STPCustomerContext.m in Sources */,
-				BF_801105503627 /* STPDelegateProxy.m in Sources */,
-				BF_513813635076 /* STPDispatchFunctions.m in Sources */,
-				BF_161334189326 /* STPEmailAddressValidator.m in Sources */,
-				BF_445949043870 /* STPEphemeralKey.m in Sources */,
-				BF_884995049144 /* STPEphemeralKeyManager.m in Sources */,
-				BF_124234759863 /* STPFile.m in Sources */,
-				BF_721271532741 /* STPFormEncoder.m in Sources */,
-				BF_474140462599 /* STPFormTextField.m in Sources */,
-				BF_677961554122 /* STPImageLibrary.m in Sources */,
-				BF_506403901135 /* STPLegalEntityParams.m in Sources */,
-				BF_920165268680 /* STPLocalizationUtils.m in Sources */,
-				BF_550396607124 /* STPMultipartFormDataEncoder.m in Sources */,
-				BF_541822299127 /* STPMultipartFormDataPart.m in Sources */,
-				BF_619165246202 /* STPPaymentActivityIndicatorView.m in Sources */,
-				BF_702488203596 /* STPPaymentCardTextField.m in Sources */,
-				BF_843119778099 /* STPPaymentCardTextFieldCell.m in Sources */,
-				BF_730365141006 /* STPPaymentCardTextFieldViewModel.m in Sources */,
-				BF_275397151973 /* STPPaymentConfiguration.m in Sources */,
-				BF_790723168256 /* STPPaymentContext.m in Sources */,
-				BF_357489808821 /* STPPaymentContextAmountModel.m in Sources */,
-				BF_455180069893 /* STPPaymentMethodTableViewCell.m in Sources */,
-				BF_249342805273 /* STPPaymentMethodTuple.m in Sources */,
-				BF_563626665274 /* STPPaymentMethodsInternalViewController.m in Sources */,
-				BF_916682364312 /* STPPaymentMethodsViewController.m in Sources */,
-				BF_221014046589 /* STPPaymentResult.m in Sources */,
-				BF_332238646659 /* STPPhoneNumberValidator.m in Sources */,
-				BF_522340134300 /* STPPostalCodeValidator.m in Sources */,
-				BF_811880897715 /* STPPromise.m in Sources */,
-				BF_896932005981 /* STPRedirectContext.m in Sources */,
-				BF_492261497607 /* STPSectionHeaderView.m in Sources */,
-				BF_447601669755 /* STPShippingAddressViewController.m in Sources */,
-				BF_559836411561 /* STPShippingMethodTableViewCell.m in Sources */,
-				BF_217006239142 /* STPShippingMethodsViewController.m in Sources */,
-				BF_309156400099 /* STPSource.m in Sources */,
-				BF_746261684005 /* STPSourceCardDetails.m in Sources */,
-				BF_619760599042 /* STPSourceOwner.m in Sources */,
-				BF_424698683183 /* STPSourceParams.m in Sources */,
-				BF_625910032218 /* STPSourcePoller.m in Sources */,
-				BF_881459130844 /* STPSourceReceiver.m in Sources */,
-				BF_557157962944 /* STPSourceRedirect.m in Sources */,
-				BF_534245496321 /* STPSourceSEPADebitDetails.m in Sources */,
-				BF_761040028655 /* STPSourceVerification.m in Sources */,
-				BF_477621904475 /* STPStringUtils.m in Sources */,
-				BF_484844982921 /* STPSwitchTableViewCell.m in Sources */,
-				BF_151721930308 /* STPTelemetryClient.m in Sources */,
-				BF_822557121935 /* STPTheme.m in Sources */,
-				BF_703994405433 /* STPToken.m in Sources */,
-				BF_110846874273 /* STPURLCallbackHandler.m in Sources */,
-				BF_606449406959 /* STPUserInformation.m in Sources */,
-				BF_542584147501 /* STPValidatedTextField.m in Sources */,
-				BF_205442017048 /* StripeError.m in Sources */,
-				BF_413861440512 /* UIBarButtonItem+Stripe.m in Sources */,
-				BF_321486603389 /* UIImage+Stripe.m in Sources */,
-				BF_837589283931 /* UINavigationBar+Stripe_Theme.m in Sources */,
-				BF_547740684006 /* UINavigationController+Stripe_Completion.m in Sources */,
-				BF_801846914366 /* UITableViewCell+Stripe_Borders.m in Sources */,
-				BF_197519452180 /* UIToolbar+Stripe_InputAccessory.m in Sources */,
-				BF_467013923609 /* UIView+Stripe_FirstResponder.m in Sources */,
-				BF_682536272872 /* UIView+Stripe_SafeAreaBounds.m in Sources */,
-				BF_152533994136 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */,
-				BF_799923208158 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */,
-				BF_755282272245 /* UIViewController+Stripe_ParentViewController.m in Sources */,
-				BF_805521780698 /* UIViewController+Stripe_Promises.m in Sources */,
+				BF_272694535622 /* Fancy.m in Sources */,
+				BF_749620751106 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_83254211423 /* Sources */ = {
+		SBP_84221274112 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_293411348661 /* PINOperationGroup.m in Sources */,
-				BF_729565343289 /* PINOperationQueue.m in Sources */,
+				BF_325335508110 /* AppJerry.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_87012950138 /* Sources */ = {
+		SBP_84494612561 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_796039839460 /* Tests.m in Sources */,
-				BF_682900860588 /* Tests2.m in Sources */,
+				BF_137837529643 /* NSArray+Stripe.m in Sources */,
+				BF_899107596582 /* NSBundle+Stripe_AppName.m in Sources */,
+				BF_478765691567 /* NSCharacterSet+Stripe.m in Sources */,
+				BF_614826181880 /* NSDecimalNumber+Stripe_Currency.m in Sources */,
+				BF_500487776665 /* NSDictionary+Stripe.m in Sources */,
+				BF_856011478606 /* NSError+Stripe.m in Sources */,
+				BF_581808474341 /* NSMutableURLRequest+Stripe.m in Sources */,
+				BF_919956655886 /* NSString+Stripe.m in Sources */,
+				BF_708261286034 /* NSURLComponents+Stripe.m in Sources */,
+				BF_168061390722 /* PKPayment+Stripe.m in Sources */,
+				BF_302723009548 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */,
+				BF_879243780838 /* STPAPIClient+ApplePay.m in Sources */,
+				BF_897890258860 /* STPAPIClient.m in Sources */,
+				BF_256572517200 /* STPAPIRequest.m in Sources */,
+				BF_339016661836 /* STPAddCardViewController.m in Sources */,
+				BF_615795409362 /* STPAddress.m in Sources */,
+				BF_137179509720 /* STPAddressFieldTableViewCell.m in Sources */,
+				BF_112047178936 /* STPAddressViewModel.m in Sources */,
+				BF_628093969059 /* STPAnalyticsClient.m in Sources */,
+				BF_624393800431 /* STPApplePayPaymentMethod.m in Sources */,
+				BF_783900044562 /* STPAspects.m in Sources */,
+				BF_383705307049 /* STPBINRange.m in Sources */,
+				BF_154257750868 /* STPBankAccount.m in Sources */,
+				BF_586042743864 /* STPBankAccountParams.m in Sources */,
+				BF_917515496184 /* STPBundleLocator.m in Sources */,
+				BF_653745811457 /* STPCard.m in Sources */,
+				BF_405210370729 /* STPCardIOProxy.m in Sources */,
+				BF_781817350106 /* STPCardParams.m in Sources */,
+				BF_336768004540 /* STPCardValidator.m in Sources */,
+				BF_219570105028 /* STPCategoryLoader.m in Sources */,
+				BF_381216440451 /* STPColorUtils.m in Sources */,
+				BF_853346063620 /* STPConnectAccountParams.m in Sources */,
+				BF_663191289928 /* STPCoreScrollViewController.m in Sources */,
+				BF_441606882074 /* STPCoreTableViewController.m in Sources */,
+				BF_302356280384 /* STPCoreViewController.m in Sources */,
+				BF_757592272989 /* STPCustomer+SourceTuple.m in Sources */,
+				BF_484204787292 /* STPCustomer.m in Sources */,
+				BF_678284120450 /* STPCustomerContext.m in Sources */,
+				BF_764055906310 /* STPDelegateProxy.m in Sources */,
+				BF_742830011938 /* STPDispatchFunctions.m in Sources */,
+				BF_847291989349 /* STPEmailAddressValidator.m in Sources */,
+				BF_134834117932 /* STPEphemeralKey.m in Sources */,
+				BF_711121425182 /* STPEphemeralKeyManager.m in Sources */,
+				BF_195212030478 /* STPFile.m in Sources */,
+				BF_223032729056 /* STPFormEncoder.m in Sources */,
+				BF_138090297162 /* STPFormTextField.m in Sources */,
+				BF_615023423365 /* STPImageLibrary.m in Sources */,
+				BF_579369186123 /* STPLegalEntityParams.m in Sources */,
+				BF_482442627169 /* STPLocalizationUtils.m in Sources */,
+				BF_533902145193 /* STPMultipartFormDataEncoder.m in Sources */,
+				BF_547821895204 /* STPMultipartFormDataPart.m in Sources */,
+				BF_282310191556 /* STPPaymentActivityIndicatorView.m in Sources */,
+				BF_452046692150 /* STPPaymentCardTextField.m in Sources */,
+				BF_777312866759 /* STPPaymentCardTextFieldCell.m in Sources */,
+				BF_901245616579 /* STPPaymentCardTextFieldViewModel.m in Sources */,
+				BF_104746139472 /* STPPaymentConfiguration.m in Sources */,
+				BF_386982105162 /* STPPaymentContext.m in Sources */,
+				BF_325270855464 /* STPPaymentContextAmountModel.m in Sources */,
+				BF_174303735628 /* STPPaymentMethodTableViewCell.m in Sources */,
+				BF_204309584836 /* STPPaymentMethodTuple.m in Sources */,
+				BF_741943896980 /* STPPaymentMethodsInternalViewController.m in Sources */,
+				BF_503027097537 /* STPPaymentMethodsViewController.m in Sources */,
+				BF_102221489346 /* STPPaymentResult.m in Sources */,
+				BF_348851446943 /* STPPhoneNumberValidator.m in Sources */,
+				BF_278829573744 /* STPPostalCodeValidator.m in Sources */,
+				BF_206864577886 /* STPPromise.m in Sources */,
+				BF_394659372902 /* STPRedirectContext.m in Sources */,
+				BF_966256741207 /* STPSectionHeaderView.m in Sources */,
+				BF_644055395911 /* STPShippingAddressViewController.m in Sources */,
+				BF_186163370017 /* STPShippingMethodTableViewCell.m in Sources */,
+				BF_632482032205 /* STPShippingMethodsViewController.m in Sources */,
+				BF_201216735639 /* STPSource.m in Sources */,
+				BF_457120798592 /* STPSourceCardDetails.m in Sources */,
+				BF_688412023245 /* STPSourceOwner.m in Sources */,
+				BF_546913603120 /* STPSourceParams.m in Sources */,
+				BF_372419327804 /* STPSourcePoller.m in Sources */,
+				BF_556535368733 /* STPSourceReceiver.m in Sources */,
+				BF_384586044957 /* STPSourceRedirect.m in Sources */,
+				BF_265834091794 /* STPSourceSEPADebitDetails.m in Sources */,
+				BF_334815795400 /* STPSourceVerification.m in Sources */,
+				BF_758805317529 /* STPStringUtils.m in Sources */,
+				BF_668090102880 /* STPSwitchTableViewCell.m in Sources */,
+				BF_397168673519 /* STPTelemetryClient.m in Sources */,
+				BF_804144951548 /* STPTheme.m in Sources */,
+				BF_710837320023 /* STPToken.m in Sources */,
+				BF_764466462314 /* STPURLCallbackHandler.m in Sources */,
+				BF_271910114791 /* STPUserInformation.m in Sources */,
+				BF_762592850533 /* STPValidatedTextField.m in Sources */,
+				BF_699400014971 /* StripeError.m in Sources */,
+				BF_101090340568 /* UIBarButtonItem+Stripe.m in Sources */,
+				BF_868279965357 /* UIImage+Stripe.m in Sources */,
+				BF_246871801942 /* UINavigationBar+Stripe_Theme.m in Sources */,
+				BF_626946760252 /* UINavigationController+Stripe_Completion.m in Sources */,
+				BF_117152966090 /* UITableViewCell+Stripe_Borders.m in Sources */,
+				BF_749593072306 /* UIToolbar+Stripe_InputAccessory.m in Sources */,
+				BF_595033292052 /* UIView+Stripe_FirstResponder.m in Sources */,
+				BF_753696533019 /* UIView+Stripe_SafeAreaBounds.m in Sources */,
+				BF_594223087452 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */,
+				BF_139035489647 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */,
+				BF_375786299436 /* UIViewController+Stripe_ParentViewController.m in Sources */,
+				BF_282469902247 /* UIViewController+Stripe_Promises.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_87554900864 /* Sources */ = {
+		SBP_85576223632 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_790802022403 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_91038982921 /* Sources */ = {
+		SBP_86378675498 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_486194470271 /* Stub.m in Sources */,
+				BF_185419460814 /* Tests.m in Sources */,
+				BF_712791594497 /* Tests2.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_87971444010 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_90371855781 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_396206799972 /* Stub.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_90650572958 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_855562422631 /* AppDelegate.m in Sources */,
+				BF_588369128785 /* NoArc.m in Sources */,
+				BF_606363516352 /* Some.cc in Sources */,
+				BF_870378261019 /* UrlGetViewController.m in Sources */,
+				BF_363806556004 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		TD_535733985110 /* PBXTargetDependency */ = {
+		TD_705726845901 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_243789410170 /* share-extension */;
-			targetProxy = CIP_44300245758 /* PBXContainerItemProxy */;
+			target = NT_757956135481 /* ios-app */;
+			targetProxy = CIP_70572684590 /* PBXContainerItemProxy */;
 		};
-		TD_555833782667 /* PBXTargetDependency */ = {
+		TD_745023143073 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_361814418977 /* siri-extension */;
-			targetProxy = "CIP_44300245758-1" /* PBXContainerItemProxy */;
+			target = NT_287747118355 /* siri-extension */;
+			targetProxy = CIP_74502314307 /* PBXContainerItemProxy */;
 		};
-		TD_685884567289 /* PBXTargetDependency */ = {
+		TD_779354981654 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_443002457585 /* ios-app */;
-			targetProxy = CIP_87012950138 /* PBXContainerItemProxy */;
+			target = NT_757956135481 /* ios-app */;
+			targetProxy = CIP_77935498165 /* PBXContainerItemProxy */;
 		};
-		TD_729310227567 /* PBXTargetDependency */ = {
+		TD_818879859525 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_443002457585 /* ios-app */;
-			targetProxy = CIP_58354672782 /* PBXContainerItemProxy */;
+			target = NT_205363634933 /* share-extension */;
+			targetProxy = CIP_81887985952 /* PBXContainerItemProxy */;
 		};
-		TD_747346155877 /* PBXTargetDependency */ = {
+		TD_835876748852 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_910389829219 /* strings-extension */;
-			targetProxy = "CIP_44300245758-2" /* PBXContainerItemProxy */;
+			target = NT_107066082523 /* strings-extension */;
+			targetProxy = CIP_83587674885 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		VG_167175369874 /* AppIntentVocabulary.plist */ = {
+		VG_557820679266 /* AppIntentVocabulary.plist */ = {
 			isa = PBXVariantGroup;
 			children = (
-				FR_167175369874 /* Base */,
-				FR_871158067621 /* cs */,
-				FR_494783133802 /* zh-Hans */,
+				FR_557820679266 /* Base */,
+				FR_682116511702 /* cs */,
+				FR_489653346797 /* zh-Hans */,
 			);
 			name = AppIntentVocabulary.plist;
 			sourceTree = "<group>";
 		};
-		VG_549793573278 /* Localizable.strings */ = {
+		VG_753262157515 /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
-				FR_695303806021 /* de */,
-				FR_549793573278 /* en */,
-				FR_742505614292 /* es */,
-				FR_599715734317 /* fi */,
-				FR_644623788371 /* fr */,
-				FR_841907106254 /* it */,
-				FR_547267518002 /* ja */,
-				FR_361266480566 /* nl */,
-				FR_776344734580 /* zh-Hans */,
-			);
-			name = Localizable.strings;
-			sourceTree = "<group>";
-		};
-		VG_827262883523 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				FR_827262883523 /* Base */,
-				FR_788950277856 /* cs */,
-				FR_125791735798 /* en-GB */,
-				FR_770631286662 /* zh-Hant */,
+				FR_753262157515 /* Base */,
+				FR_109100472565 /* cs */,
+				FR_725361281093 /* en-GB */,
+				FR_130346079060 /* zh-Hant */,
 			);
 			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		VG_879680789012 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				FR_910846099975 /* de */,
+				FR_879680789012 /* en */,
+				FR_399258034997 /* es */,
+				FR_269033352898 /* fi */,
+				FR_671409370609 /* fr */,
+				FR_691227681167 /* it */,
+				FR_694828367809 /* ja */,
+				FR_271927629469 /* nl */,
+				FR_689893178935 /* zh-Hans */,
+			);
+			name = Localizable.strings;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		BC_112067615371 /* Debug */ = {
+		BC_105681971110 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_110955225260 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_120071755999 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/",
+					"-fmodule-name=PINOperation_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_137888055975 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/",
+					"-fmodule-name=PINOperation_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_138088792074 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				CLANG_ENABLE_MODULES = NO;
@@ -3600,7 +5231,7 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
@@ -3609,13 +5240,14 @@
 					"-D_FORTIFY_SOURCE=1",
 				);
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
-			name = Debug;
+			name = Release;
 		};
-		BC_117628839605 /* Debug */ = {
+		BC_146866809537 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -3635,7 +5267,7 @@
 					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
 					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
@@ -3687,15 +5319,15 @@
 					CoreLocation,
 				);
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
-			name = Debug;
+			name = Release;
 		};
-		BC_149169485958 /* Debug */ = {
+		BC_176349865012 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -3709,8 +5341,517 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_179897240653 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-fobjc-arc-exceptions",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_182938313366 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		BC_187820785568 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
+				PRODUCT_NAME = UnitTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_195530817446 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_220004231922 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
+				PRODUCT_NAME = UITests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_221139496326 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		BC_278368275167 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"-DEXAMPLE_DEF=1",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_294046083723 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_307868647969 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ios-app/ShareExtension/ShareExtension-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
@@ -3735,7 +5876,73 @@
 			};
 			name = Debug;
 		};
-		BC_156313484114 /* Debug */ = {
+		BC_312013187446 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_320506846780 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_329180532788 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -3752,19 +5959,16 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-D_FORTIFY_SOURCE=1",
-					"-fobjc-arc-exceptions",
+					"-Wno-everything",
 					"-Wnon-modular-include-in-framework-module",
 					"-g",
 					"-stdlib=libc++",
@@ -3778,29 +5982,226 @@
 					"-fstrict-aliasing",
 					"-Wno-error=nonportable-include-path",
 					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
-					"-fmodule-name=PINCache_pod_module",
+					"-I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/",
+					"-fmodule-name=Stripe_pod_module",
 				);
 				OTHER_LDFLAGS = (
 					"-framework",
 					Foundation,
-					"-weak_framework",
-					UIKit,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
 				);
 				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
 					"-framework",
 					Foundation,
-					"-weak_framework",
-					UIKit,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
 				);
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
 			name = Debug;
 		};
-		BC_176726248110 /* Debug */ = {
+		BC_331640760912 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
+				PRODUCT_NAME = UnitTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_374707413770 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/SiriExtension-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-sectcreate",
+					__TEXT,
+					__entitlements,
+					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-siri-extension_entitlements.entitlements",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.SiriExtension;
+				PRODUCT_NAME = "siri-extension";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_392949935540 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -3872,925 +6273,14 @@
 					CoreLocation,
 				);
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_178002298339 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1";
-				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
 		};
-		BC_183684992585 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-fobjc-arc-exceptions",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
-					"-fmodule-name=PINCache_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_214672727881 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_219739276036 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-					"-DEXAMPLE_DEF=1",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_222888624732 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
-				PRODUCT_NAME = UITests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_224177172233 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_229340051279 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
-		BC_236990032397 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-fobjc-arc-exceptions",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
-					"-fmodule-name=PINCache_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_252483423678 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/UrlGet/UrlGet-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-					"-DEXAMPLE_DEF=1",
-				);
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-					"-sectcreate",
-					__TEXT,
-					__entitlements,
-					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet;
-				PRODUCT_NAME = "ios-app";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_264099224458 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
-				PRODUCT_NAME = UnitTestsWithHost;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_295513606904 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		BC_304579797559 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/UrlGet/UrlGet-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-					"-DEXAMPLE_DEF=1",
-				);
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-					"-sectcreate",
-					__TEXT,
-					__entitlements,
-					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet;
-				PRODUCT_NAME = "ios-app";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_314576148233 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/SiriExtension-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-sectcreate",
-					__TEXT,
-					__entitlements,
-					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-siri-extension_entitlements.entitlements",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.SiriExtension;
-				PRODUCT_NAME = "siri-extension";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_366749234220 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				OTHER_CFLAGS = "";
-				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_367276398481 /* Debug */ = {
+		BC_405912307535 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -4817,81 +6307,9 @@
 			};
 			name = Debug;
 		};
-		BC_388852820408 /* Debug */ = {
+		BC_411167911201 /* Release */ = {
 			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
-					"-fmodule-name=PINCache_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_390353555046 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		BC_417518959352 /* Release */ = {
-			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -4903,38 +6321,11 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_422821497100 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
 				);
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "$(SRCROOT)/ios-app/StringsExtension/Resources/StringsExtension-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
@@ -4957,14 +6348,328 @@
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
+			name = Release;
+		};
+		BC_414927924888 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
 			name = Debug;
 		};
-		BC_430395197856 /* Release */ = {
+		BC_415215904150 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-fobjc-arc-exceptions",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_416404307328 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/UrlGet/UrlGet-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"-DEXAMPLE_DEF=1",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-sectcreate",
+					__TEXT,
+					__entitlements,
+					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet;
+				PRODUCT_NAME = "ios-app";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_420944243807 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_430286168504 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		BC_444205486961 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_468059036733 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_474929246975 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				CLANG_ENABLE_MODULES = NO;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGNING_REQUIRED = NO;
@@ -4975,10 +6680,10 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
 					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
 					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4999,21 +6704,14 @@
 				);
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"$(inherited)",
 					"-D_FORTIFY_SOURCE=1",
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
 				);
 				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
 					"-framework",
 					CoreLocation,
 					"-framework",
@@ -5023,6 +6721,8 @@
 					"-framework",
 					UIKit,
 					"-framework",
+					CoreGraphics,
+					"-framework",
 					QuartzCore,
 					"-framework",
 					Foundation,
@@ -5030,74 +6730,236 @@
 					CoreImage,
 					"-framework",
 					Intents,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
 					"-framework",
-					SystemConfiguration,
+					CoreLocation,
 					"-framework",
-					WebKit,
+					AudioToolbox,
 					"-framework",
-					PassKit,
+					Security,
 					"-framework",
-					Contacts,
+					UIKit,
 					"-framework",
-					CoreText,
+					CoreGraphics,
 					"-framework",
-					SafariServices,
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_498780084379 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-fobjc-arc-exceptions",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
 					"-weak_framework",
 					UIKit,
 				);
 				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					QuartzCore,
 					"-framework",
 					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
 					"-weak_framework",
 					UIKit,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
-				PRODUCT_NAME = UITests;
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_503124594100 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
 		};
-		BC_458231144637 /* Debug */ = {
+		BC_505114290744 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-fobjc-arc-exceptions",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_515041536280 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGNING_REQUIRED = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -5109,116 +6971,19 @@
 					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
 				);
 				HEADER_SEARCH_PATHS = "";
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/Localization/Base.lproj/AppIntentVocabulary.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
-			name = Debug;
+			name = Release;
 		};
-		BC_463601024211 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_479945831424 /* Debug */ = {
+		BC_528827945251 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -5273,1628 +7038,11 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
-				XCHAMMER_DEPS_HASH = "version:0.1.7:-8473842487065668034-1537481146-5003061736987530029-390533949451143316313908610728580882113281163160542124800-2228606524981042457-8742693117245690758-1537476040-666111654822239088-1537476040-689712657248687846829074163902571322396278295626662351341-2626311190415904923-8220394299430735609-848205287412479865-7989260170070047884-15374760407964233260437465531-7315060473208213662-15374760402506253069274818631050767898345806038-641936043688698666430576453881372195303063640766068516120-41538179474337742386374722415315892097-82397515401807903352616904902310998854-1198817581469908844-36098138363674446223659374292725667277-6145581409945031556-9491122994963957051236023912715738082-8640188960862850106655538682259426817-5396365198391674060-6944411394966634106-13354932680071789666048628499963014512-29835980521213810202327330699439257550-84860043461589761683973855870880942773-7037027415018862143360557621777643576-74743546315099427603946931962866781981-4033096085752626477-243567739455111951448569008498051097537654849263714863761-3153676371510550094658784597265149670233423825478050905059645432936803753104321288890129527346578166757383820315859645432936803957958234540657452832526578166757383822364343482489067929606526019629108967248926-7236451628659420411-52713803689258256105874044749057908540-1537476040-82935793621333967098091738737287316495-24906256297722267935215807742037225772-5656621702510990160-897414455782409771468943591654976078316881668035512326325353966058420992420-2263650544365863282-226365054437452235059114089404216901443597818447160785385287954445083372688753529732058630993039176440746505590191-6383679802501917264-66711988634858689132251412223089385180-1819710864076497660-13329635375452864736732404479720310212-140426299055237937278119000820901715835479200048025102809-41212799320032860561282519532391727281-137144657612567836619851504346547269566569168551233595949-21220209294831232943632972316564818412400302578160835789-902433587976499384-18197108631634640404956436316425211180805928446767235862654784857191994033381171071219097302314-2866620983180345553-3590727606572635947-55885302505308116263597818449791034878591140894028668393459114089401516777241587037301362313144210431520127303435668346890531594354175939921408888366183-3680283591925415706-8541337013526846941-2242878072073645662183749405582914245-7274686006380541694508067371762222596312801032173867417578985798789083720983-4202161092895152869-575286511831899290841216728073903563088618831412926224195645620850931045619357225786532362886804343195022405542524-38855181692692576446637561724678013005-224287807004468206-2257901425632751912970735921499989850-51912020885728585359143360305213034881-422875270180934981889494235253478339484496180869915976970-20407078503085061636322555219372279237974833166119393090-33018273507779216286133428808155420912-61271368785319032995767722004966034424-47114697935560995156243586993326364416-99077624179654376-712620711368000375-7288723744525280516-8553921798311893554210761480006943676878818305665984923071703661006427277057-6904570403681993912-15374760401755464309364312943-23314443749141391507325941422466297535-519770597385937275-8928615114325607656914909668490681259246572463829197465132153707909329342434-344677931328580572589880945785837199318061944023736615496211076234407182841-254699082990696193290891760074384379236779953081111327896-112603923680690345762110762236697645961806194402373661594-74996125440857759916779953081111327731416152674646777748017190627256944674646034086409752273750-153747604080053012144377728585838339743922510100583833974392251005572340465739238839397680366925008311850695429917665310025-23958590956128905697249639371895310586-6891338346720224301-86143188263156475347852119466168534136-5673742439910773876-16588538439281621653234192857290398870-8304905425395355725-1596460088433530626-8316377004599514437-83049054253953544404604750415501804467-8316377004599513152-1541163495668397492-8301449956874797629-5211733006286472034329752029311339967863890333067618503-6581560403632727199-6283534780113295205-533113332062405806-8551211679468785459-6949839392077997200-6445007950814995297-5822557612972898855-5822557612973686043-2536329804598649973-3034744668576306530-854856621041004067-64450700041002970544778979733151873194-7243333586285146422-67584646558321408713874301050447003723-777391826313672730090644442531916221821047653126212533932-7128117354473976278-4357478449263585881-51581266568669504637190440716111841517-27627610187460101701218803536432621002-88498333752229290867877956564326449158-18114671186637752785637063357011499587-6816594419247441316-472335823793700167-755605995536591848057144723262544131313381265717187726027-25573319889817079365103367079938147412-6457052047986066107-20031696272457995802584001436029579522-2564043186334740827-2554450031438243958-25725702582778379431549321101038512819749364998859121854066363801911850203596216023827140148782612410299201793184642805162941122491-874147814276973698519498264006806117-1297673377488256334-5618929415671352875-470991578592802387-1797161565442885945-497870399485846354130801818758795580528921457137830740698-5025505910325555987-71748147863451095983514581946839263154171089315380797051035819647606755869281858984029838206770-846915525716855438-5381778577690914331-8934713361162389792-7425182610629903075-3776942967643613935378506615099610750459882482813160979441492180332462387262812726556628449074162577179615724830915685640124890978076582712769546219024-1632946264362837076134708164214703351935864358425304314992320567596589946185496737379650954363190270423170265875767274402540587937100-5146300641224843879-420547763654339443070646241098826217956661393486720217708155681803991896742990721680993853538614492446827099433501-9150545133656132954-5784371068132079820-53778074123560498868477442263421133317-2325565609803830733-914262001139296435279779540754665037069704533714540884879029339242192110080-3888416660141790407-173214210445803384586343544299546678986306930438006995392499737177965022866-6212902320520456328-846424668119443393932171496564708118476291262662687955887-5757138779571961560-50627049829661797956638317134827282745499767966855736513924781346342729531777078429956863629646-7805102015281157501-15330391241138473898899913557904586433-64402537155341725708156133641060255206-5082245608491487341-5082316390694818926-55825443009127205-55860834144544550-208856916110695963954245601238017969255424555721527164993-5603778982163127565756789379832514345007126653012716882-2088569282305243924-4267217066399715596-3297213526801476837-72287346627108695427898178289881896867-15713231466135867757414923180058431144-2577376116295449141-2481772395022816309-762034084062431094163473859907043301057861193690199199060-31783558432733862107010984440183225364345623079905451400426611770956637352476449252379337893225-31467454224052098168598011772476578433-11659321574129463444663451176409096812-2919754145606491099-3571475855954180651125316086694770432224866402236771321-1323082589411256850535218274143547596541752328032481614477861619194807813960-40942889017251057954524024711420814040-178077607080898698-9157173701435248747829697380580983407-1261304270772289443440083696852240706576598277690791921-56073180957048620-56108572092465965-55967007550796585-56002398686213930-559316164153792401159149248022878214-55896225279961895-579202978221074974-8165058893617288468506713072125131344-6768638495793371300-60166145726317116267826963784751386498563906337829439133477819284789700417647206648093253773468-7129713383820693606727548983207182592-528637341713259779986041528545651693202553269516817023003-29033527890485952193939640614317340338-71563490991645083844889376863217236839-1537476040-2734903828164989554-4904300549154576140-72509058801099333023541741586727571566-1571974436101795153-8794830429588852570-6937927939398094993-153747604029318484432325853161092228348017813118-9172388575791882391-15374760401266669884985814400-8200195202873624183229642977192114489361685543880047028456873549916340109362603042038616278871-1537476040-5379949573569615966912474502863786525-1537476040764779775372864970-518762995561969027743083248053588588736024510140756371167-1300290581354301737-3757611446925466749-3021600819009237531-6990093571529791457-7631331722773599654-153747604133634660380252717118580589455731383345293687605984840774533090801874617451201565770061809255856-152599344783630600088048671706069230486477618845528781901-4303278975975260862-6869125066255877620-1795116698857636708537595140006656545183447978183663179233070196995010422122-2260647788846168689-4276896340267911842-5093359424358337413-345984647488585051361026930144828353346180215561669910556551393317151109392966791908317641768261028495299071691025-5780732881134893548134527046398695846-3814287260755625935096918605365204153-7616095980476685457-8624793976082427695-762233928808360361986069774157087971278212289478691851857-8369392565227583961-4257148888508944087001692845648613347-7555618079386075475-1814084458839648689-458267045786218290870094035312237201463124140430442589262-530619228265943108629943314194428907141562781342664298645375274006423132735-4956869912925519438593750632552763106336877924640079665802878766677142073501-8108777575804407231-5862817283401373821-575278887408637931450910306309145424788302369421641284453-7736040194202602941-3796704030168022526546838735880137363730170009563457730176922357904540159962-27149324200064027816053478684044016953-30887438693051688169115537400476924075-2734079538358622208-6918111226815082953-63872804354060092907275601901389325593-3822397865959401300502150765037680942-3818795253849093167-1968538031453718676-7359138630317540396-41511320589780839416537612002480391824-2581517825770038465-5836712311632587931-861476900341284211435718035068128535703741949137153716471305851921115033558-2301224456156565457-3700722707174462586173131485585321968-3957735361494639117-32648924197697444676207454418362117841-8834750551330569143-6482263251241233110550660400743960253-3937558125733917265-525797115407159479595356153041763620954081652038163760740485113732020886321878952005039091038-189187649126344693956937745143203898747883131626417694334714343325152078222030441114771750442258730795857284416713-46298452223734004662489406388980622604897650008303623460583261357079234389864371039499188078450-7985176282021350539-890594783483320423-8816495203601786030383083241890657624-8467928135676887902-1182689963897618409-5305895700570765760350688504586783163160638381046221406112330474776361537010-3129426597234946883934091105261587069961604695282962294459311697083225391-748735994897278855212333522912235066444099288540304578940-193023047173334913872872067965633381-775554138942294136844832231524437519178387777382356336830-1173462493705284015-5238425108396792350845240672416248117-75156898191612145463106855320600802427-7102346195876436083150003197670960185-1637328811256441964-3191678382061182300-2056383879666190270-7777796771682812237-14733490073593136428426526313124199139-6029044304684587995-341728503182768951635064590586628011913001067921454263912-35568568602698638015376539208261076021-8245062055692356865-2695971652034484750-147285141128344929231085066872049790537664479723188189675-672835058043888047541085979732964236376905581916387248911511800355713375338-190055137013545524286694457905124665362517681924335866271221718267727648696981776229530828447857002148616488368111438043691472252773-6973879806883819223-2318495357070552133885094149765079928949587209598492904-823695205232324994788224795350357706595725972713151602414-1537476040-4282099880787881025-9171748585296769620-5812985619133817607498785970547946593-6304122209670633013-1537476040-9196271956823179998776641742361938448-1537476040-6305976185429586516-332084195985421586-29040514185457191753329807709223814955-1104674858844269173-443624406853804817961952217007984133733360443657687161672-1552770175832015219-2465043645589324398-5255166164085454922-3486169254838316993-6598257045345228369500940627287546339631705530474407094895454026848949774782-5853136935096940610-2220688794442484668-80949220357653761924019696695274145206247059493270671956-8787409614002043291-4391953139238982493-7212782120134123350-3922278094170257434-2220688797126839233-5853136935097595975-2853441943191652449-87874096140018794466247059493270999641-8094922035765785842401969680264832765-7212782120133795665-439195313923898253818681269941245009934360629372886019461-2852830940620771924-57112263820392169308388557522945962171-17346859814894800776993326174504640453-6746329307664744102914749700877272964952494689013961761426283777320529700576-43072065535878048367342838742683428147-79632797486494985245908846389289709627-1805965220689450135-10175480332466088325565263540779848302-23808777008435629393109199356115250281-8850153881366543552-3068092809907961237-7873279769986162878-9111246709732985434-5411644834275607747276206406271991234991491170128507464771964137342088464537-2908296587454973080-68289086375567958333983780147711899846856041890335606977342084323259623387216949897300388424694-24585924356012015275503927230035427671-1682818238516063202689917900453681047-1458259685724693877-58510737164393033353120323744192597395-5813614699652547181460656435098093041224287028150208614-471846293253547837168925594414143606833673498024669184408-6902622699175212698-42713044631355577342382045047118316904-4909689809672103288-40585318861775968922612475962540246376-3501070213660205477-6081263340704220386-1218616241508652686-8403492651119182152-699834981312483023931084185431015817934032622170221434103-7549334420222889182-378378394307740071658269213969799378122515499195894055030-15374760408230475588994969588-241626271546556351669257064440429584144258994655471386336-5896422611027131982-6606450628573090596-5759697908174136608-35367615644010952344646299206506073514222741870315408912438128256324304255113094250145045337679-83522355493308117411413461386407024051-7977203383812669281-7068401052501839007-8734281439813677633-5894116888770946645-2331854564413923931-18874210198127865207771364053422041894-50141204301461207497913699937702783707-59484249008404918543188280677168897176-48342453567399306025819394548853393103-8820857979107049471-8307632356464343371-9401985661379981517218497335565279082-8461253180509702746894831502314437699086341317065234986176889164589538297877-8723995406746172646-86051054813611769668618982277117395785-9071862009417017167-80827946796069550918111820904769276742-3940921787535932942-3418610985781711067-5163578102766911807-4901533933803695986-3156566816818495246985191163501953735-3805137622202046267-2386337454380775001-6821539016493956325-5862051654627549400-6509340292102773505-5585534171345902525-4627792047763159032-3678877618572717121-380350331905304659944360711329995767504844325431715992525105917377327235702071603965396391648818653281089046424772-4154856040537513212-4572201187776714781-7460831994075743370-4073542884633883110-5087440323333254985-6334987661853195220-3878338557255866337-48021446780127373178874954504598862821-7006660837750983805-5018119404064567660-109484576773358706613601343034511545493094250145045337679-2320735395209062814-739640963000497757057618778981551435578012800193552761175-5306399489804795808-3097509426665355679217128463852469616788313909515564465435533849317861102172-4815530957473844621-5741680527920463253-5017027146168614310-4538324291269851531-6390136520858823059-49393636433711753222448491304728689257-3374716092869348769-64680088360053416145811055984065095262-5646301263029037982919333096537937998-4685441722156674733-3832158940269526432-7056507856780735396-8494315990011829804-42613723755019990727599580832716815961566171596469228770-59339840388585073686982286842607061392-8187815246271049387-561833121750202888576462350739257007109008131162228668665-8903556893007701306-738001375719130141121547534287426563-8490256423316899205-4311343889716905663-2413982301023387771-91874808276917112344827483420206552699174875857639703067527167926528784568961512432872478234617732655843719490430-4429065378995243687-18281409283635908625763418943888172747-20768951135332605078873980745877047568417091797995436955-3623792770550834324-71335380798479909242243540060595838417821290326421264689015071608974411348-19175843867117669224271391049427005024-36367952980625895775326188733261896435-80342788036677805281062169866366795112-1449294593069044388-6725343574498655754-3617050155975143892-70182352934314774044397221553342886022-7825098835662495383570158864536521053189321077799557917021635996809781594712-41203134232476445727349382668551553619-73800137571912689-4437555678701784967-7806835797742704788-17415861589087709152485817334632644735-2246962629282046549-2076895113533260754329220530438939977-812704701965941899-8391270515165303763-57188422081656953917059256685391148943-214542201402617444927167926528784570619201005883727497220-30350484420538348674690548871100037497-39519136424907672995849255319224190979-4350845199414797880-6770444019469066726-22647890199731617347856175917192735477-244300490563447667388043443693448537576349272358821568055-7133538069110572679-2116524801590351257-4129360994491637459-2406878139638086923-50574535347763027883725386103422952117-6606062086576074229-3060948633229337761-78304655980990478772169292694389348210-27014948547497894873706235376393639206-8765030008941914385296058755524994419-8034278803667780363-408279055023638268013218293569984834559201005883727497220-1323801672220005825984320194666510853-3930240172579484320-28949798065104455247326594773412675856-8965782736173724005-1790696023029691486-1248564546589389749-66907447676162726432183860160709575690-1878230637187037878-4696779300135016099852225297646133604-1929714896014728690-605388118916313852740071391646428682948655073216253617062-3746472641145228684-8567920162698772203-8683984971074641134143338958731757550327077859600439401084007139167327222859-3746472641145228669-768061694271072733286550732162536170526483636398832934938-8895418190159185950-7089795325586559829-6828854797510195142-1466675174200336369-34181174704385567038076008369706722444-32227963820930298767766756038758038191-83013956408474573558218836515529944661209850004947409972855347155816188863504895433216809267160-8683984971074641134-1261926750710890924157801205260994822098500052158454293424202104962945770755347155816188863406104277019839509043-39378539847515720405361848198642421857-2486233477922970107-2403982024974840053-7545709383095297575-4181262871707013297-4743902710763029998153780604384546155-48816242609936975676770704141747301322-4990415325230236548-49529185914419233666653695955892070159-656730546770198192705884332234794528775616539398580009-86726399203546052658131532148159738345-5390914570818143915-8521628537669495763-8511206813611740493-18323849227671412393809009575042587278-7021139909883180698-64886594245514796264001941227546723030-879316197977714782539900788767058486762315509761361707222142735786132963948-786772646939776813222448230869246977079192153239783657203-5625381048197754402-19703607487266499381166194074727831523772707940555682179-1452374135488047467-6096958767615286894636797673177947237-32179302573059147306590750093607392065-9182321291799331689194211454389777431633492366070554720923983815571346778172-3572668871465356414-6493770306557789307965068509766316080-4750522143772391545529784307579825090123196827457838157811905720546140124481-48056500676900065032870345719612304194-5536000956888526745-65862750659324993618745094870401652089-844667068764220987887923253107102056582857013216746045152069879396369644698489328441250916416658649715289384634-42799046772760425545895865341776517979-4248840277500115555-4924845183912142932-831663154918195311-514485683308333321-4232287667641463179-90761268866251858876299879971231137342-8204205066769705916-259310459352510902725336127084534533028715743675281347747-10502598001718404612864635111175816252-3504931041948050369-1520756311810104397-58572239697320275874745273363038473522-1931834000199887563-46385329496051204251100472939212180362-6815040101744084349-86975513214494251077982144795103675032-5751138600613056700-451369677854040977725556921890765811903390954399404486537-53676077256890545055971697923695251914-39475952425084067045325896478626066996238359048352286422-66762402647502642973405518101840420522-8450727807960721692399922081223888492488037632346565065-7360920501492573276-3340376692029257838-6932644245945231586-3725987573540650640-297100485149267853878851063499686019457993790354148380510-140946096598215807-593155483297652491141615178436723453462224386605285684571063781937808792672-36131826745894577218565760706882267377168492837685395929883037756344393903995930774910010637662637973771029605736345313934436380915797165914816516860396755460663304019279241700363200128898489105013595961317081-482034711917157552742124297917633253801429672798583047994765028108242030734-6185361174088072112-684129840805457611035744285794035558194331711412153012674-39232619670152441147753970665500016823-91018048155898130565290390226973463714-387701809258320936991779714542117927607060516638171529558-1998393256587269737-8242197003348318842-60260155350948473451691449254950642901-5347007072306521819-4580741741685593698-75003057292822068116241755574927062180-2304242856566738100-50389160451796624188561239934615136734-4720397464744429504649953120963679545428016241014414087004320296267236311425-6198552897944831690-7155426633672612162-9136395549303478816-846527424213593507063402388639046458082384687416615563386-969623466207234439-6350994620449891329743438346080433852084036457750547647235409423100462506248749220069158785006771983032447089208904191850927568999385-30544296600601846972923049675721616030-8332444105727320130-8727617102784681755469676965462024961-7478085846660880488522620662872071903228297968489736526722111547681784584178-76053302803343894244723284766101090366608919509580932301-79066357373480282611063782768973731412172443970151416286825030886316600651482659311998231205586349553376129609796-69713199818566089726406468869274811822-1732254364865997554-6104343279093292704-602755733510388172-468297091346866055646432338200995024743004549650532136738-2247878778987252689124188531031234040645126037529444815147163904224730678911-8311678561343315495-425997074531723909466789887325078885201667889204856734220-19033149951009591226650909420480346468-1321024580239148794-873166975321204200491396925988171551862262375852188489583-177654723318061285-2325878903348830040-26870009685614059486821056597368099778850769660154802888879877081767479763-9839645660856584484311780001916232582-8507076631081871754-840301620592165477369781956346527422453800908694327293121-41299969743539032721446426419412806368-1715139924414912780-30254516002515663997216092533499726483-39174167633755647388529533433425632422-5360129265651203790-14590293389271706925709634970879672937-2166939787998615743-7910988462665650723-6071622698047367112-27370657341931085794285399742733873489-236023380049780072876946567451963802997226403872602724586-37369627618459697242254867244477414578-2458701987023923478-78493081190532529771242714691197614068-6806806937204737667-14560202208377420542599064586478974857-82597746265197662857118564917997445744-4815065188934800769-25927634727433431891935904276598642129-442655378625276730-60071282628749302267438460524996314039-72621076940676035384629423888225346138-3173208751174891330716197741322691627953518716602191883696239300418351871963-576086746294602220372669540675092063366691295380327060420784678197226556811304133063959771855-555495304951028728886593791118984565917109658029809125614-653134040275782397557244530164563628046836155456494637534-765542082701681192-5407029681682951651-11153548869843556075354227530804449471663395756374892003842438710409293381301314024034043970223-7908672190242522070-902140961093511670670880903573902291167997039506266725521-85853055765468501752413087668355033472598579915521369869-175024384416533544-8358502356988706162109348430979843483-8444183788760870903504924516979985911742071614398820666774083811067464613461898841793318494494-780570825629012766758306044679953722792701454673577791856-30330239905289183636229000227705321597222792185143707812-81075094658965605748688213209394731319-5968525785162653070-90176490745888689813408915926022728289-7899919827437698680-619435336707938644640752392262879792162811896568835407881-3162103900613354657-3623748570753732063-5541494679176074373-21442227773661179304041402725700084678-34238451907112128048692632944857180996-7303969957937301601-6712194242837566910-1501343192940295504-6518973261915126378-3856330561019103902-63589912223356726274913492429434039705-75377141768682934153569550581314318717-8110778868146919992-74974542683586821251427681379662758431-621924626579158934-7199937138051816074-3100555203250675777901720091097762298340637808819931157968992507917036410256-8433105929432080549-6570196209670628578-903925712009799277818258612859220104187314214201230622334356880673163810205-5410521161894707162-1504491986580647078-367498255353268300749505654579507400548051184306205989053-2581639449495778692153505654349363282742967871306706907526896476094481150211-6962111242932739071-5893307832034863450-22371029650278677537942435710264951091852735944775287727370427581749724331717275067089620872970689145473860930381-56021775492369328-6177795380184573808-5072505919702849896-34455766022234187321904242301881417759-4946317409618038955-9058668480376387247503207118026251940-1940967814517377954253092200999352037416727195814091996199161372645505399431662948111152578211471008798080416852638911346259534432217-1318352466143572142-7675567217871193575710619538625340490640652155548668582062627480089789296348837139375629569299169987290077522261-8538698435825990576-7907540119955873050-472419854599519334060704224239825061276994036545469708291-1993320240101744977-43411703481733627256033399705578552532-882272343455654323-1851884267665513183-15374760406230246366364580697-84561718801179021537686002673570695001302494714544680999-22867168126745469036190953376737240437-132037769601076588457407058343030172819051293304839427781-29591620633253790-776301875346978494887653100981724348683818714774732171588654002911926612484128085514444221827457011753517461414787955448314170039965-577866678332053977268056946665567885945000423109594358420-30509390441758234359020797856957300006295181312654243258340516393487255422-692368657619202605-85955931583003529976288030400018796343-47776200174645351764812586206581730250-32559690740026044511333710604824908554-121745006608660271282694024128516610181071723757575546898-7899571232758122523-7243452406292062485-834878039970631275648929110672720438621722126037464856283724061482760664745617860771578588380-5927107476141755495492131892461502986817737211744694507381477221860350425918-4544309966338137706-1426390754717510984-8831215943197651733-883268399880585246143831533558541817244113837111224582476-21941670889150741643530933762957584886-4541422012139078547535694687326875741490617149690016251548205612630214836842-432341639315889582947932161025465330143259807701051546444-2999010419541535130-6932051975474530339-4937913754424006835-5137934194408051544-81698524250246099273888271769002021238181258126807851111-22653445423862629736064587486631557696-103816961949657044-1516144345990665109-8339604594876112701-5725660295935222760-3264463962211624467-861097569579331249-3264463806076942602-861097621624225204-4474841487965788767-45614357084800857356420762245918551649-3948731218246647896867602953120278338373613832906958163181812580747629571567207978111552031114-79513203793198854394407837713705902994-11691719700612558074236957554566262803-90426240845845329484080336693474892858-3786599084416899028613031633750874222-6763330958955381922574004319349878343929501345928740797014948537067575510590140726358990155568758559722362527087-676333099365197789247472216913493645233498224391073175353-60273198488133436-4199407432093913424588686779054074003341369699857878763674792652699644696473069085076426814826-67767549194406877229036702694815845428-39176048280730235865543500090405319582-44880019968388811735425598571457695949-6359236837492697560-17023385397170434155905198203753363615-8012004719548351014108263382045442704632146131650384676911966217668624182062784096338331251368031226408387037798914863833869137842144202764126241524158614068071909008817857203780836289895898-83093510381607241817303255822218204605-11127437920254701092924538091648714926-161504228728083562511071345450689316561966205659619293247-11194983434557802281394135095016502102-7738812400490039209-93864927810760921957640328428445858016217566630565448839-45738053920436941532924533633136132781-11127432195316366047303251363705622460-830935327609116424654777529481349279495208929124105409869-72946077972415847111728330876301606778-7823105752294643674-819560337592343033731799538487029247317907471619714398844-3283007686385849661565159259755692275690206343425069746645239897485114478089-571822719519120056353680660835233030546871694469286612680-84601946424548682153171882890989080511-340445810574647168-539836770491915346272122499932383344751339603094759872486-9212650036895344330-87977622028430696927252297929066687998-8687728324160674262-909668507686965341868836017998182464858066517258572941939353277021266313990-27255208441537665838635209603383485142436441161134687842-7385144920863919676337018771023245621-2451119086977895259-44835139432445020606816056364410659947-608256506761169290279297396305404058081044367200405773518-653039299559285287084745608109033155006593755287104774918-5147036592784326916-8745875710721633497-85570214533222197404148967813060937423-8857570313014469847-8571323680829702839-85955931583003529524596276216501266213-23395963241709912934051418066154151329-17828703519370059972621109187189405826-883676023079153494-5599964818147236693-483750788046110501232984988081042764035670803544929244327-6937817553336341736-5553225659267598206-3479904237450658622-692368657619212850340516393487255467-21863765693633225087872954026778351126-305093904417582345079554483141805257303818714774725617938654002911925957119-86530613775418884001831318085891797571-29591620633253145-4299029351491267018-1858580608496044824-3996385597216527332-132037769869512044957407058343029763169051293315576846026-1084640404743261948-44222111970944010916190953376737240522-228671681267450593868911870682666373466189894009955671328-1426390754712268099-8832683998805857586-454430996365378314149213189246150299131773721174479936503-2483279335535082318-592710747614175541056178607715785986255114737764523143475-8044675878087251650648929110672720447121722126037464856183724061482760658296707290368289560164-834878039970631600-7899571232758127648-7243452407634239770-48799349913113026543199858574105202603-8508962383243660441071723757575552023-12174500660864388678269402412851671263-325596907400293213613337106048144227894812586206581740495-2429238691572185980688360179981824905089827719180646553726234881575392373549-9096685076868998053611671453526029134-86877283241606768274818534830438135326-92126500368953430457252297929066677753-87977622028430696474765256832112341327-44252609268076559913671768021656254843-62951142828894292757644433027879774760-3270084247219401554530451929607490825-396249613743472660-5785476239089457246-56663882500303393005209710604526434195-8748373975854394058-7595376999810755693-2543332513551927706-55644766493388165697728423414586960755-3457383830248761347647781661335025938299624682528254415464439793865972066434879000468736946901834797751972392673-655457267796051430612211713575678059645629055900849980331-67717477655049770874518528552715302640529954899591902475050269620002312325065497727208928958197903245135429151-7878736122739557692-759543079502647384324644429524450540994981704332570434420-59946220043068983652620365932188556673-6951947284611267949-5586805588842925361-29959486169392030062392121774600004646-3627342555446415746805905234240354363851782564339648287060401836621084258183567139584108127350-1333864458788395721-5785226859597804368-2440395246014623303-41803529190450307371114659190044575555-7691942648356320671-67716596151324126344512320265165947958955340666256809094793216102551775899-4323416393158897114-29990104195415325653259807701051546489-2250165439620431074535694687326875738990617149690003144298573071031258712767-45414220121390785922231845021287251161-2194167088915079289141525183268124189119765165363102953992937654772591564719-8738888692208923163-85570214533222402254148967813060938068-8857570313014142162-87458757107216335226593755287104775083-6530392995592853035-6082565067611693067792973963054042629310443672004057940032172032562185079406-48801809287874490157188902761761801729-80078437679272022192326273981863962873-44835139432445020701137932435019589136-738514492086392132-23158071030832778368635209592646066897-2725520844151145138353277021266969355806651725857556338443522311686396565058296691702407802512-4218846984596643620-1291008392906921776-17918657622408065038192650570000785864-2878619633928271074-609022822337781247-673707521726731431564291219247831712278115535465215930697-280468393778038303736349455613091685513392126997261969911339212699726197636-5834651129625077705-2456003920658843873-61660305041397079245605042209534083722-7008370186240246828572206823245152555578849120714514242864302031547454364001-170238784245421586168224428524527662345722068232787069880-2842340458262600474151087921911438624964424832560359396834302031547454364046-4603781772028137678-656199175170212247175880300949385371356518386342516593083245340184240491394857897795796862416292784905898370512802980756370415697890-3049890551978386054-2269995619271987017-320740058938474722139888020875434451483460055320682565709-7034447752918803581-7034447752918801016-6564319533728109888-1537823766-240513035645248364856050422095340632378733180307529819891783030881200381539656800674028312273305680244701765891015-2750060930334248103-1537476041";
+				XCHAMMER_DEPS_HASH = "version:0.1.7:-6288358196755028991-15380718177825250333994445206-138961584413102804311561263361742201094742368817551100956-3800843709244319878-3072210651725827995-1537409411-4813727266308518133-1537409411-8812833085439060758-8974642921608170517-428247363663855240027276797705810353797704106711548726805-19654427292766939204260173612689637764-1537409411-2660139263763028532-6954291847268389851-153740941158544052644909751794416080630251922916-625159552080923365-8127581152973408225-60382488214343808365756812780883331840-4134277424566218741-33471522196820527261494421402726165876-8839739632762004211-3935263738151507838-12529439719501099551299719477725641299-85193012119446840954353427595767363882-78103355334899461277791444040232288752-91726274820630955822459605020710812557-4395783669294421523671055742255511353-8822673737589657742523858672589095422184843977743635452434652312105692804628-7104213273274908219-679758369357832177774856805636566944918728930450344164141-6364728089032654954-37141080762521604717102645385897174716-81707277196853556924606631192293875317-5992982697423040041-8503096995296581571-5693332235794888449-3739679205833104590-5716230757708248057-5693332235794885884-7737114960902499877-5716230757708245492-1732183231285476262-56864347441565759853405109534272837352-4984536289046878985-8714641112548879863-15374094111535272661249519582-1231456848849360626-8817116352631290858-36685524108807757306871601550350133619-1660401336883226802-10751367000041273135609641346650520204412609616195565490461807385810137608646180738581000641062869019523553946014-3150152898142868814-758833836900320754144124855096254243098994248409200432061-640852832733112164-3660228457884885351-37940045754428571794413993649482312166817687830895753030463087453622734908942518354807250625054-35832094876687772714122486084028201955-81725562811829785908723483767102732987-5509955735824431380605651250255462328642453609645804892718736311004822068933-7911379599757626890861814268814732118-541563006182789555844139936496852085266895369639536811830642613850307539377280517594734901758289163415439253565236-6791071612180950727-47499881102777279064701900514049240134-22087499345364872392832779069942261149279653861633057628450388512715606404503067917672245375856-4490755223333312164-54777546916441753924522846082039178979-1377999300503704183-8352863455740276520-7265374971314436328606344796120491980989862848830671688278635119860005799164-3156972200500211178-4493159448240012765-69131764098912094768368280218004325673-1292022443148885165-3304070505721311237-9104941123779470997862440537597727494340911856049021524504917806429534330-8298398878721488180-9072952628057915309720125349985307316565498659862126372976439946659928569726-1304025089714858154-63348993169125690149127853244747763338-75896003231532701288626367840418750907-2543721056211164657-5400898642633017152637432928446907742-47935626744626292172591680521115146342567522416347926615926512144663207289428178307958062628175-6468027630610319028-24274113546014331534538352151123026577-1606305425425100434-3378163957947613866-32675788494881577566868730365892065291-1537409411-9278278889258167827812566175111307445-3388684295977440382-467454110316041951268893238645299588751410324345331634547-65518513432487852601955092935153676901-127107518028814312945444905855249199003851830458968974476515522585727202066822505909922428546254810439674437739922-6009988230364387241-5530889120317796390515522585592984338338518304589689744864954272239225251404-6009988230364387266-53915641762257413467821792062245366084-6053821571507700452-1537409411-6535893435448276227-7549966625382093590-7549966625382093600-864675401283116154944385674070531325259868862224566973562551257469915666158721958841837778039767321946876941677036064951070679673554434796172552000035764102606912655296726860257567108315047330502488487087512-51199860848237072084735710110545979212-5121459089157315136-5119986084823707043-8019589190449692488-5121459089157314971-2943110492078492025-511954238653118418486175646611307595964702320203394361545-1493776466535590959-5786574452792301155-8193766277298226014-7372569299459468694613401205547220211512655729595570523316551544805842737354596929215555455716559690104099946444655594785526635334326646793480659812552736762066623385500186551537049181670093-4082528341162969899-4584897314664415541-697721589413323834-515758622529230778629511889041549217333954367703552417477-87449488076115256607730087201848753486-791826700871607171392023070781433963457348366877321640952-303949132564988907165052298528417761298323510707194550374671607470464566480056783238092400219942299337771898097735-6218426627557843349-2142975147178256778297842119271503999385713212815202832323828387268151704065-19254712518070027655710838486732434529-1312661305193337751-38121431069173323337904110709232165900652677249264547734255925204982213198615590255469807305396-232847168952895043-6128270926062666841813627502981808093-8255568557670335926-3110406363332343134-5885884301849734180-17702799406753401991327143278253392019-2426301133938682948-17605455274075522996096886364394299575-9130031900143787567-3634511927604692285-2547487143021962340-77894130125660470041428113427913782253-8139139091374531323-8788292607868676777-3536551646188057639-5495793161182187571-4839495152964052892-1766875904516558259223092050874357732050241649474135257383798857740177320715310651746146655037-5099991733499811856380084100999441365-84795810900725735947480126719217394896-2646263051364931312-6553012701856755620-8148026740222166766-3877569293499869223-6740491435518123343-6843729515811553360483471999817582618110634294523412750265401167873245196411-3581858263665924974502581146052373343-5246314261841494417-6971485427664312224-2492181068180577426-6272770664104426303-3458436744370090110685073043780896537-2683429451122438016-80492147277249894492378868911304670439-3532658024982605066-480990759049690748249905294733503774578210355282521841931-5444233158795058188-43572083742123282438258327158363157783-16212486351755729301613999331611416448-6284912160447001145-5150004768672759937-35172559553004190039133129064392374691-1818347041014484598-8271036204017983677-8045810691566207509-25944656568100315584133539807507962803929830206370206044759003682818229339-81493537965891670395108318206660716665-78429075671085670592890694604298872771-7421062955816903248-648268335646231646122134470019866346982213438154152153033-2610806757536177900-2610811181487170285-7694039359625333515-6310197009568247227-6310197559852805815-2610833301242132210-3522019436007647199-542064694272627824-7694039374775523592-8474226909220024064-7309776704094514855-8111374297628993354821978319853532376563039625497418051316835015287969738065429176999834868582-7362205280966450237256170680221278981155935718221191645761110143800563465822-4858077158909826693-8492987856046367286-24100286959201428651688981508573441181-82869700787217278658976807282019227458-79221780915896233819021224226522360184855354868402289927-69146104409732824595910938465956068880-524144191079761359232497833882361565798713389432766028737183947079129660212-3699089071454493504111019698872830984253799976542656500817898661046773997236733538305730352048510802385169512846996581767030127137418-23446731408255419914321642933617249167-3521904517777048536-2610837725193124595-2610842149144116980-2610824453340147440-2610828877291139825-26108200293891550558555452417355842313-2610815605438162670-2938822436793690161-1232413468740098129-9135079840563352670-5482526698923264350719586268854206016364695106565051439962274313002832105037-8393787989959356178-16885366532351566091746975511865627126807542795537168648-58251264939399509481956047681886922091-6966748678664356642-765544592097642657660176597029632869011262160510426388191063250000745609258-15374094116155837777447791185555180580880402987961306462437014925523792103567000533931-3579456202732289597-3779119838565411588-405845017607979129-15374094112141334976549772774032517707741090651-4233624876059059156-15374094111526724274310261010366837201715910817277373200146520185885927710080952471030-69013897738554802707427764748909903712-15374094111104214100195089662-9220234114575190035-1537409411-150825315657793325349919140690584672693644357575455928124-6535210126130060382-229328096926335187510274868474111836867750854517315209896-3558641751975588251-5796475101255899363-1537409411-3485449558707374494-6126100305044383500-6921195816692303996-485890132876194054546972125016752544652216068939046397637-4444077357757053884-1976013693311229368-6485189872587605049-51196071390651657021321616104989027824285105495999192064873989177414327837106248401600938014307-6594546215945849701-4793353900940143512-6512460812219735434-53787222382010031384561613661007790229-6887381786951135966-2021877436425405534-3298085509848115667-4581009110180472282797058947044957574052936631845833001156947789976140211388-7714668484526488753880711270529188492-2708080657353942040-1410722059457395103-157084949046356119168459032928027751625939837956867378818519554173062751367424278191108217666875841360244493395880-392187327751438698863280246876434770871671793224851524891-1669610491412207910-1778780224350574478921985491080305686-60301691840832562573500480282633808460-1635371613213251644385508353664111379-2276897842253992548-875091218057005008453420783053029545746841353373555654079-88974720570347094031960525005642892228-10437746484191304546899747735441604015021977251994593724-6927344446959083812-296124874273086486231913519200555018595568768902497164670-1173678623890283459531927443983515257-5822033789854788956-12038502526192760318073618972548190059-3352750878535187145-8923540001637630438-43007052939834261545611524726921317207-6896431049687450580-4317934488736766973-5893873044751362001-7704705721171217913-179654088986104428772847863863115833983259891880731193657227512743134386866-6209193207895986590-9188556577077433606947004906043926540-1993350364200522510-7601158438451853174-11880320480377782533057920468480903929679534660323266005-5076917254627924371-82774216565313773258733551190231226107-3642660362367352889-8895871284016191026451841227937266037-52171793776686923385385943019454172803-8019814682953850220-73400584296079757985700573827528268674-8008864640877665075-159070591036284715384770914844941766738140414324908999250-6732028858017753634-88566507269653756057379297498523217449-620553260615532224443719295194668317073274229143885165688-6821530191601417588-4845417309374295134-628669444307311506185620041632768463883788060588556392641-697289421152423575851865240563483979-281452600067992742942808963382399254548691486668433783059-8747829503930845748-13827412628222951488767991288218703684-69781443842047776604004899083114571213-5227130954526229024747898033952934414761201275354845044574801444093347979140-3678437330460054427-4148559062256021758-4237219235271458093-168473074510757286-659271926917205019636347453833172549865154280816800775607-41531062974532319966429828000074114128-3388326981144860420-8599070869747511209-7448382840285831214317624449719434507-27295576798532137583123043034583868878-3072007095577827836-17343721949275777985617715699747851229-880437068909804437176245946867637347-5523131355790754927-78215793087070780605973679503586010121-8863922592000846073-8769934260625884356-2238521267636661896-82995323303543915641896634071301160377-73185414543211487315930234355809213754-8465659224464651733465087384821758926912609512671765986538226751086458439862-1871846634724778953-850426356249233010-13927735727023258146757046620311369105240928741220550420928005600007905172004251102373809107317-92457443041935505295895586400367087-4630054062605564114-3059819806956708943-1537409411-367651417536274514652978464690012906491570271255273625290-90508664226033576046541374480621629046-1537409411-8495077373402898375-7158351082335208479-1537409411-779555999714973585-3803898622829410383-6253402244944497348-58482862531945420982752647107835212628-1650750338012684784-7405417351542802688-4196715802433962758883516146679463748128261779232741037663600975661636535417-6409119042869162750-2331876988663372174-48901896218876547258607564926471855562822936233212702306652761779294653713346067273396248792443-8460245407341213094-8784977012973368003255457605804662363-1821098838944477813817413682076660702419096326314421075694401153039050997490606727339591324811852761779294652894092283807083293135489-1821098838944457328255457605804703328-8460245407341218219-878497701163119071819096326314421485348174136820766607014-4769125909986744838-7089411941337306861-1482278719767534408-13879718724105986978500498416650184647-4730396681227033416-34666060187450514265782004295749229887592534963366664913733668326896137017187546082815954945665-7728251334121590463776152710382900280333370530391011912417370354282556040507-28057986324603352825733148137726783808-647913010554090743745268656733795945657034953454014679118-7994178997434863040-52405420766156640483280832349823300162-31924158696330469271652425007508807513-7092128994452957331-10117687892159397196628703684387339185-978924658430755964-6814424480501123310-428500297394963693753680732731535994865061922473371401594-775219604413685410635197989192209018173279903404400494775324020955351607823609094715711074677-6420595460832702265-81705260889416332097979883999726146511-7658332669860033457-7527786287270510380787146444951694907624103136369554518655238289236063704153-5778029752892243500-1280964652117995692-9051092036890502186180914886264953531826457492904018005142043189999572686062-13732344322756171044335158747632751988-1187337684368004705-3764858474401804361-82116294091253688621580898021197091384527658396219463332-1818789359085383238-7949714289438322898-485249666756225191464386970575961917155889211618073531318-1537409411-9705690220589269214894475122324269683-1134802210541538244-6981328987040365716-3761028139933987244599610089539580712-2335175417995500276-7825050461549711416-4190327535115935436-5224225365818131410-695310636263247159937783147299798738289267060533725875976610885368846609149-1145725280989078071-8331088544884050051-47073307720292397997482902163776257269-51543058188856340017630987525852641074553871026313709650869619230614339331493993821553587047365-8784910000677868388-42394731512372507823033071542972004757-8906932480921727047-21342637900629975501767597606508428790-6297180371633691519-2435692012266303023-81157518549531440771124877710314046893-2185874182097205458-2493809555682829118723530668948626402312825230460559288331066760166897520798-85401125260060689331374695540483144458-22780466765244210833190716878713886697328288937314110232229749539995554786626276504865909496445658444023949512010532703582412105962735620341621538218831-60264547054174536153388909567958875526-3681831097160434328-3825673016599373018-362038276754229057847910017371247864726492267745067904480-6383333960957439677-505207853501188168-38931055807486979291783505921171904038-1117833916971200837-710678880438284705848960986276193744326334622409326022540329204699559799870138052726182407048013651651794195345426-37869279876550222884957546957237518182475225670818043574290594145668374470524214750079921792109-77499385959976405786120311778853240688-4417989449255371425377831472997987382435710440331184744-6368823670957377827679496471087770455-80770474512936943894445027262682731084-4941421946963987101-194720502399117992719888456442691776595627137871089238366226579386925720408530846831014965430718084334424535979078146306076646178546321662421663083303375431591389028275282-2749938126786598549-4138688844168568479-522747398434249721848244047682938197443565155604958783054885414626564913748829448263756839378631084166433269544550242989290628210248-956425109723390313-2252140799583057280-80737601256801804816150487541201987838419511270404986154459409472819923382435558760739261283116-612302088774376839341644041463963408634081368468737051325681727140279122642-2475939619058811992-42258036252217919726202195774299064068207590181924755594-3248139340991688318-61596041144185443583335988715141230219-1396431592173809361-7629794126152141378-20493206733217627727087227858069801285-956054997040117908-8031520077650822904948861400660369852-25376367290126234646258739680571891916-51211463866599433229084102088106898188197512632790680259-3132144599918905887-6349868605803841123-294336752141612712386187687392667880951788968703341843580-365672157178991430639828274884758080156893070955585607512577460713172325752-242057754228751994962455446241351541942851851314011213384-1815539201523113347-5440571645688278963-84280052588953959723450816954283867668863942548652000572189240974340584555177486074495789338887249241495753847910-2475939619058811947-1121670015686922814-8312572403905222273-3057990127772671874-4760663122245964105898304023302542698-25376367397500417091444580081107484972-81964178377097427728859023305497089540-4700079979463845974-2922752271709623641-622766075745936341-7629794126152141353-383275316815624095-3560599915257403304834995625705456424521357289150235939178238030736751008143880278428263086739-422360132388858314-35643138251131329824286108716968703249-5638518492402163506-1210458290321899040-4317784823175390936197512634132857544-146396473886458636866095342403302349593702366119596222270-542699011557158948135309001640809287284202563305331138122783755365303432833-7727153335992152264-5147636565884801150234923782235186148771838776343510838427388705766054149557-5251102098307496386689307095558560776-8268432357580995279-8242415928239843003-383275316815624095768579975401281857-49292671792139049328377855220943777643-433589210379710431383781651793674137206517715242925410729-1385587311556693283-62560646674672679616739506027368347365-6631847261576796971-4819967658118989137-232236568116642575457134080565997708776244422481184492783-5349335554349965019-793789065559052559286452801125796420687134260618390311564-63753977149370812418887196445534816291-20062022828119874698781747288799986714-79378906552549812677134260623759020689-12481407919191348118645280109895287503-5715938921756588203-453826424638266473931141660782921230679149486959577439271793318455059610473861486619584928949811270809287876861343785399047269400097-6827640233400367351-803548438005299195654670574257348150655303976015542186802-7329035232613196696-652921852511752981443735454979812234636488742889849078382-27515224415587985525303976015877731127-8853827456403007628-7329035235297551261-4899542165720367545677201468636457042-8718637113309757071616748972592429731761779114499820525872454438601534579496-414753801771366765-47761256332218572616112510257972573286-56506370599155184821075507973400796189-527697267655882601213817212841006084794432873544769820729-3463398475174406645363457827493890105-377380452828307662-3576712009430851538-28751945045309080297676473101380465256-2046290019668225379-2044847011721766957-2586747201859103924496045819375785809-2834409725670062551556778747359356958-556142774201423509075137505798447849313077890917403635090-1934455437485110875692159179162814988580134672606633490636741683406090929104695648167124305420-2613936363181450758636891760207466969173335216756648208183101770413255601284-8747694897020393319-9044045487838555760896493232373482113-468168173449263395841980199264015086775204398177347571604-9079423103187971832-7914365130613526057-2161305099059717292-6881507665145303421125465987847273358934136075210837350933049929642648430674-6086182942847453352-79151382290148458356008141613074661144-8539093572240009966-1471377448348504661115138708192653618872701121801659062467813391160768779693309006681396163437-8176887294210299528-3187414774956826235-14097729885598808965981941226029992265-4210367345068762426-2005289398849250087-676211606060863145781468850420823335944281173655498665400-5182002791343488684-4194705972447136740-3087479124259976392-316862878396732553-1136163601765758374-3394435455270461177-8753763127249139155-11139204834187901-8902501216086666906-518315659964919314025096356924677422279855117440019763786894422349044473807-36951272019531002037287544762683465481-5169250964253841592-895069337183609468649720969796310265987246435784668698021-459542983181964665617782749238038358011805798600681899613-174529502478264952046748174294343777933198188370418870922-3892074700216424717-50107783746536494677632735796393743205-9184590275627758538-1933604428369329255-2132431483438464960-4097893930779672652-8317667152951061421-8212891282038274847-177981802027109634760669590734648473342433508380788769877-60573679895741308867311023945053348411-7067143704493272960-544389227494426691061563134373995685056377030719274067120-5898058651976115520-659559807688989539816657332197579667695575505883293818809-1802668167165076527-8491105828757425142-3341232965002024060-25822137990489100341011050961120084925-8577410666130197131-176530929071345311833822812235273495061105355693358873102-62843760032514585464133339305079997843-53781778847673809775710378855343154874-661284435205144056092070049297286619312942924024171453781130346421586413440777032975222720752657914825941018893214-339624676403354735131580606116742358403274716637676675931-45426619553725244183593526948187400416-7877796003287710063-84742623437248225562408252047810758816-52940718149050335692835329850097754668-270961683254164430410624132812476947695307487593622156123-9064801347735411090-25359223904984151891525240527319828837-75790594034630166034604076767023126228-274995838780632132225918181117081134951821327664221711191-8837035345947275893-7414344868247230091-6165225340869716025-3078878278168535299-5829871064434219095-307348737599347256-2053078631430210142-225792610789366642-3789191180834355794-4468664412698789925-6229389359367994440-5460644930889091694-1820226575366482416-5573366829382614831-26265617814103096765933289971719634064960709126412218700-6205603455155531845-4243704448529556532823810542351631234382581734847029032483940238870328980430-5522260092838658363-171706353693440383280382597315432398624576440848861309251-644522185878028136839464769835835238765575505987278203309-82056129026594002436679239721899280307250153808669790427-280826729832133390112968069048073409683438361088646894565-72957878487359753863923198511947394696-1503842792422343715561061114868528351890331319288134335297468858970196430091-42262585803711774485767184731584216991-7599115033518445073-100781923161547993249353132049547197142307127630215586469-501902008888689262349394948191629446786379528637582071411217583037964858282160217696816962918706423003791250816757-3223371535339445124-3127135808500121966-2901994304945086137-49885317861984911119964001945432188957683605686430710402-401693023802682824931662634035034969733546218473837268331530000919095425544187002701608283592813443945910834607110-1091048355475292934045701469602030601430815936674340509157590955782073770374110190893232214876522525865532224748-4852523154984809169-70718095985075663798812948801769003369-1526638894741725860646502009357437980-4726768779329668485095151908418333511-19957731731786434874474910567404422694-689550462957005544614214623266641433387652590408139119650-31873746830631747602217329615139190510520417320871753470-8527897472928073793-3596554501154075776-35176863685813184556615201382845956654658619235282262685-4388364184419427017-2468094558179903037-2222634759248221485-2918033024608143503-1546085490897988135-512167485709632371834740260997164482671795508156564397824-5051274922166090834-33450118452945996614312735637225355000-345150458064632478568239690213948552-70986664510769432286317154337942495606-848742215927515011460975615218769663-6730167001796923238-52820576065816381383947262113824803323-2661182248811255-3357994968678479832-5118389374596138463699918911829966200588144810616297866443916804426418544366-73388165254640875281096274672067789202-59841872266865015071575880651673303024-896626634567202629-3973824334111789408802067695056816302054735445092431823136865285427666359493-58023804727241052996905402070429354265-4375252574367817516-7243298822642518815-2125159013359710027-53868273159179049302974706781241914372-41232474418348581034794452273715899114-4080242544842497134223246842837994459-6598188437199621734551763076811897001534398395038838103604404453172856958641-2034645283838495439-4652948815102249686-5176707467742265740-6135278762527379555-43423786945530220717569248098286910076026532733943712448-4021675831347664061-13839456383449038271470231095469740733-7866905609764197711-91616324642387145961374059894507911026-843650296309480433-425458504850825433035923854340590905711753982806121238429-875626975566018339-665211930601524861944285080249618423495335111311786529427799120313719412607384631423553090401891661101987104498525-80435943350704115653572356738018736412-55190792299225417906641485388936134993371132862139756772-6597971659485448829-7707122014974671293-3645867622584752785-7134241574121196420-2750253996811258012-5845365503403519309-2052146672475430252-241796785347409151940461284661010632526383876467937572076-72719328047699969972996472598591174885-5270358078237845207512951553471418128035849202237582338-3219947368750667218015015702331902723730364443820219796-820120563086724428-5192094348209241803-7679870751370372887822882412461032357-1193758241417328907-827265738065949982731070551188017139817207598114930752004-65665056297987556492643098470856715155-3901191875636154323-563175023983409593033244776600119796809124201921753198390-12052297130013134911445197854128460850-2404005507926423982-8526255095563922897-2558919304214119491-4790908473848786039-74353138092654979482060572321262579390801955882184071624110572745229591562811689194277922849530960401121724495008-6679344303880571062-69293431181876308116875574267534953938651848514302618946841996244989316117-3956555483215890724540317690786904390521047415104595233067190950934814655868684935571550876445420051627479834549811656316175947979625-2043870489941177598-49878168745422204447994366859931621607081315117216444188-2174127200218033291-8681676996500633881-79639551360701324961952855078270405763-2589184750142578204-1537409411-3035477635310127076-716951303932484775056954956395986790683903097868117163587-4519820537800878267-693019694717118091-6668692085959600120-203178043555181225936387624137854042967269788246008030306552533537581554877829517627928420650608048567440939591080-7181705399910920922252593239774917110346460618519637325684772084111459909480-321170690730928265233086298613266812027923646027654729229339597383312226546-3333421213018531033-4965454008996699967-8771705147701039074-8359060660060040481-66582308094961628086206444236462440448-45414564067952741731325210071875284950-749815479753010241081401073019888076376098222197872335419-8333354272496132890329147268100519028730442467355015070423660931726177763061-8541036952435566581-2810577045155306996-44775908345559123197178482531175756451-4515636939078405400-391660361426691452745440803528003896584831748321654586557-155730802064394239-4437108634226049062-7364796349800781112409196580649229644378219470684076932645187174352346844524-735859197586315367529344388400528376417048404091358947001-57573038881269907081856579905749732736-1274552137397719970-2635897709557671302-8207637926964430386-6910086239979666778-4023697285195740710-14068595500198817456446233607014977936318094160934690100827332778144071102706737669181012320720-7037750656072528177-578286472053220904-281830666861335077729575832338164718973771450323180139292-396714161266657804488075006803690842135628485765468962081-36694966746658019427264945448351093968-366949663996920597270840963830029229592264561337840701328577401385408061494627293754984809470503735068288016002587-39825312560684878022666527073941464152-75913553740139191390805442600750473746637162286404733808-52130613266928507306286899842312301210668486698384133737341304272909762284067981725187593061929-5683952608406310634-8839386949466998240-6222141508998867018-5626844914698326118874608548703478555687278944607785682112618376864683137907-8821195923210780895291080598650767429335483149885745109017908961134613086504-1413650404075128766102754681439619868-2884612169130874665-3674782572556734428-458132337884983856-8570464418427644132-78302193659170985927857945461549236257-3252440553084189214-5234075855590945825-5038863812503903654-825379320759257024160729412188425723386655053521244289843-577177557815291680-3394546762668311010-6255877529041816426-8552273392171426787-57046391255864525964198765959890670289-37111646077208711333073954286494461351-2999649891948001958451417533655920859445258395048994483507194024328511519888-7237578662108811328-22233746569579659827826953789954043373098668302056050266430889140571265618-570464094513264787157817612480277920644508037899125166490567226248658030351581102104055897681297013001442972983123-159424347215952779139061564737404763598278268965405706928-22233659828089734-7237579234602644833719402403359045414314345202476004145508550156463554200665-7670381267339215927-34950137307578034417667367618245775893-23301048162657227435188066065624043467-296670439362138203143732943502749703233456915979151267833-1001266383669959208-8895167797984724402-7438359144146465571-530332696065380335733447866281245344884314185392486779726-173839930974223364981011921176220141336448595910967229658-5632287036852893840-2280237633043641692-2303711855119035847-8752795494251161142154756135608944138-180402517796697351724109251737220524727396622028415579550-3333825881623888501-6158548229838823896-176863822700069263931019793963095407612812254686513093246-15592275373005412768762332745831003473-2611233374601175613196905969243398129-2482431331295635842-292792441461375510323997672304946084601598600439644182823153137560261980289-59183229682195317936818621609795822525-3884465495851147321884288524079621069-1366544142676916416710546103673867753583385357569255388822331373111673037669-6658230809496162798-17014683408699008435965864940979985448-40299608227823787573189319794986921620455774679055211334745998119014430028813166056298299613310-7571657719168808752-75345797814504881862625681161785027816-870595183713620388554320186934733431743186078393418545313-8359060660060041766-8771705147701039064-2515189526871677385852066050016478325133959737794351742147720841114612202058048567440939509155-71817053999110028473014744856580499527-646909495897373320772697882460080303914544752299633384974-4866277730678672981-23521490071737288-6668692086295144445-20317804355518173843638762415127581581-4313722248467368635-1518852177289516928-693019694717118076-4519820537800873142-2526980938240737877-693206641796218522-73647963498001257477821947068407692619-443710863389050473745440803528003896684831748321655897282-8201685006476504368-3916603614266914512-4515636939078404115-73935556522994475372224671552417733441-2810577045155306981-44775908372402668847178482531175756366-7429189352617188988-854103695243556662630442467355015063973660931726009990896-13788855565719377628296296424379741556736064233297153537032914726810051909326098222197872355904-8333354272496131605-749815479753014337581401073019874969121325210071875286235843482721239717366173966220284155798756350798284581906381996655276010968592410925173722134397-4127127390574901813-1804025177966973842-2465970604508704089-2303711855119035682154756135608942853-87527954942511611328608676348624137008881214332146714996-298577389795978414293333940427718732987567477470556089635796989219167853995770549675997330466-1358979662825235698-370422568353326600280662634064100490868307973939553292195-30462347467413298826771879507365573776-8636065996644550998-4845297310004774885218008606068247614-8500695516163834343-29018430241331847671177805804815435830-342730347896704140528096930365830691828142738091074011380-8789246303259861697-1763920391147123947-3520095705333537674-151748765064788558167132976652127145057722215138570448222-3281537431820122565-86019702557733461048799338991376374081-76888745966259430386771872737040863882-5911203831163099997-4241286257166168436-1150503864732357606-54475669854943318282243660330286555998-7190073336464191253-5192054309786832590-1030606986822531793-18602196883088440447667584264502437230-68944198386575130251655202644936269836-83996128211006595783422673402514364495-3704194404602394948-4043920680767265844-7972304014786459250-1750048072274500217-8010387545547281558-80626297827729978291610896181350727305-2902245842709360599-6910086239979011413-8207637926964430551-1406859550019881420-402369728519574070078963101924597345921856579895012314491-1274552137397883815-8395908726055591217-5757303888126990718-81262763588412788372934438840052836996-2269763192408375159-1322906815574988758-1899598815819581511-3613551578840303615-13665441426769189817105461036738677620833853575692557984788428851334220282468186216097958225503153137560261980264-29279244146137551282399767230494611025159860043964420847-5429152979531151567-10152453412935454609147264332990683764-668205655209802023933591523673204820573196905966559043564-5351712480984760014-1559227537300541301-65064994797568522773101979394967363476-1768638227000364954-6158548229838741971-333382588162356081690147477349190448602370868137322018653-4308511061972951649-39485602252794169411894913028716146601-4234365309529005425-12754550377702665932981732647476320273-2772664111971231387-11832434492405352935124313439651929945-934997462888135672-9153626765835372870-6772898769325482882-67728987693254827973416543102569682170101489320456090594-76043780718458862899109157866543429965-2156027579191978857-1562594467463247754800141154114149475710141277570898054821045846196603043984239140747015687901-1562594467421304709-8383746017562828375-4119126103250018292-117204309409675209010141277570898054926658771200183610357-2145611482641453591-1158115551130621505-5991730688344042860852760880167121304643353260287852806241526256009195104154-1755353452106518065-2599832437534605478-794876788577275190-5971026171258739653-5327170609472977757-5675025583111566064-5581480874635254359-5581480874635254034-7418484590630376829-153808055814528950487311550759109157866543427400394248223584578040672731565614074625677913778005744615737913999629415834981251968229907378204-1537409411";
 			};
 			name = Debug;
 		};
-		BC_483137769241 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_511860608467 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
-				PRODUCT_NAME = UnitTestsWithHost;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_557631990268 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-fobjc-arc-exceptions",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
-					"-fmodule-name=PINCache_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_562292461304 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
-				PRODUCT_NAME = UnitTests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_565473548049 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
-		BC_591136155966 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				OTHER_CFLAGS = "";
-				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_592196569038 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/",
-					"-fmodule-name=PINOperation_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_596532546965 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
-					"-fmodule-name=PINCache_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_636128561523 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_642205841780 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/",
-					"-fmodule-name=PINOperation_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_673694054335 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-framework",
-					XCTest,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-					"-framework",
-					SystemConfiguration,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreText,
-					"-framework",
-					SafariServices,
-					"-weak_framework",
-					UIKit,
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
-				PRODUCT_NAME = UnitTests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_677531963685 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				OTHER_CFLAGS = "";
-				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_677815231989 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_680184608082 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_691299199769 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
-					"-fmodule-name=PINCache_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_706866179120 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/ShareExtension/ShareExtension-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-sectcreate",
-					__TEXT,
-					__entitlements,
-					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-share-extension_entitlements.entitlements",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.ShareExtension;
-				PRODUCT_NAME = "share-extension";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_719580982558 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_738764295197 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_749074985102 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					CoreLocation,
-					"-framework",
-					AudioToolbox,
-					"-framework",
-					Security,
-					"-framework",
-					UIKit,
-					"-framework",
-					CoreGraphics,
-					"-framework",
-					QuartzCore,
-					"-framework",
-					Foundation,
-					"-framework",
-					CoreImage,
-					"-framework",
-					Intents,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_765449506078 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/SiriExtension-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-sectcreate",
-					__TEXT,
-					__entitlements,
-					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-siri-extension_entitlements.entitlements",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.SiriExtension;
-				PRODUCT_NAME = "siri-extension";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_768025783147 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_801060526314 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/Localization/Base.lproj/AppIntentVocabulary.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_807439532077 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
-		BC_823899891620 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		BC_824394874758 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-Wno-everything",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/",
-					"-fmodule-name=Stripe_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-					"-framework",
-					Security,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreLocation,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-					"-framework",
-					Security,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreLocation,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_831395347628 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
-					"-fmodule-name=PINCache_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-					"-weak_framework",
-					UIKit,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_832986511068 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/StringsExtension/Resources/StringsExtension-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-				);
-				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-ObjC",
-					"-sectcreate",
-					__TEXT,
-					__entitlements,
-					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-strings-extension_entitlements.entitlements",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.StringsExtension;
-				PRODUCT_NAME = "strings-extension";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_834161284878 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-Wno-everything",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/",
-					"-fmodule-name=Stripe_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-					"-framework",
-					Security,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreLocation,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-					"-framework",
-					Security,
-					"-framework",
-					WebKit,
-					"-framework",
-					PassKit,
-					"-framework",
-					Contacts,
-					"-framework",
-					CoreLocation,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_859592500837 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"-D_FORTIFY_SOURCE=1",
-					"-Wnon-modular-include-in-framework-module",
-					"-g",
-					"-stdlib=libc++",
-					"-DCOCOAPODS=1",
-					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
-					"-fdiagnostics-show-note-include-stack",
-					"-fno-common",
-					"-fembed-bitcode-marker",
-					"-fmessage-length=0",
-					"-fpascal-strings",
-					"-fstrict-aliasing",
-					"-Wno-error=nonportable-include-path",
-					"-DPOD_CONFIGURATION_RELEASE=0",
-					"-I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/",
-					"-fmodule-name=PINOperation_pod_module",
-				);
-				OTHER_LDFLAGS = (
-					"-framework",
-					Foundation,
-				);
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
-					"-framework",
-					Foundation,
-				);
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_865748433585 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
-				HEADER_SEARCH_PATHS = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_881114754245 /* Release */ = {
+		BC_542888429264 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -6944,7 +7092,757 @@
 			};
 			name = Release;
 		};
-		BC_886049552216 /* Debug */ = {
+		BC_544716700791 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"-DEXAMPLE_DEF=1",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_562754960482 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_570780211329 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		BC_578204247302 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wno-everything",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/",
+					"-fmodule-name=Stripe_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-framework",
+					Security,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					CoreLocation,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_590325174063 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
+				PRODUCT_NAME = UnitTestsWithHost;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_604006001917 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_614578264696 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/ShareExtension/ShareExtension-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-sectcreate",
+					__TEXT,
+					__entitlements,
+					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-share-extension_entitlements.entitlements",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.ShareExtension;
+				PRODUCT_NAME = "share-extension";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_615410118998 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_616279119361 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/SiriExtension-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-sectcreate",
+					__TEXT,
+					__entitlements,
+					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-siri-extension_entitlements.entitlements",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.SiriExtension;
+				PRODUCT_NAME = "siri-extension";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_628089537676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/StringsExtension/Resources/StringsExtension-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = "-ObjC";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-sectcreate",
+					__TEXT,
+					__entitlements,
+					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-strings-extension_entitlements.entitlements",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.StringsExtension;
+				PRODUCT_NAME = "strings-extension";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_647778033313 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/UrlGet/UrlGet-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"-DEXAMPLE_DEF=1",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+					"-sectcreate",
+					__TEXT,
+					__entitlements,
+					"$(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet;
+				PRODUCT_NAME = "ios-app";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_703073852495 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -6964,7 +7862,7 @@
 					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
 					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
@@ -6996,67 +7894,23 @@
 					Foundation,
 				);
 				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
 			name = Debug;
 		};
-		BC_909014643424 /* Debug */ = {
+		BC_708881499625 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_221764191289 /* Diags.xcconfig */;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
-				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
-					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
-					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
-					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
-					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
-					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
-					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
-				);
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-D_FORTIFY_SOURCE=1",
-					"-DEXAMPLE_DEF=1",
-				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
 			};
 			name = Debug;
 		};
-		BC_912478558951 /* Debug */ = {
+		BC_714611442171 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGNING_REQUIRED = NO;
@@ -7076,289 +7930,910 @@
 			};
 			name = Debug;
 		};
+		BC_723893922217 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/Localization/Base.lproj/AppIntentVocabulary.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_725150166710 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_738497845442 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
+				PRODUCT_NAME = UITests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_738554161130 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_740356170332 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/",
+					"-fmodule-name=PINCache_pod_module",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+					"-weak_framework",
+					UIKit,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_780283628198 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_800755484696 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HEADER_SEARCH_PATHS = "";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_838777390423 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-D_FORTIFY_SOURCE=1",
+					"-Wnon-modular-include-in-framework-module",
+					"-g",
+					"-stdlib=libc++",
+					"-DCOCOAPODS=1",
+					"-DOBJC_OLD_DISPATCH_PROTOTYPES=0",
+					"-fdiagnostics-show-note-include-stack",
+					"-fno-common",
+					"-fembed-bitcode-marker",
+					"-fmessage-length=0",
+					"-fpascal-strings",
+					"-fstrict-aliasing",
+					"-Wno-error=nonportable-include-path",
+					"-DPOD_CONFIGURATION_RELEASE=0",
+					"-I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/",
+					"-fmodule-name=PINOperation_pod_module",
+				);
+				OTHER_LDFLAGS = (
+					"-framework",
+					Foundation,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-framework",
+					Foundation,
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_843043525341 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "";
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/Localization/Base.lproj/AppIntentVocabulary.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_871425410041 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_116888961223 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map",
+					"$(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map",
+					"$(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map",
+					"$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map",
+					"$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map",
+					"$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public",
+					"$(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map",
+				);
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+					"$(inherited)",
+					"-D_FORTIFY_SOURCE=1",
+				);
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"-ObjC",
+					"-framework",
+					XCTest,
+					"-framework",
+					CoreGraphics,
+					"-framework",
+					CoreLocation,
+					"-framework",
+					AudioToolbox,
+					"-framework",
+					Security,
+					"-framework",
+					UIKit,
+					"-framework",
+					QuartzCore,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreImage,
+					"-framework",
+					Intents,
+					"-framework",
+					CoreText,
+					"-framework",
+					SafariServices,
+					"-framework",
+					WebKit,
+					"-framework",
+					PassKit,
+					"-framework",
+					Contacts,
+					"-framework",
+					SystemConfiguration,
+					"-weak_framework",
+					UIKit,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
+				PRODUCT_NAME = UnitTestsWithHost;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		CL_100178272237 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */ = {
+		CL_107066082523 /* Build configuration list for PBXNativeTarget "strings-extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_823899891620 /* Debug */,
-				BC_229340051279 /* Release */,
+				BC_628089537676 /* Debug */,
+				BC_411167911201 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_173102942353 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */ = {
+		CL_131920372131 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_295513606904 /* Debug */,
-				BC_565473548049 /* Release */,
+				BC_505114290744 /* Debug */,
+				BC_415215904150 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_175704718595 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-9.0" */ = {
+		CL_162101825678 /* Build configuration list for PBXNativeTarget "UnitTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_214672727881 /* Debug */,
-				BC_749074985102 /* Release */,
+				BC_187820785568 /* Debug */,
+				BC_331640760912 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_179453799913 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */ = {
+		CL_196725857447 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_366749234220 /* Debug */,
-				BC_677531963685 /* Release */,
+				BC_474929246975 /* Debug */,
+				BC_615410118998 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_183987345262 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */ = {
+		CL_205363634933 /* Build configuration list for PBXNativeTarget "share-extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_390353555046 /* Debug */,
-				BC_807439532077 /* Release */,
+				BC_307868647969 /* Debug */,
+				BC_614578264696 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_196722873933 /* Build configuration list for PBXNativeTarget "Stripe-ios-11.3" */ = {
+		CL_232037670091 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_117628839605 /* Debug */,
-				BC_834161284878 /* Release */,
+				BC_420944243807 /* Debug */,
+				BC_503124594100 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_243789410170 /* Build configuration list for PBXNativeTarget "share-extension" */ = {
+		CL_287747118355 /* Build configuration list for PBXNativeTarget "siri-extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_149169485958 /* Debug */,
-				BC_706866179120 /* Release */,
+				BC_616279119361 /* Debug */,
+				BC_374707413770 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_253406074136 /* Build configuration list for PBXNativeTarget "siri-ext-bin" */ = {
+		CL_321038524600 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_458231144637 /* Debug */,
-				BC_801060526314 /* Release */,
+				BC_320506846780 /* Debug */,
+				BC_604006001917 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_314191844776 /* Build configuration list for PBXNativeTarget "UnitTests" */ = {
+		CL_394586624846 /* Build configuration list for PBXNativeTarget "UnitTestsWithHost" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_673694054335 /* Debug */,
-				BC_562292461304 /* Release */,
+				BC_590325174063 /* Debug */,
+				BC_871425410041 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_361814418977 /* Build configuration list for PBXNativeTarget "siri-extension" */ = {
+		CL_419288162904 /* Build configuration list for PBXProject "UrlGet" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_314576148233 /* Debug */,
-				BC_765449506078 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_443002457585 /* Build configuration list for PBXNativeTarget "ios-app" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_252483423678 /* Debug */,
-				BC_304579797559 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_460131545307 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-11.3" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_463601024211 /* Debug */,
-				BC_677815231989 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_479390457595 /* Build configuration list for PBXProject "UrlGet" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_479945831424 /* Debug */,
-				BC_881114754245 /* Release */,
+				BC_528827945251 /* Debug */,
+				BC_542888429264 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		CL_515018785028 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-11.3" */ = {
+		CL_424996891355 /* Build configuration list for PBXNativeTarget "share-extension-Bazel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_236990032397 /* Debug */,
-				BC_183684992585 /* Release */,
+				BC_714611442171 /* Debug */,
+				BC_444205486961 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_524308052075 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-9.0" */ = {
+		CL_466327725618 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_367276398481 /* Debug */,
-				BC_178002298339 /* Release */,
+				BC_740356170332 /* Debug */,
+				BC_738554161130 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_540393113192 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-9.0" */ = {
+		CL_535582595715 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_156313484114 /* Debug */,
-				BC_557631990268 /* Release */,
+				BC_414927924888 /* Debug */,
+				BC_430286168504 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_583546727827 /* Build configuration list for PBXNativeTarget "UnitTestsWithHost" */ = {
+		CL_575785382123 /* Build configuration list for PBXNativeTarget "PINOperation-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_511860608467 /* Debug */,
-				BC_264099224458 /* Release */,
+				BC_703073852495 /* Debug */,
+				BC_120071755999 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_593532437987 /* Build configuration list for PBXNativeTarget "share-extension-Bazel" */ = {
+		CL_576098273475 /* Build configuration list for PBXNativeTarget "siri-ext-bin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_912478558951 /* Debug */,
-				BC_591136155966 /* Release */,
+				BC_723893922217 /* Debug */,
+				BC_843043525341 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_637944311431 /* Build configuration list for PBXNativeTarget "ios-ext-bin" */ = {
+		CL_629454187867 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_112067615371 /* Debug */,
-				BC_224177172233 /* Release */,
+				BC_708881499625 /* Debug */,
+				BC_182938313366 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_686972168627 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-9.0" */ = {
+		CL_655977824079 /* Build configuration list for PBXNativeTarget "ios-ext-bin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_388852820408 /* Debug */,
-				BC_691299199769 /* Release */,
+				BC_780283628198 /* Debug */,
+				BC_294046083723 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_707080851040 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-11.3" */ = {
+		CL_656630461598 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_865748433585 /* Debug */,
-				BC_417518959352 /* Release */,
+				BC_498780084379 /* Debug */,
+				BC_179897240653 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_745612128133 /* Build configuration list for PBXNativeTarget "strings-ext-bin" */ = {
+		CL_664069285608 /* Build configuration list for PBXNativeTarget "Stripe-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_738764295197 /* Debug */,
-				BC_680184608082 /* Release */,
+				BC_329180532788 /* Debug */,
+				BC_146866809537 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_756408111234 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-9.0" */ = {
+		CL_677790726659 /* Build configuration list for PBXNativeTarget "PINOperation-ios-9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_483137769241 /* Debug */,
-				BC_768025783147 /* Release */,
+				BC_838777390423 /* Debug */,
+				BC_137888055975 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_764575073058 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-11.3" */ = {
+		CL_700633204216 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_636128561523 /* Debug */,
-				BC_719580982558 /* Release */,
+				BC_110955225260 /* Debug */,
+				BC_800755484696 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_776001027518 /* Build configuration list for PBXNativeTarget "PINOperation-ios-9.0" */ = {
+		CL_757956135481 /* Build configuration list for PBXNativeTarget "ios-app" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_592196569038 /* Debug */,
-				BC_642205841780 /* Release */,
+				BC_416404307328 /* Debug */,
+				BC_647778033313 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_805275538402 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-11.3" */ = {
+		CL_767805223807 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_596532546965 /* Debug */,
-				BC_831395347628 /* Release */,
+				BC_176349865012 /* Debug */,
+				BC_515041536280 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_813294530495 /* Build configuration list for PBXNativeTarget "Stripe-ios-9.0" */ = {
+		CL_818473893886 /* Build configuration list for PBXNativeTarget "ios-app-bin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_176726248110 /* Debug */,
-				BC_824394874758 /* Release */,
+				BC_278368275167 /* Debug */,
+				BC_544716700791 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_832542114231 /* Build configuration list for PBXNativeTarget "PINOperation-ios-11.3" */ = {
+		CL_842212741120 /* Build configuration list for PBXNativeTarget "strings-ext-bin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_886049552216 /* Debug */,
-				BC_859592500837 /* Release */,
+				BC_312013187446 /* Debug */,
+				BC_725150166710 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_870129501381 /* Build configuration list for PBXNativeTarget "UITests" */ = {
+		CL_844946125614 /* Build configuration list for PBXNativeTarget "Stripe-ios-9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_222888624732 /* Debug */,
-				BC_430395197856 /* Release */,
+				BC_578204247302 /* Debug */,
+				BC_392949935540 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_875549008649 /* Build configuration list for PBXNativeTarget "ios-app-bin" */ = {
+		CL_855762236329 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_909014643424 /* Debug */,
-				BC_219739276036 /* Release */,
+				BC_195530817446 /* Debug */,
+				BC_138088792074 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_910389829219 /* Build configuration list for PBXNativeTarget "strings-extension" */ = {
+		CL_863786754985 /* Build configuration list for PBXNativeTarget "UITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_422821497100 /* Debug */,
-				BC_832986511068 /* Release */,
+				BC_220004231922 /* Debug */,
+				BC_738497845442 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_879714440108 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_570780211329 /* Debug */,
+				BC_221139496326 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_903718557818 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-9.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_405912307535 /* Debug */,
+				BC_468059036733 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_906505729587 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-12.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_562754960482 /* Debug */,
+				BC_105681971110 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = P_4793904575952 /* Project object */;
+	rootObject = P_4192881629041 /* Project object */;
 }

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests-Bazel.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests-Bazel.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_183987345262"
+               BlueprintIdentifier = "LT_629454187867"
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_183987345262"
+               BlueprintIdentifier = "LT_629454187867"
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_173102942353"
+               BlueprintIdentifier = "LT_879714440108"
                BuildableName = "GeneratedFiles"
                BlueprintName = "GeneratedFiles"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -42,7 +42,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_100178272237"
+               BlueprintIdentifier = "LT_535582595715"
                BuildableName = "ResetLLDBInit"
                BlueprintName = "ResetLLDBInit"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -56,7 +56,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_443002457585"
+               BlueprintIdentifier = "NT_757956135481"
                BuildableName = "ios-app.app"
                BlueprintName = "ios-app"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -70,7 +70,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_870129501381"
+               BlueprintIdentifier = "NT_863786754985"
                BuildableName = "UITests.xctest"
                BlueprintName = "UITests"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -88,7 +88,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_870129501381"
+               BlueprintIdentifier = "NT_863786754985"
                BuildableName = "UITests.xctest"
                BlueprintName = "UITests"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -98,7 +98,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_870129501381"
+            BlueprintIdentifier = "NT_863786754985"
             BuildableName = "UITests.xctest"
             BlueprintName = "UITests"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -121,7 +121,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_870129501381"
+            BlueprintIdentifier = "NT_863786754985"
             BuildableName = "UITests.xctest"
             BlueprintName = "UITests"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -140,7 +140,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_870129501381"
+            BlueprintIdentifier = "NT_863786754985"
             BuildableName = "UITests.xctest"
             BlueprintName = "UITests"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_183987345262"
+               BlueprintIdentifier = "LT_629454187867"
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_183987345262"
+               BlueprintIdentifier = "LT_629454187867"
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_173102942353"
+               BlueprintIdentifier = "LT_879714440108"
                BuildableName = "GeneratedFiles"
                BlueprintName = "GeneratedFiles"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -42,7 +42,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_100178272237"
+               BlueprintIdentifier = "LT_535582595715"
                BuildableName = "ResetLLDBInit"
                BlueprintName = "ResetLLDBInit"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -56,7 +56,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_314191844776"
+               BlueprintIdentifier = "NT_162101825678"
                BuildableName = "UnitTests.xctest"
                BlueprintName = "UnitTests"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -74,7 +74,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_314191844776"
+               BlueprintIdentifier = "NT_162101825678"
                BuildableName = "UnitTests.xctest"
                BlueprintName = "UnitTests"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -84,7 +84,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_314191844776"
+            BlueprintIdentifier = "NT_162101825678"
             BuildableName = "UnitTests.xctest"
             BlueprintName = "UnitTests"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -107,7 +107,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_314191844776"
+            BlueprintIdentifier = "NT_162101825678"
             BuildableName = "UnitTests.xctest"
             BlueprintName = "UnitTests"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -126,7 +126,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_314191844776"
+            BlueprintIdentifier = "NT_162101825678"
             BuildableName = "UnitTests.xctest"
             BlueprintName = "UnitTests"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost-Bazel.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost-Bazel.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_183987345262"
+               BlueprintIdentifier = "LT_629454187867"
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_183987345262"
+               BlueprintIdentifier = "LT_629454187867"
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_173102942353"
+               BlueprintIdentifier = "LT_879714440108"
                BuildableName = "GeneratedFiles"
                BlueprintName = "GeneratedFiles"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -42,7 +42,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_100178272237"
+               BlueprintIdentifier = "LT_535582595715"
                BuildableName = "ResetLLDBInit"
                BlueprintName = "ResetLLDBInit"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -56,7 +56,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_443002457585"
+               BlueprintIdentifier = "NT_757956135481"
                BuildableName = "ios-app.app"
                BlueprintName = "ios-app"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -70,7 +70,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_583546727827"
+               BlueprintIdentifier = "NT_394586624846"
                BuildableName = "UnitTestsWithHost.xctest"
                BlueprintName = "UnitTestsWithHost"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -88,7 +88,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_583546727827"
+               BlueprintIdentifier = "NT_394586624846"
                BuildableName = "UnitTestsWithHost.xctest"
                BlueprintName = "UnitTestsWithHost"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -98,7 +98,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_583546727827"
+            BlueprintIdentifier = "NT_394586624846"
             BuildableName = "UnitTestsWithHost.xctest"
             BlueprintName = "UnitTestsWithHost"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -121,7 +121,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_583546727827"
+            BlueprintIdentifier = "NT_394586624846"
             BuildableName = "UnitTestsWithHost.xctest"
             BlueprintName = "UnitTestsWithHost"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -140,7 +140,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_583546727827"
+            BlueprintIdentifier = "NT_394586624846"
             BuildableName = "UnitTestsWithHost.xctest"
             BlueprintName = "UnitTestsWithHost"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_183987345262"
+               BlueprintIdentifier = "LT_629454187867"
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_179453799913"
+               BlueprintIdentifier = "NT_700633204216"
                BuildableName = "ios-app-Bazel.app"
                BlueprintName = "ios-app-Bazel"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -46,7 +46,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_179453799913"
+            BlueprintIdentifier = "NT_700633204216"
             BuildableName = "ios-app-Bazel.app"
             BlueprintName = "ios-app-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -69,7 +69,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_179453799913"
+            BlueprintIdentifier = "NT_700633204216"
             BuildableName = "ios-app-Bazel.app"
             BlueprintName = "ios-app-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -88,7 +88,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_179453799913"
+            BlueprintIdentifier = "NT_700633204216"
             BuildableName = "ios-app-Bazel.app"
             BlueprintName = "ios-app-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_183987345262"
+               BlueprintIdentifier = "LT_629454187867"
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_173102942353"
+               BlueprintIdentifier = "LT_879714440108"
                BuildableName = "GeneratedFiles"
                BlueprintName = "GeneratedFiles"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -42,7 +42,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_100178272237"
+               BlueprintIdentifier = "LT_535582595715"
                BuildableName = "ResetLLDBInit"
                BlueprintName = "ResetLLDBInit"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -56,7 +56,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_443002457585"
+               BlueprintIdentifier = "NT_757956135481"
                BuildableName = "ios-app.app"
                BlueprintName = "ios-app"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -74,7 +74,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_314191844776"
+               BlueprintIdentifier = "NT_162101825678"
                BuildableName = "UnitTests.xctest"
                BlueprintName = "UnitTests"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -84,7 +84,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_870129501381"
+               BlueprintIdentifier = "NT_863786754985"
                BuildableName = "UITests.xctest"
                BlueprintName = "UITests"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -94,7 +94,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_583546727827"
+               BlueprintIdentifier = "NT_394586624846"
                BuildableName = "UnitTestsWithHost.xctest"
                BlueprintName = "UnitTestsWithHost"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -104,7 +104,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_443002457585"
+            BlueprintIdentifier = "NT_757956135481"
             BuildableName = "ios-app.app"
             BlueprintName = "ios-app"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -127,7 +127,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_443002457585"
+            BlueprintIdentifier = "NT_757956135481"
             BuildableName = "ios-app.app"
             BlueprintName = "ios-app"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -146,7 +146,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_443002457585"
+            BlueprintIdentifier = "NT_757956135481"
             BuildableName = "ios-app.app"
             BlueprintName = "ios-app"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
+++ b/sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "LT_183987345262"
+               BlueprintIdentifier = "LT_629454187867"
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +28,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "NT_593532437987"
+               BlueprintIdentifier = "NT_424996891355"
                BuildableName = "share-extension-Bazel.appex"
                BlueprintName = "share-extension-Bazel"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -46,7 +46,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_593532437987"
+            BlueprintIdentifier = "NT_424996891355"
             BuildableName = "share-extension-Bazel.appex"
             BlueprintName = "share-extension-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -69,7 +69,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_593532437987"
+            BlueprintIdentifier = "NT_424996891355"
             BuildableName = "share-extension-Bazel.appex"
             BlueprintName = "share-extension-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -88,7 +88,7 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "NT_593532437987"
+            BlueprintIdentifier = "NT_424996891355"
             BuildableName = "share-extension-Bazel.appex"
             BlueprintName = "share-extension-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/sample/UrlGet/ios-app/BUILD
+++ b/sample/UrlGet/ios-app/BUILD
@@ -82,6 +82,7 @@ objc_library(
     name = "ios-app-bin",
     srcs = [
         "UrlGet/main.m",
+        ":GeneratedSource"
     ],
     deps = [
         ":UrlGetClasses",
@@ -89,6 +90,17 @@ objc_library(
     defines = [
         "EXAMPLE_DEF=1"
     ]
+)
+
+genrule(
+    name = "GeneratedSource",
+    srcs = [],
+    outs = ["Generated.m"],
+    cmd = "touch $@",
+    # Set this to the xchammer tag so that the source is present for our Xcode
+    # builds, during build time. If you don't use Xcode build, this tag doesn't
+    # matter. ( See Docs/XCHammerFAQ.md for more info )
+    tags=["xchammer"]
 )
 
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")


### PR DESCRIPTION
This commit allows source files to be missing at generation time.

This fixes an aspect of #46 where generation fails where files are missing.