### PR TITLE
Remove `if Xcode` defines, improve docs

### DIFF
--- a/Docs/XCHammerFAQ.md
+++ b/Docs/XCHammerFAQ.md
@@ -65,5 +65,19 @@ adding examples of edge cases and bugs here :). Pull requests welcome!*
 
 ### How can I develop XCHammer with Xcode?
 
-To generate an Xcode project, use the make command, `make workspace`. Make sure, that in the scheme, to setup absolute paths to the `WORKSPACE` and `XCHammerConfig`.
+To generate an Xcode project, use the make command, `make workspace`. 
 
+*Running*
+To run XCHammer from Xcode for a given workspace, correctly setup the scheme for
+running. Set absolute paths to the `WORKSPACE` via `--workspace_root`,
+`XCHammerConfig` ( the first argument ), and `--bazel`. All 3 of these arguments
+are required.
+
+```
+1)  generate 
+2)  /path/to/UrlGet/XCHammer.yml 
+3)  --workspace_root /path/to/UrlGet/
+4)  --bazel /path/to/bazel/binary
+```
+_note: Currently, there are multiple issues using the SPM generated workspace,
+which will be fixed upon supporting XCHammer in XCHammer._ 

--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -732,14 +732,7 @@ enum Generator {
 
     private static func getAssetBase() -> String {
         let assetDir = "/XCHammerAssets"
-        #if Xcode
-            // Xcode Swift PM build system support.
-            // There is no way to correctly bundle resources in this scenario.
-            let components = #file .split(separator: "/")
-            let assetBase = "/" + components [0 ... components.count - 4].joined(separator: "/")
-        #else
-            let assetBase = Bundle.main.resourcePath!
-        #endif
+        let assetBase = Bundle.main.resourcePath!
         guard FileManager.default.fileExists(atPath: assetBase + assetDir) else {
             fatalError("Missing XCHammerAssets")
         }
@@ -747,15 +740,7 @@ enum Generator {
     }
 
     private static func getTulsiAspectRepo() -> String {
-        #if Xcode
-            // Xcode Swift PM build system support.
-            // There is no way to correctly bundle resources in this scenario.
-            let components = #file .split(separator: "/")
-            let assetBase = "/" + components [0 ... components.count - 4].joined(separator: "/")
-            return assetBase + "/tulsi-aspects"
-        #else
-            return Bundle.main.bundlePath
-        #endif
+        return Bundle.main.bundlePath
     }
 
     private static func getDepsHashSettingValue(projectPath: Path) throws ->


### PR DESCRIPTION
This commit removes the `if Xcode` hack in Generator.swift. This isn't
needed anymore and causes issues. Additionally clarify Xcode usage in
the Docs.