### PR TITLE
Improve handling of project paths

### DIFF
--- a/Sources/XCHammer/XCHammerGenerateOptions.swift
+++ b/Sources/XCHammer/XCHammerGenerateOptions.swift
@@ -35,7 +35,7 @@ struct XCHammerGenerateOptions {
     }
 
     var pathsSet: Set<String> {
-        let paths = config.projects[projectName]?.paths ?? []
+        let paths = config.projects[projectName]?.paths ?? ["**"]
         return Set(paths)
     }
 

--- a/Sources/XCHammer/XcodeTargetMap.swift
+++ b/Sources/XCHammer/XcodeTargetMap.swift
@@ -35,7 +35,7 @@ func alwaysIncludePathPredicate(_ path: String) -> Bool {
 /// Return a predicate that determines if a file should be included or not.
 /// We can use this function to filter based on user input.
 func makePathFiltersPredicate(_ paths: Set<String>) -> (String) -> Bool {
-    let recursiveFilters = Set<String>(paths.filter({ $0.hasSuffix("/**") }).map() {
+    let recursiveFilters = Set<String>(paths.filter({ $0.hasSuffix("**") }).map() {
         $0.substring(to: $0.characters.index($0.endIndex, offsetBy: -2))
     })
 


### PR DESCRIPTION
This is a fix to how XCHammer handles project paths for the very simple, new user initial use case.

With this change, either of these configs now work:

```yml
projects:
  HammerLyft: {}
```

```yml
projects:
  HammerLyft:
    paths:
      - "**"
```

The change is twofold:

1. Make `**` the default path set if one is not provided
2. Handle `**` as a recursive glob

For the second part, previously, recursive globs had to be prefixed by a `/`.