### PR TITLE
Resolve full path of XCHammer for bazel_build.py

### DIFF
--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -985,7 +985,7 @@ public class XcodeTarget: Hashable, Equatable {
         let targetConfig = genOptions.config.getTargetConfig(for: label.value)
 
         // bazel_build.py is adjacent to the XCHammer bin
-        let buildInvocation = dirname(CommandLine.arguments[0]) +
+        let buildInvocation = dirname(ProcessInfo.processInfo.arguments[0]) +
             "/bazel_build.py " + label.value + " --bazel " +
             genOptions.bazelPath.string
 


### PR DESCRIPTION
This fixes an issue with generating the path to `bazel_build.py`. The error message:

```
~/Library/Developer/Xcode/DerivedData/HammerLyft-apdrvgdqsckgxbeluodmnicxohsd/Build/Intermediates.noindex/HammerLyft.build/Debug-iphonesimulator/ArchitectureCore-Bazel.build/Script-SSBP_7741122292.sh: line 3: ./bazel_build.py: No such file or directory
```

The fix is to use `ProcessInfo.processInfo.arguments` instead of `CommandLine.arguments` because the former has the full path to `XCHammer` while the latter has just whatever was given on the command line, which will often be just `"XCHammer"`.