### PR TITLE
Update extractBuiltProductName to handle static libraries

### DIFF
--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -416,6 +416,8 @@ public class XcodeTarget: Hashable, Equatable {
             return xcTargetName + ".xctest"
             case .AppExtension, .XPCService, .Watch1App, .Watch2App, .Watch1Extension, .Watch2Extension, .TVAppExtension:
             return xcTargetName + ".appex"
+            case .StaticLibrary:
+            return xcTargetName
             default:
             fatalError()
         }


### PR DESCRIPTION
This change is required to support building targets that are built from rules_swift's `swift_library` rule.