### PR TITLE
Fix aspect error on CI

### DIFF
--- a/IntegrationTests/run_tests.sh
+++ b/IntegrationTests/run_tests.sh
@@ -111,9 +111,8 @@ function runTests() {
 ## Execution
 
 echo "Running tests"
-
 # Do a debug build
-make build
+make build || exit 1
 
 trap testsDidFinish EXIT
 preflightEnv

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PREFIX := /usr/local
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 aspects:
+	swift package resolve
 	# Export the tulsi workspace to PWD. We need this for
 	# Xcode, because there is no way to correctly install
 	# resources.
@@ -87,10 +88,11 @@ build-impl:
 	# in the context of our custom release package.
 	ditto $(ASPECTDIR) .build/$(CONFIG)/
 
+# Build impl doesn't build aspects because it is slow.
 build: build-debug
 	@ln -sf $(PWD)/.build/debug sample/UrlGet/tools/XCHammer
 
-test:
+test: aspects
 	$(ROOT_DIR)/IntegrationTests/run_tests.sh
 
 debug: build


### PR DESCRIPTION
The hacky Makefile wasn't building aspects before running tests. Resolve
packages

We need to get rid of this Makefile and SPM - until XCHammer can build
XCHammer Xcode projects it's required.