### PR TITLE
Perf tests: ReactNative Bazel C++ example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: generic
 os:
   - osx
+before_install:
+  - sudo gem install cocoapods
 osx_image: xcode10
 script: make ci

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,21 @@ run_force: build
 	    --bazel $(ROOT_DIR)/sample/UrlGet/tools/bazelwrapper \
 	    --force
 
+run_perf: build-release
+	@[[ -d sample/Frankenstein/Vendor/rules_pods ]] \
+		|| (echo "Run 'make' in sample/Frankenstein" && exit 1)
+	$(ROOT_DIR)/.build/release/$(PRODUCT) generate \
+	    $(ROOT_DIR)/sample/Frankenstein/XCHammer.yaml \
+	    --workspace_root $(ROOT_DIR)/sample/Frankenstein \
+	    --bazel $(ROOT_DIR)/sample/Frankenstein/tools/bazelwrapper \
+	    --force
 
-ci: test
+# On the CI we always load the deps
+run_perf_ci:
+	$(MAKE) -C sample/Frankenstein
+	$(MAKE) run_perf
+
+ci: test run_perf_ci
 
 format:
 	$(ROOT_DIR)/tools/bazelwrapper run buildifier

--- a/sample/Frankenstein/.bazelrc
+++ b/sample/Frankenstein/.bazelrc
@@ -1,0 +1,5 @@
+# Needed for folly.
+# FIXME: Propagate HEADER_SEARCH_PATHS to hdrs
+build \
+    --spawn_strategy=standalone \
+

--- a/sample/Frankenstein/.gitignore
+++ b/sample/Frankenstein/.gitignore
@@ -1,0 +1,8 @@
+Vendor/DoubleConversion/
+Vendor/Folly/
+Vendor/React/
+Vendor/Yoga/
+Vendor/boost-for-react-native/
+Vendor/glog/
+Vendor/rules_pods/
+*.xcodeproj

--- a/sample/Frankenstein/BUILD
+++ b/sample/Frankenstein/BUILD
@@ -1,0 +1,32 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+
+# This is needed for implicit entitlement rules created for
+# files.
+package(default_visibility = ["//visibility:public"])
+
+ios_application(
+    name = "ios-app",
+    bundle_id = "com.Frankenstein",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    visibility = ["//visibility:public"],
+    deps = ["ios-app-bin"],
+)
+
+objc_library(
+    name = "ios-app-bin",
+    srcs = [
+        "main.m",
+    ],
+    deps = [
+        "//Vendor/React:Core",
+        "//Vendor/React:CxxBridge",
+        "//Vendor/React:DevSupport",
+        "//Vendor/React:RCTImage",
+        "//Vendor/React:RCTNetwork",
+        "//Vendor/React:RCTText",
+        "//Vendor/React:RCTWebSocket",
+        "//Vendor/React:RCTAnimation",
+        "//Vendor/Yoga:Yoga"
+    ],
+)

--- a/sample/Frankenstein/Info.plist
+++ b/sample/Frankenstein/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>ios-app</string>
+	<key>CFBundleExecutable</key>
+	<string>ios-app</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.Frankenstein</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>ios-app</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+</dict>
+</plist>

--- a/sample/Frankenstein/Makefile
+++ b/sample/Frankenstein/Makefile
@@ -1,0 +1,3 @@
+deps:
+	git clone https://github.com/pinterest/PodToBUILD.git Vendor/rules_pods
+	Vendor/rules_pods/bin/update_pods.py

--- a/sample/Frankenstein/Pods.WORKSPACE
+++ b/sample/Frankenstein/Pods.WORKSPACE
@@ -1,0 +1,90 @@
+new_pod_repository(
+  name = "boost-for-react-native",
+  url = 'https://github.com/react-native-community/boost-for-react-native/archive/v1.63.0-0.zip',
+  # This podspec isn't included in the http archives of boost.
+  podspec_url = 'Vendor/PodSpecs/boost-for-react-native-1.63.0-0/boost-for-react-native.podspec',
+  generate_module_map = False,
+  install_script = """
+    __INIT_REPO__
+    # TODO: We need to add the ability to not generate this dir.
+    rm -rf pod_support/Headers/Public/boost
+  """,
+)
+
+new_pod_repository(
+  name = "Folly",
+  podspec_url = "Vendor/PodSpecs/react-0.57/third-party-podspecs/Folly.podspec",
+  url = "https://github.com/facebook/folly/archive/v2016.09.26.00.zip",
+  # header_visibility = "everything",
+  generate_module_map = False
+)
+
+new_pod_repository(
+  name = "DoubleConversion",
+  url = 'https://github.com/google/double-conversion/archive/v1.1.5.zip',
+  podspec_url = 'Vendor/PodSpecs/react-0.57/third-party-podspecs/DoubleConversion.podspec',
+  install_script = """
+    # prepare_command
+    mv src double-conversion
+    __INIT_REPO__
+  """,
+
+  generate_module_map = False
+)
+
+new_pod_repository(
+  name = "glog",
+  url = 'https://github.com/google/glog/archive/v0.3.4.zip',
+  podspec_url = 'Vendor/PodSpecs/react-0.57/third-party-podspecs/GLog.podspec',
+  install_script = """
+    # prepare_command
+  	sh ../PodSpecs/glog-0.3.4/ios-configure-glog.sh || exit 1
+  	__INIT_REPO__
+  """,
+  generate_module_map = False
+)
+
+# LEAVEME: Prior hacks for podspecs
+# - Copy over third-party-podspecs to Vendor/Podspecs
+# - Comment out busted prepare commands
+new_pod_repository(
+  name = "React",
+  owner = "@schneider",
+  url = 'https://github.com/facebook/react-native/archive/v0.57.0.zip',
+  user_options = [
+    # TODO: If Xcode is compiling CppLike with this standard, P2B should too.
+    "jsinspector.copts += -std=c++14",
+  ],
+
+  # Module map doesn't work because it seems to be expecting the folly library
+  generate_module_map = False,
+  inhibit_warnings = True,
+
+  # This is a workaround for a bug and warning emitted in `ObjcLibrary`
+  # where we include non propagated headers in headers.
+  header_visibility = "everything"
+)
+
+# WARNING: the version of react-native here doesn't match up with yoga.
+new_pod_repository(
+  name = "Yoga",
+  owner = "@schneider",
+  url = 'https://github.com/facebook/react-native/archive/v0.55.4.zip',
+  strip_prefix = 'react-native-0.55.4/ReactCommon/yoga',
+  install_script = """
+    # We need to fix the package parameter here (even though we don't use in pod2build)
+    # because the evaluation of the podspec in Ruby will fail. The package parameter
+    # points to a JSON.parse of a file outside the yoga sandbox.
+    /usr/bin/sed -i "" "s,^package.*,package = { 'version' => '0.46.3' },g" Yoga.podspec
+
+    
+    # The canonical version of Yoga uses the Podspec.name, 'Yoga'
+    # React uses the name of 'yoga'. To use this with Texture, we need to
+    # uppercase the name. This is an issue with React <-> Texture integration in
+    # Pods.
+    /usr/bin/sed -i "" "s,spec.module_name.*yoga,spec.module_name = 'Yoga,g" Yoga.podspec
+    __INIT_REPO__
+  """,
+
+  generate_module_map = False
+)

--- a/sample/Frankenstein/Vendor/PodSpecs/boost-for-react-native-1.63.0-0/boost-for-react-native.podspec
+++ b/sample/Frankenstein/Vendor/PodSpecs/boost-for-react-native-1.63.0-0/boost-for-react-native.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |spec|
+  spec.name = 'boost-for-react-native'
+  spec.version = '1.63.0'
+  spec.license = { :type => 'Boost Software License', :file => "LICENSE_1_0.txt" }
+  spec.homepage = 'http://www.boost.org'
+  spec.summary = 'Boost provides free peer-reviewed portable C++ source libraries.'
+  spec.authors = 'Rene Rivera'
+  spec.source = { :git => 'https://github.com/react-native-community/boost-for-react-native.git',
+                  :tag => 'v1.63.0-0' }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => '8.0', :tvos => '9.2' }
+  spec.requires_arc = false
+
+  spec.module_name = 'boost'
+  spec.header_dir = 'boost'
+  spec.preserve_path = 'boost'
+end

--- a/sample/Frankenstein/Vendor/PodSpecs/glog-0.3.4/ios-configure-glog.sh
+++ b/sample/Frankenstein/Vendor/PodSpecs/glog-0.3.4/ios-configure-glog.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+PLATFORM_NAME="${PLATFORM_NAME:-iphoneos}"
+CURRENT_ARCH="${CURRENT_ARCH:-armv7}"
+
+export CC=/usr/bin/clang
+export CXX=/usr/bin/clang++
+
+# Remove automake symlink if it exists
+if [ -h "test-driver" ]; then
+    rm test-driver
+fi
+
+# source ../PodSpecs/react-native-third-party-0.51.0/Env.sh
+
+echo  "set -o xtrace" > config2
+chmod +x config2
+cat configure >> config2
+
+./config2 --host arm-apple-darwin
+
+# Fix build for tvOS
+cat << EOF >> src/config.h
+
+/* Add in so we have Apple Target Conditionals */
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#include <Availability.h>
+#endif
+
+/* Special configuration for AppleTVOS */
+#if TARGET_OS_TV
+#undef HAVE_SYSCALL_H
+#undef HAVE_SYS_SYSCALL_H
+#undef OS_MACOSX
+#endif
+
+/* Special configuration for ucontext */
+#undef HAVE_UCONTEXT_H
+#undef PC_FROM_UCONTEXT
+#if defined(__x86_64__)
+#define PC_FROM_UCONTEXT uc_mcontext->__ss.__rip
+#elif defined(__i386__)
+#define PC_FROM_UCONTEXT uc_mcontext->__ss.__eip
+#endif
+EOF

--- a/sample/Frankenstein/Vendor/PodSpecs/react-0.57/third-party-podspecs/DoubleConversion.podspec
+++ b/sample/Frankenstein/Vendor/PodSpecs/react-0.57/third-party-podspecs/DoubleConversion.podspec
@@ -1,0 +1,17 @@
+Pod::Spec.new do |spec|
+  spec.name = 'DoubleConversion'
+  spec.version = '1.1.6'
+  spec.license = { :type => 'MIT' }
+  spec.homepage = 'https://github.com/google/double-conversion'
+  spec.summary = 'Efficient binary-decimal and decimal-binary conversion routines for IEEE doubles'
+  spec.authors = 'Google'
+  spec.prepare_command = 'mv src double-conversion'
+  spec.source = { :git => 'https://github.com/google/double-conversion.git',
+                  :tag => "v#{spec.version}" }
+  spec.module_name = 'DoubleConversion'
+  spec.source_files = 'double-conversion/*.{h,cc}'
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "9.0", :tvos => "9.2" }
+
+end

--- a/sample/Frankenstein/Vendor/PodSpecs/react-0.57/third-party-podspecs/Folly.podspec
+++ b/sample/Frankenstein/Vendor/PodSpecs/react-0.57/third-party-podspecs/Folly.podspec
@@ -1,0 +1,35 @@
+Pod::Spec.new do |spec|
+  spec.name = 'Folly'
+  spec.version = '2016.10.31.00'
+  spec.license = { :type => 'Apache License, Version 2.0' }
+  spec.homepage = 'https://github.com/facebook/folly'
+  spec.summary = 'An open-source C++ library developed and used at Facebook.'
+  spec.authors = 'Facebook'
+  spec.source = { :git => 'https://github.com/facebook/folly.git',
+                  :tag => "v#{spec.version}" }
+  spec.module_name = 'folly'
+  spec.dependency 'boost-for-react-native'
+  spec.dependency 'DoubleConversion'
+  spec.dependency 'glog'
+  spec.compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1'
+  spec.source_files = 'folly/Bits.cpp',
+                      'folly/Conv.cpp',
+                      'folly/Demangle.cpp',
+                      'folly/StringBase.cpp',
+                      'folly/Unicode.cpp',
+                      'folly/dynamic.cpp',
+                      'folly/json.cpp',
+                      'folly/portability/BitsFunctexcept.cpp',
+                      'folly/detail/MallocImpl.cpp'
+  # workaround for https://github.com/facebook/react-native/issues/14326
+  spec.preserve_paths = 'folly/*.h',
+                        'folly/detail/*.h',
+                        'folly/portability/*.h'
+  spec.libraries           = "stdc++"
+  spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
+                               "CLANG_CXX_LANGUAGE_STANDARD" => "c++14",
+                               "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\"" }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "9.0", :tvos => "9.2" }
+end

--- a/sample/Frankenstein/Vendor/PodSpecs/react-0.57/third-party-podspecs/glog.podspec
+++ b/sample/Frankenstein/Vendor/PodSpecs/react-0.57/third-party-podspecs/glog.podspec
@@ -1,0 +1,33 @@
+Pod::Spec.new do |spec|
+  spec.name = 'glog'
+  spec.version = '0.3.5'
+  spec.license = { :type => 'Google', :file => 'COPYING' }
+  spec.homepage = 'https://github.com/google/glog'
+  spec.summary = 'Google logging module'
+  spec.authors = 'Google'
+
+  # spec.prepare_command = File.read("../scripts/ios-configure-glog.sh")
+  spec.source = { :git => 'https://github.com/google/glog.git',
+                  :tag => "v#{spec.version}" }
+  spec.module_name = 'glog'
+  spec.header_dir = 'glog'
+  spec.source_files = 'src/glog/*.h',
+                      'src/demangle.cc',
+                      'src/logging.cc',
+                      'src/raw_logging.cc',
+                      'src/signalhandler.cc',
+                      'src/symbolize.cc',
+                      'src/utilities.cc',
+                      'src/vlog_is_on.cc'
+  # workaround for https://github.com/facebook/react-native/issues/14326
+  spec.preserve_paths = 'src/*.h',
+                        'src/base/*.h'
+  spec.exclude_files       = "src/windows/**/*"
+  spec.libraries           = "stdc++"
+  spec.pod_target_xcconfig = { "USE_HEADERMAP" => "NO",
+                               "HEADER_SEARCH_PATHS" => "$(PODS_TARGET_SRCROOT)/src" }
+
+  # Pinning to the same version as React.podspec.
+  spec.platforms = { :ios => "9.0", :tvos => "9.2" }
+
+end

--- a/sample/Frankenstein/WORKSPACE
+++ b/sample/Frankenstein/WORKSPACE
@@ -1,0 +1,20 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", system_git_repository = "git_repository")
+
+git_repository(
+    name = "build_bazel_rules_apple",
+    commit = "6f93226e29fef0ac6ba00fb5dc56389d3bd8c25f",
+    remote = "https://github.com/bazelbuild/rules_apple.git",
+)
+
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
+
+apple_rules_dependencies()
+
+http_file(
+    name = "xctestrunner",
+    executable = 1,
+    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.3/ios_test_runner.par"],
+)

--- a/sample/Frankenstein/XCHammer.yaml
+++ b/sample/Frankenstein/XCHammer.yaml
@@ -1,0 +1,7 @@
+targets:
+    - ":ios-app"
+
+projects:
+    "Frankenstein":
+        paths:
+            - "**"

--- a/sample/Frankenstein/main.m
+++ b/sample/Frankenstein/main.m
@@ -1,0 +1,3 @@
+int main(int argc, char * argv[]) {
+    return 0;
+}

--- a/sample/Frankenstein/tools/bazelwrapper
+++ b/sample/Frankenstein/tools/bazelwrapper
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -e
+
+# Make sure we're in the project root directory.
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+pushd "$SCRIPTPATH/.." > /dev/null
+trap popd > /dev/null ERR EXIT
+
+# Go to bazel release page
+# These are typically posted in groups.google
+# https://groups.google.com/forum/#!forum/bazel-discuss
+BAZEL_VERSION="0.16.1"
+BAZEL_VERSION_SHA="07d5c753738c7186117168770f525b59c39b24103f714be2ffcaadd8e2c53a78"
+BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
+
+BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"
+BAZEL_PATH="$BAZEL_ROOT/bin/bazel"
+XCODE_SELECT_ENV_PATH="${SCRIPTPATH}/.xcode_select_env"
+LEGACY_BAZEL_PATH="$SCRIPTPATH/../Scripts/bazel/bin/bazel"
+
+BAZEL=""
+
+function install_bazel() {
+    curl -L "$BAZEL_VERSION_URL" > $PWD/install_bazel.sh
+    SHA=$(shasum -a 256 install_bazel.sh | awk '{ print $1 }')
+    if [[ $SHA == $BAZEL_VERSION_SHA ]]; then
+        chmod +x install_bazel.sh
+        $PWD/install_bazel.sh --prefix="$BAZEL_ROOT" && rm install_bazel.sh
+    else
+        echo "You version of bazel is out of date; ask for help in #cx-ios"
+        exit 1
+    fi
+}
+
+# Check if we have the correct version of bazel installed in the home
+# directory.
+# Fallback to ./Scripts/bazel/bin/bazel for legacy installations
+# Lastly, check if there is one installed on the path
+if [[ -e "$BAZEL_PATH" ]]; then
+  BAZEL="$BAZEL_PATH"
+elif [[ -e "$LEGACY_BAZEL_PATH" ]] && [[ $("$LEGACY_BAZEL_PATH" version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
+  BAZEL="$LEGACY_BAZEL_PATH"
+elif [[ -e $(which bazel) ]] && [[ $($(which bazel) version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
+  BAZEL=$(which bazel)
+fi
+
+# Ensure we can execute the path for bazel and that it's the correct version
+if ! [[ -e "$BAZEL" ]]; then
+  echo "WARNING: Missing installation or incorrect bazel version ($BAZEL_VERSION)" >&2;
+  echo "Installing Bazel $BAZEL_VERSION to $BAZEL_PATH" >&2;
+  install_bazel
+  BAZEL=$BAZEL_PATH
+fi
+
+if [[ -x "${BAZEL}" ]]; then
+  CURRENT_XCODE_PATH="$(/usr/bin/xcode-select -p)"
+  XCODE_VERSION=$(/usr/bin/xcodebuild -version | grep Xcode | cut -d ' ' -f2)
+  CURRENT_XCODE_HASH="${CURRENT_XCODE_PATH}-${XCODE_VERSION}-${BAZEL_VERSION}"
+  if [[ -f "${XCODE_SELECT_ENV_PATH}" ]]; then
+    EXISTING_XCODE_HASH="$(cat "${XCODE_SELECT_ENV_PATH}")"
+    if [[ $EXISTING_XCODE_HASH != $CURRENT_XCODE_HASH ]]; then
+      echo "Xcode select path or Bazel version has changed, must clear cached data"
+      $BAZEL clean --expunge
+    fi
+  fi
+  echo "${CURRENT_XCODE_HASH}" > $XCODE_SELECT_ENV_PATH
+
+  # Make variable support
+  # In the context of Xcode builds, variables are defined as "Make variable"
+  # strings.
+  # In practice, the variables are stored as strings, and then later assigned to
+  # the value of the current environment.
+  ARGS=()
+  for ARG in "$@"; do
+      if [[ "$ARG" =~ \$(.*) ]]; then
+        # Get the name of the make variable
+        MAKEVAR=$(echo $ARG | sed 's,.*\$(\(.*\)).*,\1,g')
+        # Next, parameter expansion of the variable by name
+        VALUE="${!MAKEVAR}"
+        REPLACED="$(echo $ARG | sed "s,\$(\(.*\)),$VALUE,g")"
+        ARGS+=(${REPLACED})
+      else
+        ARGS+=("${ARG}")
+      fi
+  done
+
+  exec -a "$0" /usr/bin/env - TERM=$TERM SHELL=$SHELL PATH=$PATH HOME=$HOME "${BAZEL}" "${ARGS[@]}"
+else
+  echo "WARNING: Missing installation of bazel" >&2;
+  exit 1
+fi


### PR DESCRIPTION
This commit adds another example of a project containing RN and all of
it's trans deps.

On the CI, we run XCHammer to just build the Xcode project as a perf
test of this condition.

Now that PodToBUILD can build ReactNative, this is easy to setup. Future
work will clean this up when we add support for external in P2B

On a maxed out 2.9 GHz Intel Core i7 MBP
```
XCHammer: ** Completed xcode_gen in 378.3899s
XCHammer: ** Completed make_schemes in 0.0283s
XCHammer: ** Completed generate_project in 380.5344s

```
This is a highly optimized case in XCHammer logic ( only 2s here ) and
exemplifies the XcodeGen issue