### PR TITLE
Transitive track visited

### DIFF
--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -338,17 +338,25 @@ public class XcodeTarget: Hashable, Equatable {
             return []
         }
 
-        return unfilteredDependencies.flatMap { (xcodeTarget: XcodeTarget) -> [XcodeTarget] in
+        var transitiveTargets: [XcodeTarget] = []
+        var queue = unfilteredDependencies
+        while let xcodeTarget = queue.first {
+            queue.removeFirst()
+
             switch predicate.run(xcodeTarget) {
             case .stop:
-                return []
+                continue
             case .justOnceMore:
-                return [xcodeTarget]
+                transitiveTargets.append(xcodeTarget)
             case .keepGoing:
-                return [xcodeTarget] + xcodeTarget.transitiveTargets(map: targetMap,
-                        predicate: predicate, force: force)
+                transitiveTargets.append(xcodeTarget)
+                if force || xcodeTarget.needsRecursiveExtraction {
+                    queue.insert(contentsOf: xcodeTarget.unfilteredDependencies, at: 0)
+                }
             }
         }
+
+        return transitiveTargets
     }
 
     func makePathFiltersTransitionPredicate(paths: Set<String>) -> TraversalTransitionPredicate<XcodeTarget> {

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -338,10 +338,15 @@ public class XcodeTarget: Hashable, Equatable {
             return []
         }
 
+        var visited: Set<XcodeTarget> = [self]
         var transitiveTargets: [XcodeTarget] = []
         var queue = unfilteredDependencies
         while let xcodeTarget = queue.first {
             queue.removeFirst()
+
+            guard visited.insert(xcodeTarget).inserted else {
+                continue
+            }
 
             switch predicate.run(xcodeTarget) {
             case .stop:


### PR DESCRIPTION
Note: This change depends on #77 which has not yet merged.

For diff of this change, see 208cc8a.

This change (on top of #77) reduces `generate` time **from 2min to 8s**. When combined with #77, this sample project `generate` time is improved from ~8min to ~8sec.

This change tracks visited `XcodeTarget`s, to avoid repeatedly traversing the dependency graph for nodes already visited. **This changes the behavior of `transitiveTargets()`**. Now the returned array is essentially a `Set`. Many but not all of the callers convert the result of `transitiveTargets()` to a `Set`, so this is desired behavior by many callers. For the callers that don't convert to a `Set`, it's not clear to me if they need a fully flattened graph, which seems unlikely. If any code needs that, I think it's a discussion to change those callers. These callers are:

* `XcodeTarget.settings` (for `settings.copts`)
* `extractLibraryDeps()`
* `extractAttributeArray()`

