### PR TITLE
Copy tulsi-aspects to TulsiGenerator.framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ aspects:
 	# resources.
 	# Note that the build process always exports from this directory to the
 	# bundle
-	./export_tulsi_aspect_dir.sh ${PWD}/tulsi-aspects
+	./export_tulsi_aspect_dir.sh ${PWD}/$(ASPECTDIR)
 
 # Copy the tulsi-aspects and XCHammerAssets adjacent to the Xcode build
 # directory to allow loading of resources, since we can't express this in SPM or
@@ -27,9 +27,9 @@ workspace: aspects
 			-scheme XCHammer \
 			|  awk '$$1 == "BUILD_DIR" { print $$3 }'))
 	@mkdir -p "$(BUILD_DIR)"
-	@ditto "$(ASPECTDIR)" "$(BUILD_DIR)/Debug/"
+	@ditto "$(ASPECTDIR)" "$(BUILD_DIR)/Debug/TulsiGenerator.framework"
 	@ditto "$(ASSETDIR)" "$(BUILD_DIR)/Debug/$(ASSETDIR)"
-	@ditto "$(ASPECTDIR)" "$(BUILD_DIR)/Release/"
+	@ditto "$(ASPECTDIR)" "$(BUILD_DIR)/Release/TulsiGenerator.framework"
 	@ditto "$(ASSETDIR)" "$(BUILD_DIR)/Release/$(ASSETDIR)"
 
 clean:


### PR DESCRIPTION
This is a change to enable debugging via Xcode. TulsiGenerator accesses its `WORKSPACE` file, and probably more, from its bundle. However the `ditto` commands in the `Makefile` don't copy to the correct destination. This change copies the contents of `tulsi-aspects` into `TulsiGenerator.framework`, which in turn enables debugging via Xcode.