### PR TITLE
Workspace rules and sample Pass 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ tulsi-aspects
 *.xcode_select_env
 bazel-*
 sample/*/*.xcodeproj
+external

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests-Bazel.xcscheme
@@ -106,7 +106,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
-      revealArchiveInOrganizer = "YES">
+      revealArchiveInOrganizer = "YES"
+      buildConfiguration = "Debug">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
@@ -158,7 +158,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
-      revealArchiveInOrganizer = "YES">
+      revealArchiveInOrganizer = "YES"
+      buildConfiguration = "Debug">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
@@ -106,7 +106,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
-      revealArchiveInOrganizer = "YES">
+      revealArchiveInOrganizer = "YES"
+      buildConfiguration = "Debug">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -144,7 +144,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
-      revealArchiveInOrganizer = "YES">
+      revealArchiveInOrganizer = "YES"
+      buildConfiguration = "Debug">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost-Bazel.xcscheme
@@ -106,7 +106,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
-      revealArchiveInOrganizer = "YES">
+      revealArchiveInOrganizer = "YES"
+      buildConfiguration = "Debug">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
@@ -158,7 +158,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
-      revealArchiveInOrganizer = "YES">
+      revealArchiveInOrganizer = "YES"
+      buildConfiguration = "Debug">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
@@ -106,7 +106,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
-      revealArchiveInOrganizer = "YES">
+      revealArchiveInOrganizer = "YES"
+      buildConfiguration = "Debug">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
@@ -76,28 +76,43 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = ""
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BuildableName = "UITests.xctest"
                BlueprintName = "UITests"
-               ReferencedContainer = "container:UrlGet.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = ""
-               BuildableName = "UnitTestsWithHost.xctest"
-               BlueprintName = "UnitTestsWithHost"
-               ReferencedContainer = "container:UrlGet.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = ""
+=======
                BuildableName = "UnitTests.xctest"
                BlueprintName = "UnitTests"
+>>>>>>> Workspace rules and sample Pass 1:sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+               ReferencedContainer = "container:UrlGet.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = ""
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+               BuildableName = "UnitTestsWithHost.xctest"
+               BlueprintName = "UnitTestsWithHost"
+=======
+               BuildableName = "UITests.xctest"
+               BlueprintName = "UITests"
+>>>>>>> Workspace rules and sample Pass 1:sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+               ReferencedContainer = "container:UrlGet.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = ""
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+=======
+               BuildableName = "UnitTestsWithHost.xctest"
+               BlueprintName = "UnitTestsWithHost"
+>>>>>>> Workspace rules and sample Pass 1:sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                ReferencedContainer = "container:UrlGet.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -164,7 +179,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
-      revealArchiveInOrganizer = "YES">
+      revealArchiveInOrganizer = "YES"
+      buildConfiguration = "Debug">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
@@ -106,7 +106,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Debug"
-      revealArchiveInOrganizer = "YES">
+      revealArchiveInOrganizer = "YES"
+      buildConfiguration = "Debug">
    </ArchiveAction>
 </Scheme>

--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,13 @@ run_force: build
 	    --bazel $(ROOT_DIR)/sample/$(SAMPLE)/tools/bazelwrapper \
 	    --force
 
+run_workspace_sample: build
+	$(ROOT_DIR)/.build/debug/$(PRODUCT) generate \
+	    $(ROOT_DIR)/sample/WorkspaceSource/XCHammer.yaml \
+	    --workspace_root $(ROOT_DIR)/sample/WorkspaceSource \
+	    --bazel $(ROOT_DIR)/sample/WorkspaceSource/tools/bazelwrapper \
+	    --force
+
 run_perf: build-release
 	@[[ -d sample/Frankenstein/Vendor/rules_pods ]] \
 		|| (echo "Run 'make' in sample/Frankenstein" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -131,13 +131,6 @@ run_force: build
 	    --bazel $(ROOT_DIR)/sample/$(SAMPLE)/tools/bazelwrapper \
 	    --force
 
-run_workspace_sample: build
-	$(ROOT_DIR)/.build/debug/$(PRODUCT) generate \
-	    $(ROOT_DIR)/sample/WorkspaceSource/XCHammer.yaml \
-	    --workspace_root $(ROOT_DIR)/sample/WorkspaceSource \
-	    --bazel $(ROOT_DIR)/sample/WorkspaceSource/tools/bazelwrapper \
-	    --force
-
 run_perf: build-release
 	@[[ -d sample/Frankenstein/Vendor/rules_pods ]] \
 		|| (echo "Run 'make' in sample/Frankenstein" && exit 1)

--- a/sample/WorkspaceSource/.gitignore
+++ b/sample/WorkspaceSource/.gitignore
@@ -1,0 +1,1 @@
+*.xcodeproj

--- a/sample/WorkspaceSource/BUILD
+++ b/sample/WorkspaceSource/BUILD
@@ -1,0 +1,23 @@
+load("@build_bazel_rules_apple//apple:ios.bzl", "ios_application")
+load('@build_bazel_rules_swift//swift:swift.bzl', 'swift_library')
+
+# This is needed for implicit entitlement rules created for
+# files.
+package(default_visibility = ["//visibility:public"])
+
+ios_application(
+    name = "ios-app",
+    bundle_id = "com.Sample",
+    families = ["iphone"],
+    infoplists = ["Info.plist"],
+    visibility = ["//visibility:public"],
+    deps = ["ios-app-main"],
+)
+
+objc_library(
+    name = "ios-app-main",
+    srcs = [
+        "main.m",
+    ],
+    deps = ["@Some//:Some"]
+)

--- a/sample/WorkspaceSource/Info.plist
+++ b/sample/WorkspaceSource/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>ios-app</string>
+	<key>CFBundleExecutable</key>
+	<string>ios-app</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.Sample</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>ios-app</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+</dict>
+</plist>

--- a/sample/WorkspaceSource/WORKSPACE
+++ b/sample/WorkspaceSource/WORKSPACE
@@ -1,0 +1,30 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load(":workspace.bzl", "gen_repo")
+
+git_repository(
+    name = "build_bazel_rules_apple",
+    remote = "https://github.com/bazelbuild/rules_apple.git",
+    tag = "0.6.0",
+)
+
+load(
+    "@build_bazel_rules_apple//apple:repositories.bzl",
+    "apple_rules_dependencies",
+)
+
+apple_rules_dependencies()
+
+git_repository(
+    name = "build_bazel_rules_swift",
+    remote = "https://github.com/bazelbuild/rules_swift.git",
+    tag = "0.3.0",
+)
+
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+gen_repo(name="Some")
+
+swift_rules_dependencies()

--- a/sample/WorkspaceSource/XCHammer.yaml
+++ b/sample/WorkspaceSource/XCHammer.yaml
@@ -1,0 +1,7 @@
+targets:
+    - ":ios-app"
+
+projects:
+    "WorkspaceSource":
+        paths:
+            - "**"

--- a/sample/WorkspaceSource/XCHammer.yaml
+++ b/sample/WorkspaceSource/XCHammer.yaml
@@ -1,5 +1,5 @@
 targets:
-    - ":ios-app"
+    - "//:ios-app"
 
 projects:
     "WorkspaceSource":

--- a/sample/WorkspaceSource/main.m
+++ b/sample/WorkspaceSource/main.m
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+#import "external/Some/some.h"
+
+int main(int argc, char * argv[]) {
+    NSLog(@"%d", SomeVersion);
+    return 0;
+}

--- a/sample/WorkspaceSource/tools/bazelwrapper
+++ b/sample/WorkspaceSource/tools/bazelwrapper
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -e
+
+# Make sure we're in the project root directory.
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+pushd "$SCRIPTPATH/.." > /dev/null
+trap popd > /dev/null ERR EXIT
+
+# Go to bazel release page
+# These are typically posted in groups.google
+# https://groups.google.com/forum/#!forum/bazel-discuss
+BAZEL_VERSION="0.16.1"
+BAZEL_VERSION_SHA="07d5c753738c7186117168770f525b59c39b24103f714be2ffcaadd8e2c53a78"
+BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
+
+BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"
+BAZEL_PATH="$BAZEL_ROOT/bin/bazel"
+XCODE_SELECT_ENV_PATH="${SCRIPTPATH}/.xcode_select_env"
+LEGACY_BAZEL_PATH="$SCRIPTPATH/../Scripts/bazel/bin/bazel"
+
+BAZEL=""
+
+function install_bazel() {
+    curl -L "$BAZEL_VERSION_URL" > $PWD/install_bazel.sh
+    SHA=$(shasum -a 256 install_bazel.sh | awk '{ print $1 }')
+    if [[ $SHA == $BAZEL_VERSION_SHA ]]; then
+        chmod +x install_bazel.sh
+        $PWD/install_bazel.sh --prefix="$BAZEL_ROOT" && rm install_bazel.sh
+    else
+        echo "You version of bazel is out of date; ask for help in #cx-ios"
+        exit 1
+    fi
+}
+
+# Check if we have the correct version of bazel installed in the home
+# directory.
+# Fallback to ./Scripts/bazel/bin/bazel for legacy installations
+# Lastly, check if there is one installed on the path
+if [[ -e "$BAZEL_PATH" ]]; then
+  BAZEL="$BAZEL_PATH"
+elif [[ -e "$LEGACY_BAZEL_PATH" ]] && [[ $("$LEGACY_BAZEL_PATH" version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
+  BAZEL="$LEGACY_BAZEL_PATH"
+elif [[ -e $(which bazel) ]] && [[ $($(which bazel) version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
+  BAZEL=$(which bazel)
+fi
+
+# Ensure we can execute the path for bazel and that it's the correct version
+if ! [[ -e "$BAZEL" ]]; then
+  echo "WARNING: Missing installation or incorrect bazel version ($BAZEL_VERSION)" >&2;
+  echo "Installing Bazel $BAZEL_VERSION to $BAZEL_PATH" >&2;
+  install_bazel
+  BAZEL=$BAZEL_PATH
+fi
+
+if [[ -x "${BAZEL}" ]]; then
+  CURRENT_XCODE_PATH="$(/usr/bin/xcode-select -p)"
+  XCODE_VERSION=$(/usr/bin/xcodebuild -version | grep Xcode | cut -d ' ' -f2)
+  CURRENT_XCODE_HASH="${CURRENT_XCODE_PATH}-${XCODE_VERSION}-${BAZEL_VERSION}"
+  if [[ -f "${XCODE_SELECT_ENV_PATH}" ]]; then
+    EXISTING_XCODE_HASH="$(cat "${XCODE_SELECT_ENV_PATH}")"
+    if [[ $EXISTING_XCODE_HASH != $CURRENT_XCODE_HASH ]]; then
+      echo "Xcode select path or Bazel version has changed, must clear cached data"
+      $BAZEL clean --expunge
+    fi
+  fi
+  echo "${CURRENT_XCODE_HASH}" > $XCODE_SELECT_ENV_PATH
+
+  # Make variable support
+  # In the context of Xcode builds, variables are defined as "Make variable"
+  # strings.
+  # In practice, the variables are stored as strings, and then later assigned to
+  # the value of the current environment.
+  ARGS=()
+  for ARG in "$@"; do
+      if [[ "$ARG" =~ \$(.*) ]]; then
+        # Get the name of the make variable
+        MAKEVAR=$(echo $ARG | sed 's,.*\$(\(.*\)).*,\1,g')
+        # Next, parameter expansion of the variable by name
+        VALUE="${!MAKEVAR}"
+        REPLACED="$(echo $ARG | sed "s,\$(\(.*\)),$VALUE,g")"
+        ARGS+=(${REPLACED})
+      else
+        ARGS+=("${ARG}")
+      fi
+  done
+
+  exec -a "$0" /usr/bin/env - TERM=$TERM SHELL=$SHELL PATH=$PATH HOME=$HOME "${BAZEL}" "${ARGS[@]}"
+else
+  echo "WARNING: Missing installation of bazel" >&2;
+  exit 1
+fi

--- a/sample/WorkspaceSource/workspace.bzl
+++ b/sample/WorkspaceSource/workspace.bzl
@@ -1,0 +1,16 @@
+def _impl(ctx):
+    ctx.file("some.h", "extern int SomeVersion;")
+    ctx.file("some.m", "int SomeVersion = 1;")
+    ctx.file("BUILD", """
+objc_library(
+    name = "Some",
+    srcs = ["some.m"],
+    hdrs = ["some.h"],
+    visibility = ["//visibility:public"]
+)
+             """)
+
+gen_repo = repository_rule(
+    implementation=_impl,
+    local=False,
+)


### PR DESCRIPTION
This commit implements repository rule in XCHammer. It patches outputs
to `external` and finally, symlinks the canonical `external` directory
into the workspace. This ensures that the feature is portable, and
points to the canonical repostories inside of Bazel, rather than the
transient ones.

Fixes #11