### PR TITLE
Remove debugging code

### DIFF
--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -1006,7 +1006,6 @@ public class XcodeTarget: Hashable, Equatable {
         ]
 
         guard let productType = BuildTypeToTargetType[self.type] else {
-            print("Unknown product type: \(self.type). Unable to extract xcode equivalent")
             return nil
         }
         return productType


### PR DESCRIPTION
We left print statments that print confusing messages that product types
aren't supported.