### PR TITLE
Include Xcode schemes for specified labels

### DIFF
--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -236,11 +236,15 @@ enum Generator {
             return []
         }
 
+        let specifiedLabels = Set(genOptions.config.buildTargetLabels)
         return targets
             .compactMap { xcodeTarget in
                 let type = xcodeTarget.xcType!
                 let name = xcodeTarget.xcTargetName
-                guard type.contains("application") || type.contains("-test") else {
+                guard type.contains("application")
+                    || type.contains("-test")
+                    || specifiedLabels.contains(xcodeTarget.label)
+                    else {
                     return nil
                 }
 

--- a/sample/UrlGet/XCHammer.yaml
+++ b/sample/UrlGet/XCHammer.yaml
@@ -4,6 +4,7 @@ targets:
     - "//ios-app:UnitTestsWithHost"
     - "//ios-app:ios-app"
     - "//ios-app:share-extension"
+    - "//ios-app:ios-app-bin"
 
 projects:
     "UrlGet":


### PR DESCRIPTION
The original XCHammer logic was very specific, and generated schemes for
Tests, and Applications. This commit generates schemes for all specified
targets.

Fixes #69