### PR TITLE
Generate XCHammer .xcodeproj with XCHammer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ tulsi-aspects
 bazel-*
 sample/*/*.xcodeproj
 external
+xchammer-bazel.xcodeproj

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,14 @@ aspects:
 	# bundle
 	./export_tulsi_aspect_dir.sh ${PWD}/$(ASPECTDIR)
 
+
+# Make a SPM generated Xcode project.
+# cause problems.
 # Copy the tulsi-aspects and XCHammerAssets adjacent to the Xcode build
-# directory to allow loading of resources, since we can't express this in SPM or
-# Xcode generated SPM
-# This is the format of the XCHammer package
-workspace: aspects
+# directory to allow loading of resources, since we can't express this in SPM
+#
+# Note: this is brittle and might not work as expected
+workspace_legacy: aspects
 	swift package generate-xcodeproj
 	$(eval BUILD_DIR=$(shell xcodebuild -showBuildSettings \
 			-project XCHammer.xcodeproj/ \
@@ -31,6 +34,14 @@ workspace: aspects
 	@ditto "$(ASSETDIR)" "$(BUILD_DIR)/Debug/$(ASSETDIR)"
 	@ditto "$(ASPECTDIR)" "$(BUILD_DIR)/Release/TulsiGenerator.framework"
 	@ditto "$(ASSETDIR)" "$(BUILD_DIR)/Release/$(ASSETDIR)"
+
+# Make an XCHammer XCHammer Xcode project.
+#
+# Note: incremental builds are currently not working with Bazel
+workspace: build
+	$(ROOT_DIR)/.build/debug/$(PRODUCT) generate \
+	    $(ROOT_DIR)/XCHammer.yaml \
+	    --bazel $(ROOT_DIR)/tools/bazelwrapper
 
 clean:
 	rm -rf tmp_build_dir

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ aspects:
 # Copy the tulsi-aspects and XCHammerAssets adjacent to the Xcode build
 # directory to allow loading of resources, since we can't express this in SPM
 #
-# Note: this is brittle and might not work as expected
-workspace_legacy: aspects
+# Note: this is brittle and may not work as expected
+workspace_spm: aspects
 	swift package generate-xcodeproj
 	$(eval BUILD_DIR=$(shell xcodebuild -showBuildSettings \
 			-project XCHammer.xcodeproj/ \
@@ -35,13 +35,19 @@ workspace_legacy: aspects
 	@ditto "$(ASPECTDIR)" "$(BUILD_DIR)/Release/TulsiGenerator.framework"
 	@ditto "$(ASSETDIR)" "$(BUILD_DIR)/Release/$(ASSETDIR)"
 
+
 # Make an XCHammer XCHammer Xcode project.
 #
-# Note: incremental builds are currently not working with Bazel
-workspace: build
+# Note:
+# - incremental builds are currently not working with Bazel
+# - run with `force` for development
+workspace_xchammer: build
 	$(ROOT_DIR)/.build/debug/$(PRODUCT) generate \
 	    $(ROOT_DIR)/XCHammer.yaml \
-	    --bazel $(ROOT_DIR)/tools/bazelwrapper
+	    --bazel $(ROOT_DIR)/tools/bazelwrapper \
+	    --force
+
+workspace: workspace_spm
 
 clean:
 	rm -rf tmp_build_dir
@@ -64,7 +70,7 @@ unsafe_install: archive
 	mkdir -p $(PREFIX)/bin
 	ditto tmp_build_dir/$(PRODUCT) $(PREFIX)/bin/
 
-install: clean archive
+install: archive
 	mkdir -p $(PREFIX)/bin
 	ditto tmp_build_dir/$(PRODUCT) $(PREFIX)/bin/
 

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -449,7 +449,9 @@ public class XcodeTarget: Hashable, Equatable {
         // - dedupe
         // - frameworks shouldn't be injested as a resource or a source
         return Array(Set(resources + structuredResources))
-                .filter { !$0.path.hasSuffix(".framework") }
+            .filter { !$0.path.hasSuffix(".framework") }
+             // FIXME: There is path issue with a subset of BUILD files.
+            .filter { !$0.path.hasSuffix("BUILD") }
     }()
 
     func extractBuiltProductName() -> String {

--- a/XCHammer.yaml
+++ b/XCHammer.yaml
@@ -1,5 +1,5 @@
 targets:
-    - ":xchammer"
+    - "//:xchammer"
 
 projects:
     "xchammer-bazel":


### PR DESCRIPTION
This commit adds the ability to build XCHammer's Xcode project with
XCHammer.

Additionally change `make workspace` to use this instead of SPM.
Incrmental builds aren't 100% out of the box, but we should add that to
Bazel and additionally support building the XCHammer Xcode project with
XCHammer.

The legacy generation command is left until incremental builds are
working.

Known issues with Swift and XCHammer:
- includes in external
- module_name propagation
- `BUILD` file naming edge cases in resources