### PR TITLE
[Focus] Xcode target granuarilty features

### DIFF
--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -55,7 +55,7 @@ enum Generator {
             profiler.logEnd(true)
         }
 
-        let entries: [XcodeGenTarget] = targetMap.includedTargets.compactMap {
+        let entries: [XcodeGenTarget] = targetMap.includedProjectTargets.compactMap {
             xcodeTarget in
             guard let target = makeXcodeGenTarget(from: xcodeTarget) else {
                 return nil
@@ -197,7 +197,12 @@ enum Generator {
         return target
     }
 
-    private static func makeSchemes(for targets: [XcodeTarget], targetMap:
+    /// Generate schemes for Bazel targets
+    /// schemes:
+    /// - automatically build rules tagged `xchammer`
+    /// - automatically update the Xcode project during builds if needed
+    /// - include test dependencies
+    private static func makeXcodeSchemes(for targets: [XcodeTarget], targetMap:
             XcodeTargetMap, genOptions:
             XCHammerGenerateOptions) -> [XcodeScheme] {
         let profiler = XCHammerProfiler("make_schemes")
@@ -214,11 +219,10 @@ enum Generator {
                     outputProjectPath, bazelPath: genOptions.bazelPath,
                     configPath: genOptions.configPath, config:
                     genOptions.config, xcworkspacePath:
-                    genOptions.xcworkspacePath, generateBazelTargets:
-                    genOptions.generateBazelTargets)
+                    genOptions.xcworkspacePath)
             let targetMap = XcodeTargetMap(entryMap: targetMap.ruleEntryMap,
                 genOptions: projectGenOptions)
-            let allApps = targetMap.includedTargets.filter {
+            let allApps = targetMap.includedProjectTargets.filter {
                 $0.type == "ios_application"
             }
             
@@ -287,6 +291,8 @@ enum Generator {
             }
     }
     
+    /// Generate schemes for Bazel targets
+    /// These schemes simply run `bazel build`.
     private static func makeBazelTargetSchemes(for targets: [XcodeTarget], targetMap:
             XcodeTargetMap, genOptions:
             XCHammerGenerateOptions) ->
@@ -301,9 +307,6 @@ enum Generator {
                         ($0, true) })
 
                 let buildTargets = [
-                    XcodeScheme.BuildTarget(target: UpdateXcodeProjectTargetName,
-                            project: genOptions.projectName, productName: ""),
-                ] + [
                     XcodeScheme.BuildTarget(target: name,
                             project: genOptions.projectName, productName:
                             xcodeTarget.extractBuiltProductName() + "-Bazel")
@@ -519,9 +522,6 @@ enum Generator {
         // Get Bazel targets for the specified labels
         let getBazelBuildableTargets: (() -> [XcodeTarget]) = {
             () -> [XcodeTarget] in
-            guard genOptions.generateBazelTargets else {
-                return []
-            }
             let specifiedLabels = Set(genOptions.config.buildTargetLabels)
             return allXCTargets
                 .filter { specifiedLabels.contains($0.value.xcodeTarget.label) }
@@ -552,8 +552,11 @@ enum Generator {
             genOptions: genOptions,
             xcodeProjPath: tempProjectPath)
 
-        let xcSchemes = makeSchemes(for: allXCTargets.values.map { $0.xcodeTarget },
-                targetMap: targetMap, genOptions: genOptions)
+        let projectConfig = genOptions.config
+                .projects[genOptions.projectName]
+        let xcSchemes = (projectConfig?.generateXcodeSchemes ?? true) ?
+            makeXcodeSchemes(for: allXCTargets.values.map { $0.xcodeTarget },
+                    targetMap: targetMap, genOptions: genOptions) : []
 
         let bazelSchemes = makeBazelTargetSchemes(for:
                 bazelBuildableXcodeTargets, targetMap: targetMap, genOptions:
@@ -777,8 +780,7 @@ enum Generator {
     public static func generateProjects(workspaceRootPath: Path, bazelPath: Path,
                                         configPath: Path, config:
                                         XCHammerConfig, xcworkspacePath: Path?,
-                                        force: Bool = false,
-                                        generateBazelTargets: Bool = false) -> Result<(),
+                                        force: Bool = false) -> Result<(),
                 GenerateError> {
         // Listen to Tulsi logs. Assume this function is called 1 time
         NotificationCenter.default.addObserver(forName:
@@ -797,8 +799,7 @@ enum Generator {
                     workspaceRootPath, outputProjectPath:
                     outputProjectPath, bazelPath: bazelPath,
                     configPath: configPath, config: config, xcworkspacePath:
-                    xcworkspacePath, generateBazelTargets:
-                    generateBazelTargets)
+                    xcworkspacePath)
             guard let existingHash = try? getDepsHashSettingValue(projectPath:
                     genOptions.outputProjectPath) else {
                 return (projectName, (false, nil))
@@ -854,8 +855,7 @@ enum Generator {
                     workspaceRootPath, outputProjectPath:
                     outputProjectPath, bazelPath: bazelPath,
                     configPath: configPath, config: config, xcworkspacePath:
-                    xcworkspacePath, generateBazelTargets:
-                    generateBazelTargets)
+                    xcworkspacePath)
 
             let existingState = projectStates[projectName]
             // TODO: (jerry) Propagate transitive project updates to dependees

--- a/Sources/XCHammer/XCHammerConfig.swift
+++ b/Sources/XCHammer/XCHammerConfig.swift
@@ -71,6 +71,34 @@ struct XCHammerProjectConfig: Codable {
     /// @note: this is written into a python program which is later
     /// serialized. Spaces and escapes matter.
     let buildBazelPlatformOptions: [String: [String]]?
+
+    /// Enable generation of transitive Xcode targets.
+    /// Defaults to `true`
+    /// @note this is _generally_ required for Xcode projects to build with
+    /// Xcode.
+    /// For Non Xcode enabled C++/C/ObjC projects, header search paths are
+    /// propagated so that / indexing, code completion, and other semantic
+    /// features work.
+    let generateTransitiveXcodeTargets: Bool
+
+    /// Enable generation of transitive Xcode schemes
+    /// Defaults to `true`
+    let generateXcodeSchemes: Bool
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        paths = try container.decode(
+                [String]?.self, forKey: .paths)
+
+        buildBazelPlatformOptions = try? container.decode(
+                [String: [String]].self, forKey: .paths)
+
+        generateXcodeSchemes = (try? container.decode(
+                Bool.self, forKey: .generateXcodeSchemes)) ?? true
+
+        generateTransitiveXcodeTargets = (try? container.decode(
+                Bool.self, forKey: .generateTransitiveXcodeTargets)) ?? true
+    }
 }
 
 struct XCHammerConfig: Codable {

--- a/Sources/XCHammer/XCHammerGenerateOptions.swift
+++ b/Sources/XCHammer/XCHammerGenerateOptions.swift
@@ -28,8 +28,6 @@ struct XCHammerGenerateOptions {
 
     let xcworkspacePath: Path?
 
-    let generateBazelTargets: Bool
-
     var workspaceEnabled: Bool {
         return xcworkspacePath != nil
     }
@@ -43,5 +41,4 @@ struct XCHammerGenerateOptions {
         return outputProjectPath.lastComponentWithoutExtension
     }
 }
-
 

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -67,8 +67,6 @@ let DirectoriesAsFileSuffixes: [String] = [
     "lproj",
 ]
 
-
-
 func includeTarget(_ xcodeTarget: XcodeTarget, pathPredicate: (String) -> Bool) -> Bool {
     guard let buildFilePath = xcodeTarget.buildFilePath else {
         return false
@@ -826,12 +824,16 @@ public class XcodeTarget: Hashable, Equatable {
             }
             return target
         }
-
         return xcodeTargetDeps
-            .filter { includeTarget($0, pathPredicate: alwaysIncludePathPredicate) }
-            .compactMap { ProjectSpec.Dependency(type: .target, reference: $0.xcTargetName,
-                    embed:
-                    $0.isExtension) } + self.frameworkDependencies
+            .compactMap {
+                xcodeTarget in
+                guard targetMap.includedTargets.contains(xcodeTarget) else {
+                    return nil
+                }
+                return ProjectSpec.Dependency(type: .target, reference:
+                        xcodeTarget.xcTargetName, embed:
+                        xcodeTarget.isExtension)
+            } + self.frameworkDependencies
     }()
 
     lazy var frameworkDependencies: [ProjectSpec.Dependency] = {
@@ -994,10 +996,20 @@ public class XcodeTarget: Hashable, Equatable {
     fileprivate var xcExtensionDeps: [ProjectSpec.Dependency] {
         // Assume extensions are contained in the same workspace
         return extensions
-            .compactMap { targetMap.xcodeTarget(buildLabel: $0, depender: self) }
-            .map {
-                var mutableDep = ProjectSpec.Dependency(type: .target, reference: $0.xcTargetName,
-                                               embed: $0.isExtension)
+            .compactMap {
+                label -> XcodeTarget? in
+                guard let target = targetMap.xcodeTarget(buildLabel: label,
+                        depender: self) else {
+                    return nil 
+                }
+                guard targetMap.includedProjectTargets.contains(target) else {
+                    return nil  
+                }
+                return target
+            }.map {
+                xcodeTarget in
+                var mutableDep = ProjectSpec.Dependency(type: .target,
+                        reference: xcodeTarget.xcTargetName, embed: xcodeTarget.isExtension)
                 mutableDep.codeSign = false
                 return mutableDep
             }

--- a/Sources/XCHammer/main.swift
+++ b/Sources/XCHammer/main.swift
@@ -40,6 +40,10 @@ func getHammerConfig(path: Path) throws -> XCHammerConfig {
     return config
 }
 
+/// XCHammer generate options
+/// 
+/// Options for generation only.
+/// Configuration options for Xcode projects are part of `XCHammerConfig`
 struct GenerateOptions: OptionsProtocol {
     typealias ClientError = CommandError
 
@@ -47,7 +51,6 @@ struct GenerateOptions: OptionsProtocol {
     let workspaceRootPath: Path
     let bazelPath: Path
     let forceRun: Bool
-    let generateBazelTargets: Bool
     let xcworkspacePath: Path?
 
     private static func getEnvBazelPath() throws -> Path {
@@ -55,9 +58,9 @@ struct GenerateOptions: OptionsProtocol {
         return Path(path)
     }
 
-    static func create(_ configPath: Path) -> (Path?) -> (Path?) -> (Bool) -> (Bool) -> (Path?) -> GenerateOptions {
+    static func create(_ configPath: Path) -> (Path?) -> (Path?) -> (Bool) -> (Path?) -> GenerateOptions {
         return { workspaceRootPathOpt in { bazelPathOpt in {
-            forceRunOpt in { generateBazelTargetsOpt in { xcworkspacePathOpt -> GenerateOptions in
+            forceRunOpt in { xcworkspacePathOpt -> GenerateOptions in
                 // Defaults to PWD
                 let workspaceRootPath: Path = workspaceRootPathOpt?.normalize() ??
                     Path(FileManager.default.currentDirectoryPath)
@@ -78,10 +81,9 @@ struct GenerateOptions: OptionsProtocol {
                 workspaceRootPath: workspaceRootPath,
                 bazelPath: bazelPath,
                 forceRun: forceRunOpt,
-                generateBazelTargets: generateBazelTargetsOpt,
                 xcworkspacePath: xcworkspacePathOpt?.normalize()
             )
-        } } } } }
+        } } } } 
     }
 
     static func evaluate(_ m: CommandMode) -> Result<GenerateOptions, CommandantError<ClientError>> {
@@ -93,8 +95,6 @@ struct GenerateOptions: OptionsProtocol {
                  usage: "Path to the bazel binary")
             <*> m <| Option(key: "force", defaultValue: false,
                  usage: "Force run the generator")
-            <*> m <| Option(key: "generate_bazel_targets", defaultValue: true,
-                 usage: "Experimental generate bazel targets")
             <*> m <| Option(key: "xcworkspace", defaultValue: nil,
                  usage: "Path to the xcworkspace")
     }
@@ -113,7 +113,7 @@ struct GenerateCommand: CommandProtocol {
                     options.workspaceRootPath, bazelPath: options.bazelPath,
                     configPath: options.configPath, config: config,
                     xcworkspacePath: options.xcworkspacePath, force:
-                    options.forceRun, generateBazelTargets: options.generateBazelTargets)
+                    options.forceRun)
             switch result {
             case .success:
                 return .success(())


### PR DESCRIPTION
This commit makes it easier to configure larger XCHammer workspaces.

When a project get's too large, it slows down the users computer for
many reasons. Indexing and project generation times are slower due to
the size of the Xcode project.

This commit adds a few abilities to make Xcode projects with better
experiences:

`generateTransitiveXcodeTargets` - by default, XCHammer includes all
transitive Xcode targets. If this is disabled, it only generates Xcode
Targets specified in the config file.

`generateXcodeSchemes` - enable to generation of Xcode schemes.
By default, this is enabled.

In the new `focus` workspace, it builds exclusively with Bazel.
This gives it faster build times, and better cachability. Semantic
editor features still work, as all header search paths are propagated.

Additionally, it cleans up `generate_bazel_targets` flag. This flag
doesn't belong on `GenerateOptions`.