### PR TITLE
Use Swift stub file for targets with zero files and swift dependencies

### DIFF
--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -423,7 +423,15 @@ enum Generator {
                 genOptions.outputProjectPath)
         guard FileManager.default.createFile(atPath: stubPath,
                 contents: "".data(using: .utf8), attributes: nil) else {
-             fatalError("Can't write temp stub")
+             fatalError("Can't write temp objc stub")
+        }
+
+
+        let stubPathSwift = XCHammerAsset.stubImpSwift.getPath(underProj:
+            genOptions.outputProjectPath)
+        guard FileManager.default.createFile(atPath: stubPathSwift,
+                                             contents: "".data(using: .utf8), attributes: nil) else {
+                                                fatalError("Can't write temp swift stub")
         }
 
         let allXCTargets: [String: XcodeGenTarget] = makeTargets(targetMap:

--- a/Sources/XCHammer/XCHammerAsset.swift
+++ b/Sources/XCHammer/XCHammerAsset.swift
@@ -20,6 +20,9 @@ enum XCHammerAsset: String {
     /// An empty .m file
     case stubImp = "Stub.m"
 
+    /// An empty .swift file
+    case stubImpSwift = "Stub.swift"
+
     /// A code signing script used for Ad-Hoc code signing
     case codesigner = "codesigner.sh"
     

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -323,9 +323,11 @@ public class XcodeTarget: Hashable, Equatable {
         let resources = self.xcResources
         let bundles = self.xcBundles
 
+
+        let stubAsset = self.settings.swiftVersion == nil ?  XCHammerAsset.stubImp : XCHammerAsset.stubImpSwift
         let all: [ProjectSpec.TargetSource] = resources + nonArcFiles + (sourceFiles.filter { !$0.path.hasSuffix("h") }.count > 0 ?
             sourceFiles :
-            [ProjectSpec.TargetSource(path: XCHammerAsset.stubImp.getPath(underProj:
+            [ProjectSpec.TargetSource(path: stubAsset.getPath(underProj:
                     self.genOptions.outputProjectPath), compilerFlags: ["-x objective-c", "-std=gnu99"])]
         ) + bundles
         let s: Set<ProjectSpec.TargetSource> = Set(all)

--- a/XCHammerAssets/Stub.swift
+++ b/XCHammerAssets/Stub.swift
@@ -1,0 +1,1 @@
+// @generated If all you've got is Xcode, your only tool is a 🔨


### PR DESCRIPTION
- Adds new asset (Stub.swift)
- Should apply only to targets with swift dependencies
- Fixes swift sample project (Tailor)