### PR TITLE
Clarify supported XCHammer build system

### DIFF
--- a/Docs/XCHammerFAQ.md
+++ b/Docs/XCHammerFAQ.md
@@ -65,6 +65,9 @@ adding examples of edge cases and bugs here :). Pull requests welcome!*
 
 ### How can I develop XCHammer with Xcode?
 
+_The canonical, tested, build system of XCHammer is `make`. Xcode projects are
+currently under development._
+
 To generate an Xcode project, use the make command, `make workspace`. 
 
 *Running*
@@ -81,3 +84,33 @@ are required.
 ```
 _note: Currently, there are multiple issues using the SPM generated workspace,
 which will be fixed upon supporting XCHammer in XCHammer._ 
+
+
+## Misc
+
+### How can I build XCHammer with Bazel?
+
+_The canonical, tested, build system of XCHammer is `make`. Bazel support is
+currently under development._
+
+Add the following to `WORKSPACE` file
+```python
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "xchammer",
+    remote  = "https://github.com/pinterest/xchammer",
+    tag = "0.2"
+)
+
+load("@xchammer:third_party:repositories.bzl", "xchammer_dependencies")
+
+xchammer_dependencies()
+```
+
+Then, run `bazel build @xchammer//:xchammer` to compile from source to build a
+debug version.
+
+For release builds, build with compiler optimizations including setting
+`--compilation_mode=opt`.
+

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ aspects:
 
 
 # Make a SPM generated Xcode project.
-# cause problems.
+#
 # Copy the tulsi-aspects and XCHammerAssets adjacent to the Xcode build
 # directory to allow loading of resources, since we can't express this in SPM
 #
@@ -39,6 +39,7 @@ workspace_spm: aspects
 # Make an XCHammer XCHammer Xcode project.
 #
 # Note:
+# - this is under development and doesn't fully work
 # - incremental builds are currently not working with Bazel
 # - run with `force` for development
 workspace_xchammer: build

--- a/README.md
+++ b/README.md
@@ -17,27 +17,6 @@ You can clone the xchammer repository and run the following to build and install
 make install
 ```
 
-Alternatively, you can integrate xchammer in your existing bazel project if you prefer to use `bazel run` to invoke xchammer.
-
-Add the following to your `WORKSPACE` file
-```python
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-
-git_repository(
-    name = "xchammer",
-    remote  = "https://github.com/pinterest/xchammer",
-    tag = "0.2"
-)
-
-load("@xchammer:third_party:repositories.bzl", "xchammer_dependencies")
-
-xchammer_dependencies()
-```
-
-Then you can run `bazel build @xchammer//:xchammer` to compile from source to build a debug version of xchammer.
-
-For production, please build with `--compilation_mode=opt` to significantly speed up project generation times.
-
 ### Configuration
 
 Generate using a [XCHammerConfig](https://github.com/pinterest/xchammer/blob/master/Sources/XCHammer/XCHammerConfig.swift).


### PR DESCRIPTION
Currently the supported build system of XCHammer is `make`. There are a
few blockers to using Bazel for XCHammer:

- XCHammer assets don't load correctly.
- Incremental builds don't work.
- Test coverage / move to Bazel build in Pinterest.
- It should generate a working project

Additionally, remove advice suggesting to use Bazel from the `README`.