### PR TITLE
Use point in time master for rules_swift

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,7 +16,7 @@ apple_rules_dependencies()
 git_repository(
     name = "build_bazel_rules_swift",
     remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.3.1",
+    commit = "8f594d9a9b39ce471064cc13d35c07ea77a24628",
 )
 
 load(

--- a/sample/Tailor/WORKSPACE
+++ b/sample/Tailor/WORKSPACE
@@ -16,7 +16,7 @@ apple_rules_dependencies()
 git_repository(
     name = "build_bazel_rules_swift",
     remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.3.1",
+    commit = "8f594d9a9b39ce471064cc13d35c07ea77a24628",
 )
 
 load(

--- a/sample/WorkspaceSource/WORKSPACE
+++ b/sample/WorkspaceSource/WORKSPACE
@@ -17,7 +17,7 @@ apple_rules_dependencies()
 git_repository(
     name = "build_bazel_rules_swift",
     remote = "https://github.com/bazelbuild/rules_swift.git",
-    tag = "0.3.0",
+    commit = "8f594d9a9b39ce471064cc13d35c07ea77a24628",
 )
 
 load(


### PR DESCRIPTION
Use master `rules_swift` (as of today). The last release tag is almost 3 months old.

Of note, rules_swift has since added support to enable batch mode by default for Xcode 10. There have been recent discussions about incremental builds for xchammer, but with batch mode enabled, a change to a `Sources/***.swift` takes about ~8-9s to compile on my machine.