### PR TITLE
Revert "Don't require xcodegen settings preset files. All configuration should be (#84)"

### DIFF
--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests-Bazel.xcscheme
@@ -14,7 +14,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests-Bazel.xcscheme
                BlueprintIdentifier = "LT_691292342913"
+=======
+               BlueprintIdentifier = "LT_629454187867"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests-Bazel.xcscheme
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
@@ -14,7 +14,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BlueprintIdentifier = "LT_691292342913"
+=======
+               BlueprintIdentifier = "LT_629454187867"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +32,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BlueprintIdentifier = "LT_816521859601"
+=======
+               BlueprintIdentifier = "LT_879714440108"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BuildableName = "GeneratedFiles"
                BlueprintName = "GeneratedFiles"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -42,7 +50,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BlueprintIdentifier = "LT_456825327596"
+=======
+               BlueprintIdentifier = "LT_535582595715"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BuildableName = "ResetLLDBInit"
                BlueprintName = "ResetLLDBInit"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -56,7 +68,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BlueprintIdentifier = "NT_338352280519"
+=======
+               BlueprintIdentifier = "NT_757956135481"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BuildableName = "ios-app.app"
                BlueprintName = "ios-app"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -70,7 +86,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BlueprintIdentifier = "NT_851294388355"
+=======
+               BlueprintIdentifier = "NT_863786754985"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BuildableName = "UITests.xctest"
                BlueprintName = "UITests"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -88,7 +108,11 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BlueprintIdentifier = "NT_851294388355"
+=======
+               BlueprintIdentifier = "NT_863786754985"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
                BuildableName = "UITests.xctest"
                BlueprintName = "UITests"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -98,7 +122,11 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
             BlueprintIdentifier = "NT_851294388355"
+=======
+            BlueprintIdentifier = "NT_863786754985"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
             BuildableName = "UITests.xctest"
             BlueprintName = "UITests"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -121,7 +149,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
             BlueprintIdentifier = "NT_851294388355"
+=======
+            BlueprintIdentifier = "NT_863786754985"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
             BuildableName = "UITests.xctest"
             BlueprintName = "UITests"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -140,7 +172,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
             BlueprintIdentifier = "NT_851294388355"
+=======
+            BlueprintIdentifier = "NT_863786754985"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
             BuildableName = "UITests.xctest"
             BlueprintName = "UITests"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
@@ -14,7 +14,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
                BlueprintIdentifier = "LT_691292342913"
+=======
+               BlueprintIdentifier = "LT_629454187867"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -14,7 +14,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
                BlueprintIdentifier = "LT_691292342913"
+=======
+               BlueprintIdentifier = "LT_629454187867"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +32,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
                BlueprintIdentifier = "LT_816521859601"
+=======
+               BlueprintIdentifier = "LT_879714440108"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
                BuildableName = "GeneratedFiles"
                BlueprintName = "GeneratedFiles"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -42,7 +50,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
                BlueprintIdentifier = "LT_456825327596"
+=======
+               BlueprintIdentifier = "LT_535582595715"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
                BuildableName = "ResetLLDBInit"
                BlueprintName = "ResetLLDBInit"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -56,7 +68,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
                BlueprintIdentifier = "NT_552197308206"
+=======
+               BlueprintIdentifier = "NT_162101825678"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
                BuildableName = "UnitTests.xctest"
                BlueprintName = "UnitTests"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -74,7 +90,11 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
                BlueprintIdentifier = "NT_552197308206"
+=======
+               BlueprintIdentifier = "NT_162101825678"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
                BuildableName = "UnitTests.xctest"
                BlueprintName = "UnitTests"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -84,7 +104,11 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
             BlueprintIdentifier = "NT_552197308206"
+=======
+            BlueprintIdentifier = "NT_162101825678"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
             BuildableName = "UnitTests.xctest"
             BlueprintName = "UnitTests"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -107,7 +131,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
             BlueprintIdentifier = "NT_552197308206"
+=======
+            BlueprintIdentifier = "NT_162101825678"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
             BuildableName = "UnitTests.xctest"
             BlueprintName = "UnitTests"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -126,7 +154,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
             BlueprintIdentifier = "NT_552197308206"
+=======
+            BlueprintIdentifier = "NT_162101825678"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
             BuildableName = "UnitTests.xctest"
             BlueprintName = "UnitTests"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost-Bazel.xcscheme
@@ -14,7 +14,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost-Bazel.xcscheme
                BlueprintIdentifier = "LT_691292342913"
+=======
+               BlueprintIdentifier = "LT_629454187867"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost-Bazel.xcscheme
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
@@ -14,7 +14,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BlueprintIdentifier = "LT_691292342913"
+=======
+               BlueprintIdentifier = "LT_629454187867"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +32,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BlueprintIdentifier = "LT_816521859601"
+=======
+               BlueprintIdentifier = "LT_879714440108"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BuildableName = "GeneratedFiles"
                BlueprintName = "GeneratedFiles"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -42,7 +50,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BlueprintIdentifier = "LT_456825327596"
+=======
+               BlueprintIdentifier = "LT_535582595715"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BuildableName = "ResetLLDBInit"
                BlueprintName = "ResetLLDBInit"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -56,7 +68,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BlueprintIdentifier = "NT_338352280519"
+=======
+               BlueprintIdentifier = "NT_757956135481"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BuildableName = "ios-app.app"
                BlueprintName = "ios-app"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -70,7 +86,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BlueprintIdentifier = "NT_448073995915"
+=======
+               BlueprintIdentifier = "NT_394586624846"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BuildableName = "UnitTestsWithHost.xctest"
                BlueprintName = "UnitTestsWithHost"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -88,7 +108,11 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BlueprintIdentifier = "NT_448073995915"
+=======
+               BlueprintIdentifier = "NT_394586624846"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
                BuildableName = "UnitTestsWithHost.xctest"
                BlueprintName = "UnitTestsWithHost"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -98,7 +122,11 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
             BlueprintIdentifier = "NT_448073995915"
+=======
+            BlueprintIdentifier = "NT_394586624846"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
             BuildableName = "UnitTestsWithHost.xctest"
             BlueprintName = "UnitTestsWithHost"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -121,7 +149,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
             BlueprintIdentifier = "NT_448073995915"
+=======
+            BlueprintIdentifier = "NT_394586624846"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
             BuildableName = "UnitTestsWithHost.xctest"
             BlueprintName = "UnitTestsWithHost"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -140,7 +172,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
             BlueprintIdentifier = "NT_448073995915"
+=======
+            BlueprintIdentifier = "NT_394586624846"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
             BuildableName = "UnitTestsWithHost.xctest"
             BlueprintName = "UnitTestsWithHost"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
@@ -14,7 +14,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
                BlueprintIdentifier = "LT_691292342913"
+=======
+               BlueprintIdentifier = "LT_629454187867"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +32,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
                BlueprintIdentifier = "NT_600615860046"
+=======
+               BlueprintIdentifier = "NT_700633204216"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
                BuildableName = "ios-app-Bazel.app"
                BlueprintName = "ios-app-Bazel"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -46,7 +54,11 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
             BlueprintIdentifier = "NT_600615860046"
+=======
+            BlueprintIdentifier = "NT_700633204216"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
             BuildableName = "ios-app-Bazel.app"
             BlueprintName = "ios-app-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -69,7 +81,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
             BlueprintIdentifier = "NT_600615860046"
+=======
+            BlueprintIdentifier = "NT_700633204216"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
             BuildableName = "ios-app-Bazel.app"
             BlueprintName = "ios-app-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -88,7 +104,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
             BlueprintIdentifier = "NT_600615860046"
+=======
+            BlueprintIdentifier = "NT_700633204216"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
             BuildableName = "ios-app-Bazel.app"
             BlueprintName = "ios-app-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
@@ -14,7 +14,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BlueprintIdentifier = "LT_691292342913"
+=======
+               BlueprintIdentifier = "LT_629454187867"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +32,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BlueprintIdentifier = "LT_816521859601"
+=======
+               BlueprintIdentifier = "LT_879714440108"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BuildableName = "GeneratedFiles"
                BlueprintName = "GeneratedFiles"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -42,7 +50,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BlueprintIdentifier = "LT_456825327596"
+=======
+               BlueprintIdentifier = "LT_535582595715"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BuildableName = "ResetLLDBInit"
                BlueprintName = "ResetLLDBInit"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -56,7 +68,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BlueprintIdentifier = "NT_338352280519"
+=======
+               BlueprintIdentifier = "NT_757956135481"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BuildableName = "ios-app.app"
                BlueprintName = "ios-app"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -74,9 +90,15 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BlueprintIdentifier = "NT_851294388355"
                BuildableName = "UITests.xctest"
                BlueprintName = "UITests"
+=======
+               BlueprintIdentifier = "NT_162101825678"
+               BuildableName = "UnitTests.xctest"
+               BlueprintName = "UnitTests"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                ReferencedContainer = "container:UrlGet.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -84,9 +106,15 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BlueprintIdentifier = "NT_448073995915"
                BuildableName = "UnitTestsWithHost.xctest"
                BlueprintName = "UnitTestsWithHost"
+=======
+               BlueprintIdentifier = "NT_863786754985"
+               BuildableName = "UITests.xctest"
+               BlueprintName = "UITests"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                ReferencedContainer = "container:UrlGet.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -94,9 +122,15 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                BlueprintIdentifier = "NT_552197308206"
                BuildableName = "UnitTests.xctest"
                BlueprintName = "UnitTests"
+=======
+               BlueprintIdentifier = "NT_394586624846"
+               BuildableName = "UnitTestsWithHost.xctest"
+               BlueprintName = "UnitTestsWithHost"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
                ReferencedContainer = "container:UrlGet.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -104,7 +138,11 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
             BlueprintIdentifier = "NT_338352280519"
+=======
+            BlueprintIdentifier = "NT_757956135481"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
             BuildableName = "ios-app.app"
             BlueprintName = "ios-app"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -127,7 +165,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
             BlueprintIdentifier = "NT_338352280519"
+=======
+            BlueprintIdentifier = "NT_757956135481"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
             BuildableName = "ios-app.app"
             BlueprintName = "ios-app"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -146,7 +188,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
             BlueprintIdentifier = "NT_338352280519"
+=======
+            BlueprintIdentifier = "NT_757956135481"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
             BuildableName = "ios-app.app"
             BlueprintName = "ios-app"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
@@ -14,7 +14,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
                BlueprintIdentifier = "LT_691292342913"
+=======
+               BlueprintIdentifier = "LT_629454187867"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
                BuildableName = "UpdateXcodeProject"
                BlueprintName = "UpdateXcodeProject"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -28,7 +32,11 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
                BlueprintIdentifier = "NT_599970967680"
+=======
+               BlueprintIdentifier = "NT_424996891355"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
                BuildableName = "share-extension-Bazel.appex"
                BlueprintName = "share-extension-Bazel"
                ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -46,7 +54,11 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
             BlueprintIdentifier = "NT_599970967680"
+=======
+            BlueprintIdentifier = "NT_424996891355"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
             BuildableName = "share-extension-Bazel.appex"
             BlueprintName = "share-extension-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -69,7 +81,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
             BlueprintIdentifier = "NT_599970967680"
+=======
+            BlueprintIdentifier = "NT_424996891355"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
             BuildableName = "share-extension-Bazel.appex"
             BlueprintName = "share-extension-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">
@@ -88,7 +104,11 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
+<<<<<<< HEAD:IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
             BlueprintIdentifier = "NT_599970967680"
+=======
+            BlueprintIdentifier = "NT_424996891355"
+>>>>>>> parent of ed81cc2... Don't require xcodegen settings preset files. All configuration should be (#84):sample/UrlGet/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
             BuildableName = "share-extension-Bazel.appex"
             BlueprintName = "share-extension-Bazel"
             ReferencedContainer = "container:UrlGet.xcodeproj">

--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -514,7 +514,6 @@ enum Generator {
         let options = SpecOptions(
                 carthageBuildPath: nil,
                 createIntermediateGroups: true,
-                settingPresets: .none,
                 indentWidth: 4,
                 tabWidth: 4,
                 usesTabs: false

--- a/Sources/XCHammer/OrderedArray.swift
+++ b/Sources/XCHammer/OrderedArray.swift
@@ -48,7 +48,7 @@ struct OrderedArray<T: Hashable>: Sequence {
 
 extension OrderedArray: ExpressibleByArrayLiteral {
     typealias ArrayLiteralElement = Element
-
+    
     init(arrayLiteral elements: T...) {
         self.init(elements)
     }

--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -129,9 +129,6 @@ struct Setting<T: XCSettingStringEncodeable & Semigroup>: Semigroup {
     }
 }
 
-
-
-
 struct XCBuildSettings: Encodable {
     var copts: [String] = []
     var productName: First<String>?
@@ -168,11 +165,6 @@ struct XCBuildSettings: Encodable {
     var swiftCopts: [String] = []
     var testTargetName: First<String>?
     var pythonPath: First<String>?
-    var sdkRoot: First<String>?
-    var targetedDeviceFamily: OrderedArray<String> = OrderedArray.empty
-
-
-
 
     enum CodingKeys: String, CodingKey {
         // Add to this list the known XCConfig keys
@@ -213,9 +205,6 @@ struct XCBuildSettings: Encodable {
         case codeSignEntitlementsFile = "HAMMER_ENTITLEMENTS_FILE"
         case mobileProvisionProfileFile = "HAMMER_PROFILE_FILE"
         case tulsiWR = "TULSI_WR"
-        case sdkRoot = "SDKROOT"
-        case targetedDeviceFamily = "TARGETED_DEVICE_FAMILY"
-        
     }
 
     func encode(to encoder: Encoder) throws {
@@ -260,8 +249,8 @@ struct XCBuildSettings: Encodable {
         try useHeaderMap.map { try container.encode($0.v, forKey: .useHeaderMap) }
         try testTargetName.map { try container.encode($0.v, forKey: .testTargetName) }
         try pythonPath.map { try container.encode($0.v, forKey: .pythonPath) }
-        try sdkRoot.map { try container.encode($0.v, forKey: .sdkRoot) }
-        try container.encode(targetedDeviceFamily.joined(separator: ","), forKey: .targetedDeviceFamily)
+        //try sdkRoot.map { try container.encode($0.v, forKey: .sdkRoot) }
+        //try container.encode(targetedDeviceFamily.joined(separator: ","), forKey: .targetedDeviceFamily)
         try swiftVersion.map { try container.encode($0.v, forKey: .swiftVersion) }
 
         // XCHammer only supports Xcode projects at the root directory
@@ -309,9 +298,7 @@ extension XCBuildSettings: Monoid {
             swiftVersion: lhs.swiftVersion <> rhs.swiftVersion,
             swiftCopts: lhs.swiftCopts <> rhs.swiftCopts,
             testTargetName: lhs.testTargetName <> rhs.testTargetName,
-            pythonPath: lhs.pythonPath <> rhs.pythonPath,
-            sdkRoot: lhs.sdkRoot <> rhs.sdkRoot,
-            targetedDeviceFamily: lhs.targetedDeviceFamily <> rhs.targetedDeviceFamily
+            pythonPath: lhs.pythonPath <> rhs.pythonPath
         )
     }
 


### PR DESCRIPTION
This reverts commit ed81cc27408a06f230db649950a16f41c3f0d2ec.

This commit caused build errors in Pinterest that weren't tested in the
OSS CI. This PR is simply documentation of the issue.

The outcome of addresssing this PR is to understand _why_ it happened,
and finding the best solution to address it.