### PR TITLE
Export filtered diagnostic flags

### DIFF
--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -170,9 +170,7 @@ struct XCBuildSettings: Encodable {
     var pythonPath: First<String>?
     var sdkRoot: First<String>?
     var targetedDeviceFamily: OrderedArray<String> = OrderedArray.empty
-
-
-
+    var diagnosticFlags: [String] = []
 
     enum CodingKeys: String, CodingKey {
         // Add to this list the known XCConfig keys
@@ -212,6 +210,7 @@ struct XCBuildSettings: Encodable {
         // Hammer Rules
         case codeSignEntitlementsFile = "HAMMER_ENTITLEMENTS_FILE"
         case mobileProvisionProfileFile = "HAMMER_PROFILE_FILE"
+        case diagnosticFlags = "HAMMER_DIAGNOSTIC_FLAGS"
         case tulsiWR = "TULSI_WR"
         case sdkRoot = "SDKROOT"
         case targetedDeviceFamily = "TARGETED_DEVICE_FAMILY"
@@ -266,6 +265,7 @@ struct XCBuildSettings: Encodable {
 
         // XCHammer only supports Xcode projects at the root directory
         try container.encode("$SOURCE_ROOT", forKey: .tulsiWR)
+        try container.encode(diagnosticFlags.joined(separator: " "), forKey: .diagnosticFlags)
     }
 }
 
@@ -311,7 +311,9 @@ extension XCBuildSettings: Monoid {
             testTargetName: lhs.testTargetName <> rhs.testTargetName,
             pythonPath: lhs.pythonPath <> rhs.pythonPath,
             sdkRoot: lhs.sdkRoot <> rhs.sdkRoot,
-            targetedDeviceFamily: lhs.targetedDeviceFamily <> rhs.targetedDeviceFamily
+            targetedDeviceFamily: lhs.targetedDeviceFamily <>
+                rhs.targetedDeviceFamily,
+            diagnosticFlags: lhs.diagnosticFlags <> rhs.diagnosticFlags
         )
     }
 

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -665,10 +665,11 @@ public class XcodeTarget: Hashable, Equatable {
         // Delegate warnings and error compiler options for targets that have a
         // xcconfig.
         let configs = getXCConfigFiles(for: self)
+
+        settings.diagnosticFlags <>=  settings.copts.filter { $0.hasPrefix("-W") }
         if configs.keys.count > 0 {
             settings.copts = ["$(inherited)"] + settings.copts.filter { !$0.hasPrefix("-W") }
         }
-
         // Framework Search Paths
         settings.frameworkSearchPaths <>= ["$(inherited)",
             "$(PLATFORM_DIR)/Developer/Library/Frameworks"] <>


### PR DESCRIPTION
Previously, we used a combination of `SettingsPresets` _and_ `xcconfig` to configure the Xcode build settings. With the recent change of just supporting xcconfigs, it wasn't possible to customize `OTHER_CFLAGS` in a way that would work without generated `Diags.bzl` files. This is useful for making custom `xcconfigs` and passing in `HAMMER_DIAGNOSTIC_FLAGS`

Lastly, it enables us to update XCHammer without reverting the `SettingsPresest` commit.