### PR TITLE
Swift dependency example

### DIFF
--- a/IntegrationTests/Goldmaster/SnapshotMe.xcodeproj/project.pbxproj
+++ b/IntegrationTests/Goldmaster/SnapshotMe.xcodeproj/project.pbxproj
@@ -7,230 +7,182 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BF_176734918964 = {isa = PBXBuildFile; fileRef = FR_809175072387 /* ios-app-Bazel.app */; };
-		BF_232865863116 = {isa = PBXBuildFile; fileRef = FR_236762361925 /* ios-app.app */; };
-		BF_558624455318 /* libios-app-main.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_213277108087 /* libios-app-main.a */; };
-		BF_567361908666 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_475309967935 /* main.m */; };
-		BF_574809499347 = {isa = PBXBuildFile; fileRef = FR_162679830612 /* ios-app-main.a */; };
-		BF_626539152188 = {isa = PBXBuildFile; fileRef = FR_460641534196 /* UnitTests.xctest */; };
-		BF_648862842090 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_376207894502 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_650702818016 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_263655108168 /* AppDelegate.m */; };
-		BF_760452161575 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_913276428123 /* Tests2.m */; };
-		BF_812089772077 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_425869666354 /* Tests.m */; };
-		BF_914802105765 /* libiOSSnapshotTestCase-Core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_918847181843 /* libiOSSnapshotTestCase-Core.a */; };
+		BF_126952534939 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_408828598481 /* AppDelegate.m */; };
+		BF_152068055799 /* libiOSSnapshotTestCase-Core.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_889971147432 /* libiOSSnapshotTestCase-Core.a */; };
+		BF_221045536046 = {isa = PBXBuildFile; fileRef = FR_522766133491 /* ios-app-main.a */; };
+		BF_455942971315 = {isa = PBXBuildFile; fileRef = FR_326755382182 /* ios-app-Bazel.app */; };
+		BF_458700137986 = {isa = PBXBuildFile; fileRef = FR_878559585834 /* ios-app.app */; };
+		BF_496214899859 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_899990382606 /* Tests.m */; };
+		BF_526977936241 = {isa = PBXBuildFile; fileRef = FR_396434231687 /* UnitTests.xctest */; };
+		BF_553451473888 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_846437024042 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_712853203816 /* libios-app-main.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_489979286293 /* libios-app-main.a */; };
+		BF_862876833720 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_668688117890 /* main.m */; };
+		BF_919227748211 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_549335309428 /* Tests2.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		FR_162679830612 /* ios-app-main.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-app-main.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_213277108087 /* libios-app-main.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-app-main.a"; sourceTree = "<group>"; };
-		FR_236762361925 /* ios-app.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_245040708962 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_262810003713 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
-		FR_263655108168 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
-		FR_376207894502 /* Stub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Stub.m; sourceTree = "<group>"; };
-		FR_425869666354 /* Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
-		FR_460641534196 /* UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_475309967935 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		FR_809175072387 /* ios-app-Bazel.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app-Bazel.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_913276428123 /* Tests2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests2.m; sourceTree = "<group>"; };
-		FR_918847181843 /* libiOSSnapshotTestCase-Core.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libiOSSnapshotTestCase-Core.a"; sourceTree = "<group>"; };
+		FR_326755382182 /* ios-app-Bazel.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app-Bazel.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_396434231687 /* UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_408828598481 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		FR_489979286293 /* libios-app-main.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-app-main.a"; sourceTree = "<group>"; };
+		FR_522766133491 /* ios-app-main.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-app-main.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_549335309428 /* Tests2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests2.m; sourceTree = "<group>"; };
+		FR_668688117890 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		FR_681878669379 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		FR_784317858093 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FR_846437024042 /* Stub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Stub.m; sourceTree = "<group>"; };
+		FR_878559585834 /* ios-app.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_889971147432 /* libiOSSnapshotTestCase-Core.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libiOSSnapshotTestCase-Core.a"; sourceTree = "<group>"; };
+		FR_899990382606 /* Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		FBP_23676236192 /* Frameworks */ = {
+		FBP_39643423168 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_558624455318 /* libios-app-main.a in Frameworks */,
+				BF_152068055799 /* libiOSSnapshotTestCase-Core.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_46064153419 /* Frameworks */ = {
+		FBP_87855958583 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_914802105765 /* libiOSSnapshotTestCase-Core.a in Frameworks */,
+				BF_712853203816 /* libios-app-main.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		G_1548492089206 = {
+		G_1286414327561 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				G_2367623619254 /* ios-app */,
-				G_7150104396987 /* SnapshotMe.xcodeproj */,
-				G_2332380321410 /* Frameworks */,
-				G_2054540523939 /* Products */,
+				FR_326755382182 /* ios-app-Bazel.app */,
+				FR_522766133491 /* ios-app-main.a */,
+				FR_878559585834 /* ios-app.app */,
+				FR_396434231687 /* UnitTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		G_1647083107933 /* XCHammerAssets */ = {
+			isa = PBXGroup;
+			children = (
+				FR_846437024042 /* Stub.m */,
+			);
+			path = XCHammerAssets;
+			sourceTree = "<group>";
+		};
+		G_3911002726085 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				FR_489979286293 /* libios-app-main.a */,
+				FR_889971147432 /* libiOSSnapshotTestCase-Core.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		G_4723145104206 /* SnapshotMe.xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				G_1647083107933 /* XCHammerAssets */,
+			);
+			path = SnapshotMe.xcodeproj;
+			sourceTree = "<group>";
+		};
+		G_4974131368836 = {
+			isa = PBXGroup;
+			children = (
+				G_8785595858347 /* ios-app */,
+				G_4723145104206 /* SnapshotMe.xcodeproj */,
+				G_3911002726085 /* Frameworks */,
+				G_1286414327561 /* Products */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
 			tabWidth = 4;
 			usesTabs = 0;
 		};
-		G_2054540523939 /* Products */ = {
+		G_7404621091787 /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
-				FR_809175072387 /* ios-app-Bazel.app */,
-				FR_162679830612 /* ios-app-main.a */,
-				FR_236762361925 /* ios-app.app */,
-				FR_460641534196 /* UnitTests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		G_2332380321410 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				FR_213277108087 /* libios-app-main.a */,
-				FR_918847181843 /* libiOSSnapshotTestCase-Core.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		G_2367623619254 /* ios-app */ = {
-			isa = PBXGroup;
-			children = (
-				FR_262810003713 /* AppDelegate.h */,
-				FR_263655108168 /* AppDelegate.m */,
-				FR_245040708962 /* Info.plist */,
-				FR_475309967935 /* main.m */,
-				G_2709888296093 /* UnitTests */,
-			);
-			path = "ios-app";
-			sourceTree = "<group>";
-		};
-		G_2709888296093 /* UnitTests */ = {
-			isa = PBXGroup;
-			children = (
-				FR_425869666354 /* Tests.m */,
-				FR_913276428123 /* Tests2.m */,
+				FR_899990382606 /* Tests.m */,
+				FR_549335309428 /* Tests2.m */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
 		};
-		G_4752293984528 /* XCHammerAssets */ = {
+		G_8785595858347 /* ios-app */ = {
 			isa = PBXGroup;
 			children = (
-				FR_376207894502 /* Stub.m */,
+				FR_681878669379 /* AppDelegate.h */,
+				FR_408828598481 /* AppDelegate.m */,
+				FR_784317858093 /* Info.plist */,
+				FR_668688117890 /* main.m */,
+				G_7404621091787 /* UnitTests */,
 			);
-			path = XCHammerAssets;
-			sourceTree = "<group>";
-		};
-		G_7150104396987 /* SnapshotMe.xcodeproj */ = {
-			isa = PBXGroup;
-			children = (
-				G_4752293984528 /* XCHammerAssets */,
-			);
-			path = SnapshotMe.xcodeproj;
+			path = "ios-app";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXLegacyTarget section */
-		LT_200296861195 /* ResetLLDBInit */ = {
-			isa = PBXLegacyTarget;
-			buildArgumentsString = "-c 'echo \"settings clear target.source-map\" > ~/.lldbinit-tulsiproj'";
-			buildConfigurationList = CL_200296861195 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */;
-			buildPhases = (
-				SBP_20029686119 /* Sources */,
-			);
-			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/SnapshotMe;
-			dependencies = (
-			);
-			name = ResetLLDBInit;
-			passBuildSettingsInEnvironment = 1;
-			productName = ResetLLDBInit;
-		};
-		LT_276814399960 /* UpdateXcodeProject */ = {
-			isa = PBXLegacyTarget;
-			buildArgumentsString = "-c __PWD__/sample/SnapshotMe/SnapshotMe.xcodeproj/XCHammerAssets/updateXcodeProj.sh";
-			buildConfigurationList = CL_276814399960 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */;
-			buildPhases = (
-				SBP_27681439996 /* Sources */,
-			);
-			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/SnapshotMe;
-			dependencies = (
-			);
-			name = UpdateXcodeProject;
-			passBuildSettingsInEnvironment = 1;
-			productName = UpdateXcodeProject;
-		};
-		LT_827045797919 /* GeneratedFiles */ = {
+		LT_318624717384 /* GeneratedFiles */ = {
 			isa = PBXLegacyTarget;
 			buildArgumentsString = "-c '[[ \"$(ACTION)\" == \"clean\" ]] && (__PWD__/sample/SnapshotMe/tools/bazelwrapper clean) || (__PWD__/sample/SnapshotMe/SnapshotMe.xcodeproj/XCHammerAssets/retry.sh __PWD__/sample/SnapshotMe/tools/bazelwrapper build --experimental_show_artifacts //Vendor/iOSSnapshotTestCase:Core_includes //SnapshotMe.xcodeproj/XCHammerAssets:ios-app-ios-app_entitlements)'";
-			buildConfigurationList = CL_827045797919 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */;
+			buildConfigurationList = CL_318624717384 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */;
 			buildPhases = (
-				SBP_82704579791 /* Sources */,
+				SBP_31862471738 /* Sources */,
 			);
 			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/SnapshotMe;
+			buildWorkingDirectory = "__PWD__/sample/SnapshotMe";
 			dependencies = (
 			);
 			name = GeneratedFiles;
 			passBuildSettingsInEnvironment = 1;
 			productName = GeneratedFiles;
 		};
+		LT_398865056014 /* ResetLLDBInit */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "-c 'echo \"settings clear target.source-map\" > ~/.lldbinit-tulsiproj'";
+			buildConfigurationList = CL_398865056014 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */;
+			buildPhases = (
+				SBP_39886505601 /* Sources */,
+			);
+			buildToolPath = /bin/bash;
+			buildWorkingDirectory = "__PWD__/sample/SnapshotMe";
+			dependencies = (
+			);
+			name = ResetLLDBInit;
+			passBuildSettingsInEnvironment = 1;
+			productName = ResetLLDBInit;
+		};
+		LT_776868564126 /* UpdateXcodeProject */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "-c __PWD__/sample/SnapshotMe/SnapshotMe.xcodeproj/XCHammerAssets/updateXcodeProj.sh";
+			buildConfigurationList = CL_776868564126 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */;
+			buildPhases = (
+				SBP_77686856412 /* Sources */,
+			);
+			buildToolPath = /bin/bash;
+			buildWorkingDirectory = "__PWD__/sample/SnapshotMe";
+			dependencies = (
+			);
+			name = UpdateXcodeProject;
+			passBuildSettingsInEnvironment = 1;
+			productName = UpdateXcodeProject;
+		};
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
-		NT_162679830612 /* ios-app-main */ = {
+		NT_326755382182 /* ios-app-Bazel */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_162679830612 /* Build configuration list for PBXNativeTarget "ios-app-main" */;
+			buildConfigurationList = CL_326755382182 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */;
 			buildPhases = (
-				SBP_16267983061 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ios-app-main";
-			productName = "ios-app-main";
-			productReference = FR_162679830612 /* ios-app-main.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_236762361925 /* ios-app */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_236762361925 /* Build configuration list for PBXNativeTarget "ios-app" */;
-			buildPhases = (
-				SBP_23676236192 /* Sources */,
-				FBP_23676236192 /* Frameworks */,
-				SSBP_3456136747 /* Process IPA */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ios-app";
-			productName = "ios-app";
-			productReference = FR_236762361925 /* ios-app.app */;
-			productType = "com.apple.product-type.application";
-		};
-		NT_460641534196 /* UnitTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_460641534196 /* Build configuration list for PBXNativeTarget "UnitTests" */;
-			buildPhases = (
-				SBP_46064153419 /* Sources */,
-				FBP_46064153419 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = UnitTests;
-			productName = UnitTests;
-			productReference = FR_460641534196 /* UnitTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		NT_809175072387 /* ios-app-Bazel */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_809175072387 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */;
-			buildPhases = (
-				SSBP_1128682098 /* Bazel build */,
-				SBP_80917507238 /* Sources */,
+				SSBP_1329315528 /* Bazel build */,
+				SBP_32675538218 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -238,55 +190,103 @@
 			);
 			name = "ios-app-Bazel";
 			productName = "ios-app-Bazel";
-			productReference = FR_809175072387 /* ios-app-Bazel.app */;
+			productReference = FR_326755382182 /* ios-app-Bazel.app */;
+			productType = "com.apple.product-type.application";
+		};
+		NT_396434231687 /* UnitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_396434231687 /* Build configuration list for PBXNativeTarget "UnitTests" */;
+			buildPhases = (
+				SBP_39643423168 /* Sources */,
+				FBP_39643423168 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = UnitTests;
+			productName = UnitTests;
+			productReference = FR_396434231687 /* UnitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		NT_522766133491 /* ios-app-main */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_522766133491 /* Build configuration list for PBXNativeTarget "ios-app-main" */;
+			buildPhases = (
+				SBP_52276613349 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ios-app-main";
+			productName = "ios-app-main";
+			productReference = FR_522766133491 /* ios-app-main.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_878559585834 /* ios-app */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_878559585834 /* Build configuration list for PBXNativeTarget "ios-app" */;
+			buildPhases = (
+				SBP_87855958583 /* Sources */,
+				FBP_87855958583 /* Frameworks */,
+				SSBP_2270029210 /* Process IPA */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ios-app";
+			productName = "ios-app";
+			productReference = FR_878559585834 /* ios-app.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		P_7184844754785 /* Project object */ = {
+		P_4105053782079 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0930;
 				TargetAttributes = {
-					NT_162679830612 = {
+					NT_326755382182 = {
 						ProvisioningStyle = manual;
 					};
-					NT_236762361925 = {
+					NT_396434231687 = {
 						ProvisioningStyle = manual;
 					};
-					NT_460641534196 = {
+					NT_522766133491 = {
 						ProvisioningStyle = manual;
 					};
-					NT_809175072387 = {
+					NT_878559585834 = {
 						ProvisioningStyle = manual;
 					};
 				};
 			};
-			buildConfigurationList = CL_718484475478 /* Build configuration list for PBXProject "SnapshotMe" */;
+			buildConfigurationList = CL_410505378207 /* Build configuration list for PBXProject "SnapshotMe" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = G_1548492089206;
+			mainGroup = G_4974131368836;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				LT_827045797919 /* GeneratedFiles */,
-				LT_200296861195 /* ResetLLDBInit */,
-				NT_460641534196 /* UnitTests */,
-				LT_276814399960 /* UpdateXcodeProject */,
-				NT_236762361925 /* ios-app */,
-				NT_809175072387 /* ios-app-Bazel */,
-				NT_162679830612 /* ios-app-main */,
+				LT_318624717384 /* GeneratedFiles */,
+				LT_398865056014 /* ResetLLDBInit */,
+				NT_396434231687 /* UnitTests */,
+				LT_776868564126 /* UpdateXcodeProject */,
+				NT_878559585834 /* ios-app */,
+				NT_326755382182 /* ios-app-Bazel */,
+				NT_522766133491 /* ios-app-main */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		SSBP_1128682098 /* Bazel build */ = {
+		SSBP_1329315528 /* Bazel build */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -300,7 +300,7 @@
 			shellPath = /bin/sh;
 			shellScript = "export TULSI_USE_HAMMER_DEBUG_CONFIG=YES\n__PWD__/.build/debug/bazel_build.py //ios-app:ios-app --bazel __PWD__/sample/SnapshotMe/tools/bazelwrapper";
 		};
-		SSBP_3456136747 /* Process IPA */ = {
+		SSBP_2270029210 /* Process IPA */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -317,64 +317,70 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		SBP_16267983061 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_650702818016 /* AppDelegate.m in Sources */,
-				BF_567361908666 /* main.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_20029686119 /* Sources */ = {
+		SBP_31862471738 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_23676236192 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_648862842090 /* Stub.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_27681439996 /* Sources */ = {
+		SBP_32675538218 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_46064153419 /* Sources */ = {
+		SBP_39643423168 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_812089772077 /* Tests.m in Sources */,
-				BF_760452161575 /* Tests2.m in Sources */,
+				BF_496214899859 /* Tests.m in Sources */,
+				BF_919227748211 /* Tests2.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_80917507238 /* Sources */ = {
+		SBP_39886505601 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_82704579791 /* Sources */ = {
+		SBP_52276613349 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF_126952534939 /* AppDelegate.m in Sources */,
+				BF_862876833720 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_77686856412 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_87855958583 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_553451473888 /* Stub.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		BC_126930418192 /* Debug */ = {
+		BC_198909022709 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		BC_343698588936 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -385,16 +391,21 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/iOSSnapshotTestCase/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework CoreGraphics -framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreGraphics -framework UIKit";
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework UIKit -framework Foundation -framework QuartzCore";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework UIKit -framework Foundation -framework QuartzCore";
 				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "ios-app-main";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
+				PRODUCT_NAME = UnitTests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -402,13 +413,13 @@
 			};
 			name = Debug;
 		};
-		BC_274924348235 /* Release */ = {
+		BC_355763252126 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
-			name = Release;
+			name = Debug;
 		};
-		BC_386470745811 /* Release */ = {
+		BC_429091570319 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -420,6 +431,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = external;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = "";
@@ -436,7 +448,7 @@
 			};
 			name = Release;
 		};
-		BC_476048374496 /* Debug */ = {
+		BC_445253313198 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -450,6 +462,7 @@
 					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"\".\"",
 				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = external;
 				INFOPLIST_FILE = "$(SRCROOT)/ios-app/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -466,124 +479,96 @@
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
-			name = Debug;
+			name = Release;
 		};
-		BC_585027494330 /* Debug */ = {
+		BC_481247018519 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		BC_595090115134 /* Debug */ = {
+		BC_513200306347 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/iOSSnapshotTestCase/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework UIKit -framework Foundation -framework QuartzCore";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework UIKit -framework Foundation -framework QuartzCore";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
+				PRODUCT_NAME = UnitTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_529676794877 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_535941998172 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				
 			};
 			name = Debug;
 		};
-		BC_629572459248 /* Release */ = {
+		BC_577605069899 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		BC_676540163500 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		BC_697142494776 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"\".\"",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/iOSSnapshotTestCase/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework UIKit -framework Foundation -framework QuartzCore";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework UIKit -framework Foundation -framework QuartzCore";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
-				PRODUCT_NAME = UnitTests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_699370152446 /* Release */ = {
+		BC_693898882498 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		BC_749745473037 /* Debug */ = {
+		BC_717280443486 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"\".\"",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/Vendor/iOSSnapshotTestCase/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework UIKit -framework Foundation -framework QuartzCore";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework UIKit -framework Foundation -framework QuartzCore";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
-				PRODUCT_NAME = UnitTests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
 			};
-			name = Debug;
+			name = Release;
 		};
-		BC_772585034147 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				LIBRARY_SEARCH_PATHS = "";
-				OTHER_CFLAGS = "";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				TARGETED_DEVICE_FAMILY = "";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_810428303208 /* Release */ = {
+		BC_767914582431 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -597,6 +582,7 @@
 					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"\".\"",
 				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = external;
 				INFOPLIST_FILE = "$(SRCROOT)/ios-app/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -613,21 +599,15 @@
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
-			name = Release;
+			name = Debug;
 		};
-		BC_846225692277 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		BC_887133859691 /* Debug */ = {
+		BC_825603852867 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		BC_917030902355 /* Release */ = {
+		BC_860201645026 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGNING_REQUIRED = NO;
@@ -635,94 +615,126 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = "";
 				OTHER_CFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				TARGETED_DEVICE_FAMILY = "";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
 			name = Release;
 		};
+		BC_984239465164 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-framework CoreGraphics -framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreGraphics -framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "ios-app-main";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		CL_162679830612 /* Build configuration list for PBXNativeTarget "ios-app-main" */ = {
+		CL_318624717384 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_126930418192 /* Debug */,
-				BC_386470745811 /* Release */,
+				BC_481247018519 /* Debug */,
+				BC_577605069899 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_200296861195 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */ = {
+		CL_326755382182 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_585027494330 /* Debug */,
-				BC_274924348235 /* Release */,
+				BC_529676794877 /* Debug */,
+				BC_860201645026 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_236762361925 /* Build configuration list for PBXNativeTarget "ios-app" */ = {
+		CL_396434231687 /* Build configuration list for PBXNativeTarget "UnitTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_476048374496 /* Debug */,
-				BC_810428303208 /* Release */,
+				BC_343698588936 /* Debug */,
+				BC_513200306347 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_276814399960 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */ = {
+		CL_398865056014 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_887133859691 /* Debug */,
-				BC_629572459248 /* Release */,
+				BC_355763252126 /* Debug */,
+				BC_693898882498 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_460641534196 /* Build configuration list for PBXNativeTarget "UnitTests" */ = {
+		CL_410505378207 /* Build configuration list for PBXProject "SnapshotMe" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_749745473037 /* Debug */,
-				BC_697142494776 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_718484475478 /* Build configuration list for PBXProject "SnapshotMe" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_595090115134 /* Debug */,
-				BC_846225692277 /* Release */,
+				BC_535941998172 /* Debug */,
+				BC_717280443486 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		CL_809175072387 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */ = {
+		CL_522766133491 /* Build configuration list for PBXNativeTarget "ios-app-main" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_772585034147 /* Debug */,
-				BC_917030902355 /* Release */,
+				BC_984239465164 /* Debug */,
+				BC_429091570319 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_827045797919 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */ = {
+		CL_776868564126 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_676540163500 /* Debug */,
-				BC_699370152446 /* Release */,
+				BC_825603852867 /* Debug */,
+				BC_198909022709 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_878559585834 /* Build configuration list for PBXNativeTarget "ios-app" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_767914582431 /* Debug */,
+				BC_445253313198 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = P_7184844754785 /* Project object */;
+	rootObject = P_4105053782079 /* Project object */;
 }

--- a/IntegrationTests/Goldmaster/SnapshotMe.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/SnapshotMe.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "9.2"
-   version = "1.3">
+   version = "1.3"
+   LastUpgradeVersion = "9.2">
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
@@ -125,7 +125,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      revealArchiveInOrganizer = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/SnapshotMe.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/IntegrationTests/Goldmaster/SnapshotMe.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "9.2"
-   version = "1.3">
+   version = "1.3"
+   LastUpgradeVersion = "9.2">
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
@@ -177,7 +177,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      revealArchiveInOrganizer = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/SnapshotMe.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/SnapshotMe.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "9.2"
-   version = "1.3">
+   version = "1.3"
+   LastUpgradeVersion = "9.2">
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
@@ -98,7 +98,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      revealArchiveInOrganizer = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/SnapshotMe.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+++ b/IntegrationTests/Goldmaster/SnapshotMe.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "9.2"
-   version = "1.3">
+   version = "1.3"
+   LastUpgradeVersion = "9.2">
    <BuildAction
       parallelizeBuildables = "NO"
       buildImplicitDependencies = "YES">
@@ -150,7 +150,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      revealArchiveInOrganizer = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/IntegrationTests/Goldmaster/Tailor.xcodeproj/project.pbxproj
+++ b/IntegrationTests/Goldmaster/Tailor.xcodeproj/project.pbxproj
@@ -7,155 +7,151 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BF_312168298619 /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_164461626461 /* Stub.swift */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_433848069429 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_209587129221 /* AppDelegate.swift */; };
-		BF_738020867112 = {isa = PBXBuildFile; fileRef = FR_727585954021 /* ios-app-main.a */; };
-		BF_745439098229 /* libios-app-main.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_339814870963 /* libios-app-main.a */; };
-		BF_816617878957 = {isa = PBXBuildFile; fileRef = FR_133574888244 /* ios-app.app */; };
+		BF_156323332845 = {isa = PBXBuildFile; fileRef = FR_322453544755 /* tailor.a */; };
+		BF_165280145802 /* Tailor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_278630634086 /* Tailor.swift */; };
+		BF_195567796029 = {isa = PBXBuildFile; fileRef = FR_297322858885 /* ios-app-main.a */; };
+		BF_249217343491 = {isa = PBXBuildFile; fileRef = FR_849461705440 /* ios-app-Bazel.app */; };
+		BF_295223633148 /* libios-app-main.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_469890310621 /* libios-app-main.a */; };
+		BF_592948787377 /* libtailor.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_414070879722 /* libtailor.a */; };
+		BF_632676901407 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_695775747785 /* AppDelegate.swift */; };
+		BF_718027952470 = {isa = PBXBuildFile; fileRef = FR_848403537843 /* ios-app.app */; };
+		BF_870326953016 /* Stub.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_803640936590 /* Stub.swift */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		FR_133574888244 /* ios-app.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_164461626461 /* Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stub.swift; sourceTree = "<group>"; };
-		FR_209587129221 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		FR_215638080565 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_339814870963 /* libios-app-main.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-app-main.a"; sourceTree = "<group>"; };
-		FR_727585954021 /* ios-app-main.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-app-main.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_278630634086 /* Tailor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tailor.swift; sourceTree = "<group>"; };
+		FR_297322858885 /* ios-app-main.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-app-main.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_322453544755 /* tailor.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = tailor.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_414070879722 /* libtailor.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libtailor.a; sourceTree = "<group>"; };
+		FR_417215486089 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FR_469890310621 /* libios-app-main.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-app-main.a"; sourceTree = "<group>"; };
+		FR_695775747785 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		FR_803640936590 /* Stub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stub.swift; sourceTree = "<group>"; };
+		FR_848403537843 /* ios-app.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_849461705440 /* ios-app-Bazel.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app-Bazel.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		FBP_13357488824 /* Frameworks */ = {
+		FBP_84840353784 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_745439098229 /* libios-app-main.a in Frameworks */,
+				BF_592948787377 /* libtailor.a in Frameworks */,
+				BF_295223633148 /* libios-app-main.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		G_4186524390481 = {
+		G_3774598610164 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				FR_209587129221 /* AppDelegate.swift */,
-				FR_215638080565 /* Info.plist */,
-				G_6778937577640 /* Tailor.xcodeproj */,
-				G_8704390127787 /* Frameworks */,
-				G_8609345257264 /* Products */,
+				FR_469890310621 /* libios-app-main.a */,
+				FR_414070879722 /* libtailor.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		G_4467457135973 /* XCHammerAssets */ = {
+			isa = PBXGroup;
+			children = (
+				FR_803640936590 /* Stub.swift */,
+			);
+			path = XCHammerAssets;
+			sourceTree = "<group>";
+		};
+		G_6370919906467 = {
+			isa = PBXGroup;
+			children = (
+				FR_695775747785 /* AppDelegate.swift */,
+				FR_417215486089 /* Info.plist */,
+				FR_278630634086 /* Tailor.swift */,
+				G_6841361249121 /* Tailor.xcodeproj */,
+				G_3774598610164 /* Frameworks */,
+				G_7863792550212 /* Products */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
 			tabWidth = 4;
 			usesTabs = 0;
 		};
-		G_6778937577640 /* Tailor.xcodeproj */ = {
+		G_6841361249121 /* Tailor.xcodeproj */ = {
 			isa = PBXGroup;
 			children = (
-				G_7061369345538 /* XCHammerAssets */,
+				G_4467457135973 /* XCHammerAssets */,
 			);
 			path = Tailor.xcodeproj;
 			sourceTree = "<group>";
 		};
-		G_7061369345538 /* XCHammerAssets */ = {
+		G_7863792550212 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				FR_164461626461 /* Stub.swift */,
-			);
-			path = XCHammerAssets;
-			sourceTree = "<group>";
-		};
-		G_8609345257264 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				FR_727585954021 /* ios-app-main.a */,
-				FR_133574888244 /* ios-app.app */,
+				FR_849461705440 /* ios-app-Bazel.app */,
+				FR_297322858885 /* ios-app-main.a */,
+				FR_848403537843 /* ios-app.app */,
+				FR_322453544755 /* tailor.a */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		G_8704390127787 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				FR_339814870963 /* libios-app-main.a */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXLegacyTarget section */
-		LT_172539793472 /* GeneratedFiles */ = {
-			isa = PBXLegacyTarget;
-			buildArgumentsString = "-c '[[ \"$(ACTION)\" == \"clean\" ]] && (__PWD__/sample/Tailor/tools/bazelwrapper clean) || (__PWD__/sample/Tailor/Tailor.xcodeproj/XCHammerAssets/retry.sh __PWD__/sample/Tailor/tools/bazelwrapper build --experimental_show_artifacts //Tailor.xcodeproj/XCHammerAssets:-ios-app_entitlements)'";
-			buildConfigurationList = CL_172539793472 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */;
-			buildPhases = (
-				SBP_17253979347 /* Sources */,
-			);
-			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/Tailor;
-			dependencies = (
-			);
-			name = GeneratedFiles;
-			passBuildSettingsInEnvironment = 1;
-			productName = GeneratedFiles;
-		};
-		LT_486714375943 /* ResetLLDBInit */ = {
-			isa = PBXLegacyTarget;
-			buildArgumentsString = "-c 'echo \"settings clear target.source-map\" > ~/.lldbinit-tulsiproj'";
-			buildConfigurationList = CL_486714375943 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */;
-			buildPhases = (
-				SBP_48671437594 /* Sources */,
-			);
-			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/Tailor;
-			dependencies = (
-			);
-			name = ResetLLDBInit;
-			passBuildSettingsInEnvironment = 1;
-			productName = ResetLLDBInit;
-		};
-		LT_870745717790 /* UpdateXcodeProject */ = {
+		LT_773764077442 /* UpdateXcodeProject */ = {
 			isa = PBXLegacyTarget;
 			buildArgumentsString = "-c __PWD__/sample/Tailor/Tailor.xcodeproj/XCHammerAssets/updateXcodeProj.sh";
-			buildConfigurationList = CL_870745717790 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */;
+			buildConfigurationList = CL_773764077442 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */;
 			buildPhases = (
-				SBP_87074571779 /* Sources */,
+				SBP_77376407744 /* Sources */,
 			);
 			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/Tailor;
+			buildWorkingDirectory = "__PWD__/sample/Tailor";
 			dependencies = (
 			);
 			name = UpdateXcodeProject;
 			passBuildSettingsInEnvironment = 1;
 			productName = UpdateXcodeProject;
 		};
+		LT_831943585418 /* GeneratedFiles */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "-c '[[ \"$(ACTION)\" == \"clean\" ]] && (__PWD__/sample/Tailor/tools/bazelwrapper clean) || (__PWD__/sample/Tailor/Tailor.xcodeproj/XCHammerAssets/retry.sh __PWD__/sample/Tailor/tools/bazelwrapper build --experimental_show_artifacts //Tailor.xcodeproj/XCHammerAssets:-ios-app_entitlements)'";
+			buildConfigurationList = CL_831943585418 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */;
+			buildPhases = (
+				SBP_83194358541 /* Sources */,
+			);
+			buildToolPath = /bin/bash;
+			buildWorkingDirectory = "__PWD__/sample/Tailor";
+			dependencies = (
+			);
+			name = GeneratedFiles;
+			passBuildSettingsInEnvironment = 1;
+			productName = GeneratedFiles;
+		};
+		LT_911624144531 /* ResetLLDBInit */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "-c 'echo \"settings clear target.source-map\" > ~/.lldbinit-tulsiproj'";
+			buildConfigurationList = CL_911624144531 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */;
+			buildPhases = (
+				SBP_91162414453 /* Sources */,
+			);
+			buildToolPath = /bin/bash;
+			buildWorkingDirectory = "__PWD__/sample/Tailor";
+			dependencies = (
+			);
+			name = ResetLLDBInit;
+			passBuildSettingsInEnvironment = 1;
+			productName = ResetLLDBInit;
+		};
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
-		NT_133574888244 /* ios-app */ = {
+		NT_297322858885 /* ios-app-main */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_133574888244 /* Build configuration list for PBXNativeTarget "ios-app" */;
+			buildConfigurationList = CL_297322858885 /* Build configuration list for PBXNativeTarget "ios-app-main" */;
 			buildPhases = (
-				SBP_13357488824 /* Sources */,
-				FBP_13357488824 /* Frameworks */,
-				SSBP_3050673619 /* Process IPA */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ios-app";
-			productName = "ios-app";
-			productReference = FR_133574888244 /* ios-app.app */;
-			productType = "com.apple.product-type.application";
-		};
-		NT_727585954021 /* ios-app-main */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_727585954021 /* Build configuration list for PBXNativeTarget "ios-app-main" */;
-			buildPhases = (
-				SBP_72758595402 /* Sources */,
-				SSBP_6049053643 /* Copy Swift Objective-C Interface Header */,
+				SBP_29732285888 /* Sources */,
+				SSBP_6859543988 /* Copy Swift Objective-C Interface Header */,
 			);
 			buildRules = (
 			);
@@ -163,61 +159,104 @@
 			);
 			name = "ios-app-main";
 			productName = "ios-app-main";
-			productReference = FR_727585954021 /* ios-app-main.a */;
+			productReference = FR_297322858885 /* ios-app-main.a */;
 			productType = "com.apple.product-type.library.static";
+		};
+		NT_322453544755 /* tailor */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_322453544755 /* Build configuration list for PBXNativeTarget "tailor" */;
+			buildPhases = (
+				SBP_32245354475 /* Sources */,
+				SSBP_2538925287 /* Copy Swift Objective-C Interface Header */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = tailor;
+			productName = tailor;
+			productReference = FR_322453544755 /* tailor.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_848403537843 /* ios-app */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_848403537843 /* Build configuration list for PBXNativeTarget "ios-app" */;
+			buildPhases = (
+				SBP_84840353784 /* Sources */,
+				FBP_84840353784 /* Frameworks */,
+				SSBP_5582630014 /* Process IPA */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ios-app";
+			productName = "ios-app";
+			productReference = FR_848403537843 /* ios-app.app */;
+			productType = "com.apple.product-type.application";
+		};
+		NT_849461705440 /* ios-app-Bazel */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_849461705440 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */;
+			buildPhases = (
+				SSBP_7235941502 /* Bazel build */,
+				SBP_84946170544 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ios-app-Bazel";
+			productName = "ios-app-Bazel";
+			productReference = FR_849461705440 /* ios-app-Bazel.app */;
+			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		P_7522770210799 /* Project object */ = {
+		P_6946296729134 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0930;
 				TargetAttributes = {
-					NT_133574888244 = {
+					NT_297322858885 = {
 						ProvisioningStyle = manual;
 					};
-					NT_727585954021 = {
+					NT_322453544755 = {
+						ProvisioningStyle = manual;
+					};
+					NT_848403537843 = {
+						ProvisioningStyle = manual;
+					};
+					NT_849461705440 = {
 						ProvisioningStyle = manual;
 					};
 				};
 			};
-			buildConfigurationList = CL_752277021079 /* Build configuration list for PBXProject "Tailor" */;
+			buildConfigurationList = CL_694629672913 /* Build configuration list for PBXProject "Tailor" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = G_4186524390481;
+			mainGroup = G_6370919906467;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				LT_172539793472 /* GeneratedFiles */,
-				LT_486714375943 /* ResetLLDBInit */,
-				LT_870745717790 /* UpdateXcodeProject */,
-				NT_133574888244 /* ios-app */,
-				NT_727585954021 /* ios-app-main */,
+				LT_831943585418 /* GeneratedFiles */,
+				LT_911624144531 /* ResetLLDBInit */,
+				LT_773764077442 /* UpdateXcodeProject */,
+				NT_848403537843 /* ios-app */,
+				NT_849461705440 /* ios-app-Bazel */,
+				NT_297322858885 /* ios-app-main */,
+				NT_322453544755 /* tailor */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		SSBP_3050673619 /* Process IPA */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Process IPA";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "__PWD__/.build/debug/XCHammer process-ipa";
-		};
-		SSBP_6049053643 /* Copy Swift Objective-C Interface Header */ = {
+		SSBP_2538925287 /* Copy Swift Objective-C Interface Header */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -233,40 +272,99 @@
 			shellPath = /bin/sh;
 			shellScript = "ditto \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 		};
+		SSBP_5582630014 /* Process IPA */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Process IPA";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "__PWD__/.build/debug/XCHammer process-ipa";
+		};
+		SSBP_6859543988 /* Copy Swift Objective-C Interface Header */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(DERIVED_SOURCES_DIR)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			name = "Copy Swift Objective-C Interface Header";
+			outputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/include/$(PRODUCT_MODULE_NAME)/$(SWIFT_OBJC_INTERFACE_HEADER_NAME)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "ditto \"${SCRIPT_INPUT_FILE_0}\" \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+		};
+		SSBP_7235941502 /* Bazel build */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bazel build";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export TULSI_USE_HAMMER_DEBUG_CONFIG=YES\n__PWD__/.build/debug/bazel_build.py //:ios-app --bazel __PWD__/sample/Tailor/tools/bazelwrapper";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		SBP_13357488824 /* Sources */ = {
+		SBP_29732285888 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_312168298619 /* Stub.swift in Sources */,
+				BF_632676901407 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_17253979347 /* Sources */ = {
+		SBP_32245354475 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_165280145802 /* Tailor.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_77376407744 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_48671437594 /* Sources */ = {
+		SBP_83194358541 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_72758595402 /* Sources */ = {
+		SBP_84840353784 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_433848069429 /* AppDelegate.swift in Sources */,
+				BF_870326953016 /* Stub.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_87074571779 /* Sources */ = {
+		SBP_84946170544 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_91162414453 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -276,43 +374,40 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		BC_134451679473 /* Release */ = {
+		BC_107541815794 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = tailor;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 4.2.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_125051483304 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		BC_140427581068 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		BC_289861117045 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		BC_373620008642 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		BC_459765320219 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		BC_474346768168 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		BC_716036668538 /* Debug */ = {
+		BC_171819882366 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -326,6 +421,7 @@
 					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"\".\"",
 				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = external;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -345,40 +441,13 @@
 			};
 			name = Debug;
 		};
-		BC_752250485532 /* Release */ = {
+		BC_292803280144 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"\".\"",
-				);
-				HEADER_SEARCH_PATHS = external;
-				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/Tailor.xcodeproj/XCHammerAssets/-ios-app_entitlements.entitlements";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.Sample;
-				PRODUCT_NAME = "ios-app";
-				SDKROOT = iphoneos;
-				SWIFT_VERSION = 4.2.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
 			};
-			name = Release;
+			name = Debug;
 		};
-		BC_760053511008 /* Release */ = {
+		BC_419920477088 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -389,13 +458,14 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = external;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
 				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "ios-app-main";
+				PRODUCT_NAME = tailor;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 4.2.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -404,13 +474,30 @@
 			};
 			name = Release;
 		};
-		BC_761234494463 /* Release */ = {
+		BC_453334355034 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
 			};
-			name = Release;
+			name = Debug;
 		};
-		BC_766078007465 /* Debug */ = {
+		BC_501119956003 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -421,6 +508,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = external;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = "";
@@ -436,71 +524,203 @@
 			};
 			name = Debug;
 		};
-		BC_918712838758 /* Debug */ = {
+		BC_505564253421 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		BC_507023677943 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		BC_566203492366 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		BC_628039897056 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_669944254009 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				
 			};
 			name = Debug;
 		};
+		BC_720274283359 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "ios-app-main";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 4.2.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_724423420484 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/Tailor.xcodeproj/XCHammerAssets/-ios-app_entitlements.entitlements";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Sample;
+				PRODUCT_NAME = "ios-app";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 4.2.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_752542982023 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		BC_899702945955 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		CL_133574888244 /* Build configuration list for PBXNativeTarget "ios-app" */ = {
+		CL_297322858885 /* Build configuration list for PBXNativeTarget "ios-app-main" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_716036668538 /* Debug */,
-				BC_752250485532 /* Release */,
+				BC_501119956003 /* Debug */,
+				BC_720274283359 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_172539793472 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */ = {
+		CL_322453544755 /* Build configuration list for PBXNativeTarget "tailor" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_474346768168 /* Debug */,
-				BC_134451679473 /* Release */,
+				BC_107541815794 /* Debug */,
+				BC_419920477088 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_486714375943 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */ = {
+		CL_694629672913 /* Build configuration list for PBXProject "Tailor" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_289861117045 /* Debug */,
-				BC_140427581068 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_727585954021 /* Build configuration list for PBXNativeTarget "ios-app-main" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_766078007465 /* Debug */,
-				BC_760053511008 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_752277021079 /* Build configuration list for PBXProject "Tailor" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_918712838758 /* Debug */,
-				BC_373620008642 /* Release */,
+				BC_669944254009 /* Debug */,
+				BC_752542982023 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		CL_870745717790 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */ = {
+		CL_773764077442 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_459765320219 /* Debug */,
-				BC_761234494463 /* Release */,
+				BC_566203492366 /* Debug */,
+				BC_125051483304 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_831943585418 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_505564253421 /* Debug */,
+				BC_507023677943 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_848403537843 /* Build configuration list for PBXNativeTarget "ios-app" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_171819882366 /* Debug */,
+				BC_724423420484 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_849461705440 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_453334355034 /* Debug */,
+				BC_628039897056 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_911624144531 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_292803280144 /* Debug */,
+				BC_899702945955 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = P_7522770210799 /* Project object */;
+	rootObject = P_6946296729134 /* Project object */;
 }

--- a/IntegrationTests/Goldmaster/Tailor.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/Tailor.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      buildImplicitDependencies = "YES"
-      parallelizeBuildables = "NO">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -17,7 +17,7 @@
                BlueprintIdentifier = ""
                BuildableName = "ios-app.app-Bazel"
                BlueprintName = "ios-app-Bazel"
-               ReferencedContainer = "container:WorkspaceSource.xcodeproj">
+               ReferencedContainer = "container:Tailor.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -36,7 +36,7 @@
             BlueprintIdentifier = ""
             BuildableName = "ios-app.app-Bazel"
             BlueprintName = "ios-app-Bazel"
-            ReferencedContainer = "container:WorkspaceSource.xcodeproj">
+            ReferencedContainer = "container:Tailor.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
       <CommandLineArguments>
@@ -63,7 +63,7 @@
             BlueprintIdentifier = ""
             BuildableName = "ios-app.app-Bazel"
             BlueprintName = "ios-app-Bazel"
-            ReferencedContainer = "container:WorkspaceSource.xcodeproj">
+            ReferencedContainer = "container:Tailor.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
@@ -86,7 +86,7 @@
             BlueprintIdentifier = ""
             BuildableName = "ios-app.app-Bazel"
             BlueprintName = "ios-app-Bazel"
-            ReferencedContainer = "container:WorkspaceSource.xcodeproj">
+            ReferencedContainer = "container:Tailor.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>

--- a/IntegrationTests/Goldmaster/Tailor.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+++ b/IntegrationTests/Goldmaster/Tailor.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
@@ -3,8 +3,8 @@
    LastUpgradeVersion = "9.2"
    version = "1.3">
    <BuildAction
-      buildImplicitDependencies = "YES"
-      parallelizeBuildables = "NO">
+      parallelizeBuildables = "NO"
+      buildImplicitDependencies = "YES">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/project.pbxproj
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/project.pbxproj
@@ -7,553 +7,553 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BF_103864908901 = {isa = PBXBuildFile; fileRef = FR_446505840808 /* PINCache-Core-ios-12.0.a */; };
-		BF_103972021129 /* stp_card_amex_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_351223294806 /* stp_card_amex_template.png */; };
-		BF_106423611096 /* stp_card_cvc@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_564512028139 /* stp_card_cvc@2x.png */; };
-		BF_106426006254 /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_466487462811 /* STPAPIClient+ApplePay.m */; };
-		BF_107640671612 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_474020775691 /* STPSectionHeaderView.m */; };
-		BF_108242733761 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_515610011898 /* Tests.m */; };
-		BF_109277108982 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_795132420225 /* STPCardParams.m */; };
-		BF_110357559807 /* STPApplePayPaymentMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_949688277225 /* STPApplePayPaymentMethod.m */; };
-		BF_110522976147 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_678627904183 /* InfoPlist.strings */; };
-		BF_112599425186 = {isa = PBXBuildFile; fileRef = FR_645411521541 /* PINCache-Arc-exception-safe-ios-9.0.a */; };
-		BF_114078348659 /* stp_card_unionpay_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_109008019044 /* stp_card_unionpay_zh@2x.png */; };
-		BF_114471101614 /* STPBundleLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_504790352271 /* STPBundleLocator.m */; };
-		BF_115608921764 /* STPCoreScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_295195067470 /* STPCoreScrollViewController.m */; };
-		BF_116037651642 /* STPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_902210249661 /* STPAPIClient.m */; };
-		BF_116377765548 /* STPBINRange.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_701536383989 /* STPBINRange.m */; };
-		BF_124041089401 /* stp_card_unknown@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_810092475433 /* stp_card_unknown@3x.png */; };
-		BF_124968280406 /* stp_card_diners@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_195382795454 /* stp_card_diners@3x.png */; };
-		BF_126340360597 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_394251211369 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */; };
-		BF_127051381386 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_887912048029 /* STPPaymentContextAmountModel.m */; };
-		BF_128649453491 /* stp_card_mastercard_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_764521294758 /* stp_card_mastercard_template@2x.png */; };
-		BF_130413526576 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_201794194523 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
-		BF_130493963595 /* stp_card_unionpay_template_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_335380563722 /* stp_card_unionpay_template_zh@3x.png */; };
-		BF_130827952654 /* libPINCache-Arc-exception-safe-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_836986626561 /* libPINCache-Arc-exception-safe-ios-12.0.a */; };
-		BF_130835634102 /* NSCharacterSet+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_160616828485 /* NSCharacterSet+Stripe.m */; };
-		BF_133980896421 /* stp_card_form_back@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_785291574055 /* stp_card_form_back@3x.png */; };
-		BF_137349614193 /* stp_card_diners@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_843574680132 /* stp_card_diners@2x.png */; };
-		BF_138955362658 /* NSCharacterSet+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_160616828485 /* NSCharacterSet+Stripe.m */; };
-		BF_139454296157 /* STPAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_580663685603 /* STPAPIRequest.m */; };
-		BF_141009703626 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_485722511970 /* STPPaymentMethodTableViewCell.m */; };
-		BF_143169419803 /* strings-extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FR_409503237802 /* strings-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BF_145004478833 /* stp_card_mastercard_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_262765526800 /* stp_card_mastercard_template.png */; };
-		BF_145626146117 /* stp_card_mastercard_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_593438413731 /* stp_card_mastercard_template@3x.png */; };
-		BF_149583612787 /* STPPaymentCardTextFieldViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_301311350687 /* STPPaymentCardTextFieldViewModel.m */; };
-		BF_151715570365 /* stp_icon_checkmark@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_549986619017 /* stp_icon_checkmark@3x.png */; };
-		BF_151809760085 /* STPAnalyticsClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_212125637458 /* STPAnalyticsClient.m */; };
-		BF_157778036284 /* UIView+Stripe_SafeAreaBounds.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_214657321101 /* UIView+Stripe_SafeAreaBounds.m */; };
-		BF_161039779458 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_811655502329 /* GoogleAppIndexing.framework */; };
-		BF_161782666040 /* stp_card_amex_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_225452001627 /* stp_card_amex_template@3x.png */; };
-		BF_164869574590 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_411849423046 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_165953454949 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_826804962981 /* GoogleAppIndexingResources.bundle */; };
-		BF_166279340518 /* STPImageLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_132874026439 /* STPImageLibrary.m */; };
-		BF_176098569769 /* STPTelemetryClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_401389674811 /* STPTelemetryClient.m */; };
-		BF_176630419312 /* STPPaymentCardTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_395459264864 /* STPPaymentCardTextField.m */; };
-		BF_177629582576 /* STPMultipartFormDataPart.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_442086127483 /* STPMultipartFormDataPart.m */; };
-		BF_178404571906 /* STPCoreViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_360479079920 /* STPCoreViewController.m */; };
-		BF_179566918738 /* libstrings-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_534115266600 /* libstrings-ext-bin.a */; };
-		BF_180246982391 /* STPSourceRedirect.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_425904257008 /* STPSourceRedirect.m */; };
-		BF_182065974583 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_562402903136 /* STPDispatchFunctions.m */; };
-		BF_182898091741 = {isa = PBXBuildFile; fileRef = FR_854342266175 /* ios-app-bin-ios-12.0.a */; };
-		BF_182898266867 /* stp_icon_checkmark.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_211759521425 /* stp_icon_checkmark.png */; };
-		BF_184316768586 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_849310420444 /* libStripe-ios-9.0.a */; };
-		BF_184553022665 /* STPSwitchTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_707702346637 /* STPSwitchTableViewCell.m */; };
-		BF_185170820537 /* stp_card_diners@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_195382795454 /* stp_card_diners@3x.png */; };
-		BF_185409518232 /* stp_card_diners_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_729563592373 /* stp_card_diners_template.png */; };
-		BF_191596099026 /* stp_card_form_back@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_785291574055 /* stp_card_form_back@3x.png */; };
-		BF_193776636624 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_515610011898 /* Tests.m */; };
-		BF_200583839276 /* stp_card_error_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_245329396039 /* stp_card_error_amex@3x.png */; };
-		BF_200763756394 /* STPBankAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_571217998206 /* STPBankAccount.m */; };
-		BF_203475959424 = {isa = PBXBuildFile; fileRef = FR_135115533237 /* PINOperation-ios-9.0.a */; };
-		BF_203723500807 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_431621881643 /* stp_card_amex@3x.png */; };
-		BF_204127504215 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_411849423046 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_210482066403 /* STPCoreScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_295195067470 /* STPCoreScrollViewController.m */; };
-		BF_210628983297 /* Generated.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_536833584482 /* Generated.m */; };
-		BF_210852987118 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_800458577779 /* libPINCache-Core-ios-9.0.a */; };
-		BF_212426867441 = {isa = PBXBuildFile; fileRef = FR_101452471709 /* UITests.xctest */; };
-		BF_214492597692 /* stp_card_unionpay_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_815379450093 /* stp_card_unionpay_zh.png */; };
-		BF_214935354420 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_248755332667 /* libPINOperation-ios-9.0.a */; };
-		BF_215931264842 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_288738750739 /* GoogleNetworkingUtilities.framework */; };
-		BF_218250556539 /* stp_card_unionpay_template_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_869656627571 /* stp_card_unionpay_template_zh.png */; };
-		BF_218427460037 /* STPPaymentConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_665937321012 /* STPPaymentConfiguration.m */; };
-		BF_220363596336 /* stp_card_error@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_900806134110 /* stp_card_error@3x.png */; };
-		BF_220513902077 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = VG_114608902985 /* AppIntentVocabulary.plist */; };
-		BF_222042484068 /* UIBarButtonItem+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_416373643255 /* UIBarButtonItem+Stripe.m */; };
-		BF_226798571849 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_812073861033 /* UIViewController+Stripe_NavigationItemProxy.m */; };
-		BF_227164771933 /* STPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_821099591187 /* STPToken.m */; };
-		BF_227375850827 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_288321554063 /* STPSourcePoller.m */; };
-		BF_230723261129 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_811655502329 /* GoogleAppIndexing.framework */; };
-		BF_231519883198 /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_121139739215 /* PINCache.m */; };
-		BF_232285685203 /* STPAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_580663685603 /* STPAPIRequest.m */; };
-		BF_233545122777 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_633906012597 /* GoogleAuthUtilities.framework */; };
-		BF_239435400714 /* NSString+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_129103540819 /* NSString+Stripe.m */; };
-		BF_240229285012 /* STPMultipartFormDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_268528132629 /* STPMultipartFormDataEncoder.m */; };
-		BF_241788126271 /* STPPaymentCardTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_395459264864 /* STPPaymentCardTextField.m */; };
-		BF_245416482780 /* libPINCache-Core-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_839061891305 /* libPINCache-Core-ios-12.0.a */; };
-		BF_248488222131 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_289929860900 /* STPRedirectContext.m */; };
-		BF_249679172768 /* stp_card_unionpay_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_805132164928 /* stp_card_unionpay_zh@3x.png */; };
-		BF_252439999853 /* stp_card_jcb_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_342721641775 /* stp_card_jcb_template@3x.png */; };
-		BF_252672099139 /* STPPaymentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_459740821355 /* STPPaymentContext.m */; };
-		BF_252773349615 /* STPLocalizationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_246324868641 /* STPLocalizationUtils.m */; };
-		BF_254215603294 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_145914995522 /* PINDiskCache.m */; };
-		BF_254507463991 /* stp_card_jcb_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_651709914966 /* stp_card_jcb_template.png */; };
-		BF_254757182188 /* stp_card_discover_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_350139185969 /* stp_card_discover_template@2x.png */; };
-		BF_255304234772 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_854600736464 /* GoogleSymbolUtilities.framework */; };
-		BF_259990952773 /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_947777323233 /* stp_card_visa@3x.png */; };
-		BF_264569632952 /* STPSourceCardDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_264105247925 /* STPSourceCardDetails.m */; };
-		BF_266049611515 /* stp_card_form_back@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_608546669129 /* stp_card_form_back@2x.png */; };
-		BF_266069324995 /* stp_card_unionpay_template_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_600685478634 /* stp_card_unionpay_template_en@3x.png */; };
-		BF_272088808996 /* stp_card_visa.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_365700562027 /* stp_card_visa.png */; };
-		BF_273021152810 /* stp_card_jcb.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_357987593239 /* stp_card_jcb.png */; };
-		BF_273949134835 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_398590689728 /* PINMemoryCache.m */; };
-		BF_277334165247 /* UINavigationBar+Stripe_Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_795417469207 /* UINavigationBar+Stripe_Theme.m */; };
-		BF_278104745467 /* STPMultipartFormDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_268528132629 /* STPMultipartFormDataEncoder.m */; };
-		BF_281049355718 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_411849423046 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_286804362837 /* stp_card_form_back.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_858844900391 /* stp_card_form_back.png */; };
-		BF_288003895250 /* stp_card_unionpay_template_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_700870847596 /* stp_card_unionpay_template_en.png */; };
-		BF_288475203867 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_289929860900 /* STPRedirectContext.m */; };
-		BF_289807868980 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_288321554063 /* STPSourcePoller.m */; };
-		BF_291677581212 /* stp_card_cvc_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_384110904147 /* stp_card_cvc_amex.png */; };
-		BF_292535522668 /* STPPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_331287642191 /* STPPromise.m */; };
-		BF_294493533060 = {isa = PBXBuildFile; fileRef = FR_404433001070 /* Stripe-ios-9.0.a */; };
-		BF_295863033575 /* STPPhoneNumberValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_209621477518 /* STPPhoneNumberValidator.m */; };
-		BF_296999096933 /* STPCategoryLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_535352815691 /* STPCategoryLoader.m */; };
-		BF_298131539887 /* STPAddressViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_923168362961 /* STPAddressViewModel.m */; };
-		BF_298647117939 /* stp_card_unknown@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_359125113541 /* stp_card_unknown@2x.png */; };
-		BF_301371454701 /* UIViewController+Stripe_Promises.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_499853310274 /* UIViewController+Stripe_Promises.m */; };
-		BF_303453009225 /* STPEmailAddressValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_571164217949 /* STPEmailAddressValidator.m */; };
-		BF_304014796876 /* stp_card_diners_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_729563592373 /* stp_card_diners_template.png */; };
-		BF_305480418362 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_288738750739 /* GoogleNetworkingUtilities.framework */; };
-		BF_305993522699 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_201794194523 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
-		BF_307183633418 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_898308164695 /* UrlGetViewController.xib */; };
-		BF_310079826345 /* stp_card_discover@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_647718745479 /* stp_card_discover@3x.png */; };
-		BF_312154897338 /* stp_card_unknown@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_810092475433 /* stp_card_unknown@3x.png */; };
-		BF_312952331484 /* STPCardValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_698865802314 /* STPCardValidator.m */; };
-		BF_317966105622 /* stp_card_mastercard_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_262765526800 /* stp_card_mastercard_template.png */; };
-		BF_320109163276 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_248755332667 /* libPINOperation-ios-9.0.a */; };
-		BF_320665594632 /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_374760221277 /* STPAddressFieldTableViewCell.m */; };
-		BF_321466510472 = {isa = PBXBuildFile; fileRef = FR_273923590342 /* ios-app-bin-ios-12.0-Bazel.a */; };
-		BF_322096687583 /* STPCardIOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_684842129661 /* STPCardIOProxy.m */; };
-		BF_322601378894 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_411849423046 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_323276920420 /* SiriExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_188215767539 /* SiriExtension-Info.plist */; };
-		BF_325955960758 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_288738750739 /* GoogleNetworkingUtilities.framework */; };
-		BF_326848529959 /* PINOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_129106470870 /* PINOperationQueue.m */; };
-		BF_327255107530 /* STPBankAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_571217998206 /* STPBankAccount.m */; };
-		BF_328297349591 /* stp_card_form_front.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_646401499000 /* stp_card_form_front.png */; };
-		BF_328588753540 /* NoArc.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_914926894106 /* NoArc.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		BF_329590708976 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_485722511970 /* STPPaymentMethodTableViewCell.m */; };
-		BF_330025768680 /* ShareExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_172654872023 /* ShareExtension-Info.plist */; };
-		BF_330825893299 = {isa = PBXBuildFile; fileRef = FR_623276489142 /* Stripe-ios-12.0.a */; };
-		BF_331706236912 /* UIViewController+Stripe_ParentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_430541868205 /* UIViewController+Stripe_ParentViewController.m */; };
-		BF_332791913550 /* stp_card_form_back.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_858844900391 /* stp_card_form_back.png */; };
-		BF_334317196081 /* STPFormEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_667620021817 /* STPFormEncoder.m */; };
-		BF_334827842514 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_811655502329 /* GoogleAppIndexing.framework */; };
-		BF_335222063543 /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_693100679042 /* stp_shipping_form.png */; };
-		BF_335855908002 /* PINOperationGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_763548395573 /* PINOperationGroup.m */; };
-		BF_336574979229 /* stp_card_amex_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_225452001627 /* stp_card_amex_template@3x.png */; };
-		BF_336742621962 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_411849423046 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_336829476801 /* STPCard.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_286261044399 /* STPCard.m */; };
-		BF_339765826756 /* NSDecimalNumber+Stripe_Currency.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_133536345426 /* NSDecimalNumber+Stripe_Currency.m */; };
-		BF_340805802640 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_366960336468 /* Tests2.m */; };
-		BF_341888113091 /* stp_card_visa_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_420913153337 /* stp_card_visa_template@2x.png */; };
-		BF_345683328243 /* stp_card_diners_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_116888220100 /* stp_card_diners_template@2x.png */; };
-		BF_345965387817 /* STPSourceSEPADebitDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_410374790759 /* STPSourceSEPADebitDetails.m */; };
-		BF_346425895454 /* stp_card_unknown@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_359125113541 /* stp_card_unknown@2x.png */; };
-		BF_348067796375 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_288738750739 /* GoogleNetworkingUtilities.framework */; };
-		BF_348252718764 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_536507582456 /* PKPayment+Stripe.m */; };
-		BF_348584325092 /* STPSourceOwner.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_821560233640 /* STPSourceOwner.m */; };
-		BF_352399059718 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_854600736464 /* GoogleSymbolUtilities.framework */; };
-		BF_354310531169 /* STPSourceParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_635722256605 /* STPSourceParams.m */; };
-		BF_356777741414 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_366960336468 /* Tests2.m */; };
-		BF_357119474570 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_921549316179 /* NSURLComponents+Stripe.m */; };
-		BF_357673008284 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_525895464802 /* UIImage+Stripe.m */; };
-		BF_358938081806 /* STPCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_588629070354 /* STPCustomerContext.m */; };
-		BF_359338767983 /* stp_card_diners.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_367189898554 /* stp_card_diners.png */; };
-		BF_359556006908 /* STPConnectAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_401594702906 /* STPConnectAccountParams.m */; };
-		BF_359742756737 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_212516784466 /* libUrlGetClasses-ios-9.0.a */; };
-		BF_360273540863 /* stp_card_amex_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_862109982380 /* stp_card_amex_template@2x.png */; };
-		BF_362490869856 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_921549316179 /* NSURLComponents+Stripe.m */; };
-		BF_362744602801 /* StringsExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_111466561084 /* StringsExtension-Info.plist */; };
-		BF_364513652865 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_633906012597 /* GoogleAuthUtilities.framework */; };
-		BF_365040729130 /* stp_shipping_form@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_766714036471 /* stp_shipping_form@3x.png */; };
-		BF_366983124095 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_248755332667 /* libPINOperation-ios-9.0.a */; };
-		BF_367020795115 /* UINavigationController+Stripe_Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_725982103443 /* UINavigationController+Stripe_Completion.m */; };
-		BF_367918553830 /* STPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_902210249661 /* STPAPIClient.m */; };
-		BF_371622710360 /* stp_card_jcb_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_342721641775 /* stp_card_jcb_template@3x.png */; };
-		BF_374068575975 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_750021784507 /* main.m */; };
-		BF_375051384038 /* stp_card_amex_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_862109982380 /* stp_card_amex_template@2x.png */; };
-		BF_375327645367 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_633906012597 /* GoogleAuthUtilities.framework */; };
-		BF_377899036621 /* stp_card_unionpay_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_904565042407 /* stp_card_unionpay_en@2x.png */; };
-		BF_378472485206 /* stp_card_unionpay_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_404502426469 /* stp_card_unionpay_en.png */; };
-		BF_380811578651 /* STPFormTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_882491438659 /* STPFormTextField.m */; };
-		BF_382236950093 /* stp_card_visa_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_682789186016 /* stp_card_visa_template@3x.png */; };
-		BF_383201409239 /* stp_card_unionpay_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_730682142522 /* stp_card_unionpay_en@3x.png */; };
-		BF_386619076258 /* Some.cc in Sources */ = {isa = PBXBuildFile; fileRef = FR_262245891890 /* Some.cc */; };
-		BF_390871768126 /* stp_shipping_form@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_766714036471 /* stp_shipping_form@3x.png */; };
-		BF_391274054556 /* STPCardIOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_684842129661 /* STPCardIOProxy.m */; };
-		BF_391451429517 /* stp_card_cvc_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_222933926124 /* stp_card_cvc_amex@2x.png */; };
-		BF_392554858625 /* STPEphemeralKeyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_259766013406 /* STPEphemeralKeyManager.m */; };
-		BF_393274709300 /* stp_card_unionpay_template_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_600685478634 /* stp_card_unionpay_template_en@3x.png */; };
-		BF_394185826569 /* stp_card_cvc.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_765251530720 /* stp_card_cvc.png */; };
-		BF_399033254679 /* stp_card_cvc_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_510961761073 /* stp_card_cvc_amex@3x.png */; };
-		BF_399406404906 /* STPPaymentMethodTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_358026470844 /* STPPaymentMethodTuple.m */; };
-		BF_399903588308 /* STPCustomer.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_877683079452 /* STPCustomer.m */; };
-		BF_402375562608 /* STPAnalyticsClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_212125637458 /* STPAnalyticsClient.m */; };
-		BF_403737463455 /* STPImageLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_132874026439 /* STPImageLibrary.m */; };
-		BF_404707853042 /* UITableViewCell+Stripe_Borders.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_108265599351 /* UITableViewCell+Stripe_Borders.m */; };
-		BF_409148396445 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_750021784507 /* main.m */; };
-		BF_409727823462 /* STPEphemeralKey.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_472902154735 /* STPEphemeralKey.m */; };
-		BF_411983063613 /* stp_card_unionpay_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_904565042407 /* stp_card_unionpay_en@2x.png */; };
-		BF_412998867029 /* STPCustomer+SourceTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_670075701234 /* STPCustomer+SourceTuple.m */; };
-		BF_415575403969 /* STPPaymentMethodsInternalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_299182598435 /* STPPaymentMethodsInternalViewController.m */; };
-		BF_419189536555 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_145914995522 /* PINDiskCache.m */; };
-		BF_419281111160 /* STPSwitchTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_707702346637 /* STPSwitchTableViewCell.m */; };
-		BF_420886463516 /* stp_card_visa_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_420913153337 /* stp_card_visa_template@2x.png */; };
-		BF_426862576843 /* stp_icon_add@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_629820978782 /* stp_icon_add@2x.png */; };
-		BF_428554468212 /* STPSourceRedirect.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_425904257008 /* STPSourceRedirect.m */; };
-		BF_428922525784 /* STPCard.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_286261044399 /* STPCard.m */; };
-		BF_435735027381 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_155022079262 /* Localizable.strings */; };
-		BF_436060695556 /* STPSourceReceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_391523138388 /* STPSourceReceiver.m */; };
-		BF_437010218142 /* UINavigationBar+Stripe_Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_795417469207 /* UINavigationBar+Stripe_Theme.m */; };
-		BF_442034888602 /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_281509917340 /* STPValidatedTextField.m */; };
-		BF_443726715225 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_826804962981 /* GoogleAppIndexingResources.bundle */; };
-		BF_444417618277 /* libStripe-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_621770749327 /* libStripe-ios-12.0.a */; };
-		BF_445621345674 /* stp_card_unionpay_template_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_392935778985 /* stp_card_unionpay_template_en@2x.png */; };
-		BF_447035085506 /* stp_card_error_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_245329396039 /* stp_card_error_amex@3x.png */; };
-		BF_448009883519 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_898308164695 /* UrlGetViewController.xib */; };
-		BF_448298787531 /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_947777323233 /* stp_card_visa@3x.png */; };
-		BF_448636768591 /* stp_card_error_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_163201521832 /* stp_card_error_amex@2x.png */; };
-		BF_450867024855 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_525895464802 /* UIImage+Stripe.m */; };
-		BF_452964777174 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_826804962981 /* GoogleAppIndexingResources.bundle */; };
-		BF_453691812649 /* stp_card_cvc.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_765251530720 /* stp_card_cvc.png */; };
-		BF_455146692948 /* STPDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_685562832071 /* STPDelegateProxy.m */; };
-		BF_457839071858 /* stp_icon_add.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_168201804537 /* stp_icon_add.png */; };
-		BF_460201414699 /* stp_card_form_front@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_913750020022 /* stp_card_form_front@2x.png */; };
-		BF_461676883901 /* stp_card_error.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_918544604518 /* stp_card_error.png */; };
-		BF_466785343628 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_800458577779 /* libPINCache-Core-ios-9.0.a */; };
-		BF_470103336482 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_832155225473 /* UIViewController+Stripe_KeyboardAvoiding.m */; };
-		BF_473156637785 /* UrlGet-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_278392824234 /* UrlGet-Info.plist */; };
-		BF_474704211148 /* STPSourceSEPADebitDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_410374790759 /* STPSourceSEPADebitDetails.m */; };
-		BF_476586354355 /* Some.cc in Sources */ = {isa = PBXBuildFile; fileRef = FR_262245891890 /* Some.cc */; };
-		BF_476855115754 /* STPCategoryLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_535352815691 /* STPCategoryLoader.m */; };
-		BF_477001413936 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_423034687929 /* STPBankAccountParams.m */; };
-		BF_482014181254 = {isa = PBXBuildFile; fileRef = FR_856017749152 /* share-extension-Bazel.appex */; };
-		BF_482566846048 /* stp_card_mastercard_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_593438413731 /* stp_card_mastercard_template@3x.png */; };
-		BF_484582902622 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = VG_114608902985 /* AppIntentVocabulary.plist */; };
-		BF_488584558619 /* stp_card_unionpay_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_109008019044 /* stp_card_unionpay_zh@2x.png */; };
-		BF_493409401178 /* STPPaymentCardTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_646329714542 /* STPPaymentCardTextFieldCell.m */; };
-		BF_498738515507 /* stp_icon_add@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_629820978782 /* stp_icon_add@2x.png */; };
-		BF_500001159868 /* stp_card_applepay@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_224516879435 /* stp_card_applepay@2x.png */; };
-		BF_501540564246 /* stp_card_mastercard.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_721269067802 /* stp_card_mastercard.png */; };
-		BF_502186160447 /* STPBundleLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_504790352271 /* STPBundleLocator.m */; };
-		BF_504283189498 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_212516784466 /* libUrlGetClasses-ios-9.0.a */; };
-		BF_508918188322 = {isa = PBXBuildFile; fileRef = FR_826359326254 /* PINCache-Core-ios-9.0.a */; };
-		BF_511263762622 /* STPSourceVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_533049156564 /* STPSourceVerification.m */; };
-		BF_511432964645 /* STPPaymentMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_244801847772 /* STPPaymentMethodsViewController.m */; };
-		BF_512179953979 = {isa = PBXBuildFile; fileRef = FR_455050505758 /* ios-app-Bazel.app */; };
-		BF_514064561024 /* stp_card_jcb.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_357987593239 /* stp_card_jcb.png */; };
-		BF_514959088266 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_826804962981 /* GoogleAppIndexingResources.bundle */; };
-		BF_515310723788 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_394251211369 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */; };
-		BF_516667793180 /* stp_card_unionpay_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_815379450093 /* stp_card_unionpay_zh.png */; };
-		BF_523252872546 /* stp_card_discover_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_350139185969 /* stp_card_discover_template@2x.png */; };
-		BF_524600794098 = {isa = PBXBuildFile; fileRef = FR_114615400230 /* ios-ext-bin.a */; };
-		BF_525457625255 /* stp_card_discover.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_233463993954 /* stp_card_discover.png */; };
-		BF_525907241504 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_811655502329 /* GoogleAppIndexing.framework */; };
-		BF_526066794007 = {isa = PBXBuildFile; fileRef = FR_363951351315 /* UnitTestsWithHost.xctest */; };
-		BF_526124682716 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_562402903136 /* STPDispatchFunctions.m */; };
-		BF_528644484773 /* AppIntent.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_211196868537 /* AppIntent.m */; };
-		BF_529013860125 /* stp_card_discover@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_647718745479 /* stp_card_discover@3x.png */; };
-		BF_530018599708 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_298510265968 /* NSDictionary+Stripe.m */; };
-		BF_530927397099 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_582914940802 /* STPPaymentResult.m */; };
-		BF_532466961533 /* stp_card_unionpay_template_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_392935778985 /* stp_card_unionpay_template_en@2x.png */; };
-		BF_535469367015 = {isa = PBXBuildFile; fileRef = FR_888995822461 /* PINOperation-ios-12.0.a */; };
-		BF_535598920126 /* stp_card_diners@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_843574680132 /* stp_card_diners@2x.png */; };
-		BF_537009746287 /* STPShippingMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_292133108427 /* STPShippingMethodsViewController.m */; };
-		BF_537243679458 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_812073861033 /* UIViewController+Stripe_NavigationItemProxy.m */; };
-		BF_539410623152 /* UrlGetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_893633932801 /* UrlGetViewController.m */; };
-		BF_541010920711 /* stp_icon_checkmark.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_211759521425 /* stp_icon_checkmark.png */; };
-		BF_543588675087 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_898308164695 /* UrlGetViewController.xib */; };
-		BF_546663098919 /* STPCardValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_698865802314 /* STPCardValidator.m */; };
-		BF_548499415722 = {isa = PBXBuildFile; fileRef = FR_629548608649 /* HeaderLib-ios-12.0.a */; };
-		BF_548611216731 /* STPConnectAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_401594702906 /* STPConnectAccountParams.m */; };
-		BF_552016353612 /* stp_card_form_front@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_913750020022 /* stp_card_form_front@2x.png */; };
-		BF_555427361566 /* UIView+Stripe_FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_831704377129 /* UIView+Stripe_FirstResponder.m */; };
-		BF_557360414089 /* StringsExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_111466561084 /* StringsExtension-Info.plist */; };
-		BF_557363486779 = {isa = PBXBuildFile; fileRef = FR_682252300927 /* siri-ext-bin.a */; };
-		BF_557796894054 /* STPPaymentActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_333624610927 /* STPPaymentActivityIndicatorView.m */; };
-		BF_558017800984 /* stp_card_mastercard@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_573348568627 /* stp_card_mastercard@3x.png */; };
-		BF_559739092584 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_678627904183 /* InfoPlist.strings */; };
-		BF_562998659658 /* STPEphemeralKey.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_472902154735 /* STPEphemeralKey.m */; };
-		BF_564172932390 /* stp_card_unionpay_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_730682142522 /* stp_card_unionpay_en@3x.png */; };
-		BF_565278633141 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_155022079262 /* Localizable.strings */; };
-		BF_565788009969 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_411849423046 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_565899346979 = {isa = PBXBuildFile; fileRef = FR_540659108168 /* Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle */; };
-		BF_567470263986 /* libios-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_524174742878 /* libios-ext-bin.a */; };
-		BF_567572496505 /* ShareExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_172654872023 /* ShareExtension-Info.plist */; };
-		BF_568450192494 /* STPFile.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_140591238195 /* STPFile.m */; };
-		BF_568575296680 /* stp_card_diners_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_890612956832 /* stp_card_diners_template@3x.png */; };
-		BF_568983631361 /* UIViewController+Stripe_ParentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_430541868205 /* UIViewController+Stripe_ParentViewController.m */; };
-		BF_570993978338 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_405349128011 /* STPURLCallbackHandler.m */; };
-		BF_571286316834 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_795132420225 /* STPCardParams.m */; };
-		BF_572483412207 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_366960336468 /* Tests2.m */; };
-		BF_572886501248 /* STPBINRange.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_701536383989 /* STPBINRange.m */; };
-		BF_573302397311 /* stp_card_discover_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_723722683585 /* stp_card_discover_template.png */; };
-		BF_573833408368 /* STPUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_378986667073 /* STPUserInformation.m */; };
-		BF_575495041980 /* STPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_821099591187 /* STPToken.m */; };
-		BF_576354606459 /* stp_card_unionpay_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_404502426469 /* stp_card_unionpay_en.png */; };
-		BF_577973896423 /* stp_card_form_front.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_646401499000 /* stp_card_form_front.png */; };
-		BF_578222277700 /* STPCoreViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_360479079920 /* STPCoreViewController.m */; };
-		BF_579009408428 /* stp_card_cvc@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_564512028139 /* stp_card_cvc@2x.png */; };
-		BF_580445694140 = {isa = PBXBuildFile; fileRef = FR_848652416968 /* UrlGetClasses-ios-12.0.a */; };
-		BF_582818177540 /* stp_card_unionpay_template_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_357471098469 /* stp_card_unionpay_template_zh@2x.png */; };
-		BF_583859739891 /* stp_card_mastercard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_134545133893 /* stp_card_mastercard@2x.png */; };
-		BF_585200305923 /* stp_icon_add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_441528659827 /* stp_icon_add@3x.png */; };
-		BF_586572211287 /* PINOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_129106470870 /* PINOperationQueue.m */; };
-		BF_588052029111 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_268644933511 /* NSBundle+Stripe_AppName.m */; };
-		BF_588281487333 /* stp_icon_checkmark@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_549986619017 /* stp_icon_checkmark@3x.png */; };
-		BF_590736093727 /* UIView+Stripe_FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_831704377129 /* UIView+Stripe_FirstResponder.m */; };
-		BF_590916326727 /* STPPaymentCardTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_646329714542 /* STPPaymentCardTextFieldCell.m */; };
-		BF_594000401878 /* UITableViewCell+Stripe_Borders.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_108265599351 /* UITableViewCell+Stripe_Borders.m */; };
-		BF_595945633108 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_515610011898 /* Tests.m */; };
-		BF_596363109123 /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_680376588314 /* stp_card_visa@2x.png */; };
-		BF_598402182424 /* siri-extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FR_954961411422 /* siri-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BF_600862798226 /* PINOperationGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_763548395573 /* PINOperationGroup.m */; };
-		BF_601267756545 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_826804962981 /* GoogleAppIndexingResources.bundle */; };
-		BF_601614893583 /* UIView+Stripe_SafeAreaBounds.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_214657321101 /* UIView+Stripe_SafeAreaBounds.m */; };
-		BF_602716324569 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_905942270940 /* stp_card_amex@2x.png */; };
-		BF_608431584620 /* stp_card_unionpay_template_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_335380563722 /* stp_card_unionpay_template_zh@3x.png */; };
-		BF_610234742080 /* stp_card_unionpay_template_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_869656627571 /* stp_card_unionpay_template_zh.png */; };
-		BF_610936690460 /* stp_card_error@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_865204967261 /* stp_card_error@2x.png */; };
-		BF_612299065256 /* STPPaymentConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_665937321012 /* STPPaymentConfiguration.m */; };
-		BF_619043295407 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_832155225473 /* UIViewController+Stripe_KeyboardAvoiding.m */; };
-		BF_624121435354 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_298510265968 /* NSDictionary+Stripe.m */; };
-		BF_630468293679 /* stp_shipping_form@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_720785863149 /* stp_shipping_form@2x.png */; };
-		BF_633630823704 /* STPLocalizationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_246324868641 /* STPLocalizationUtils.m */; };
-		BF_633851398856 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_633906012597 /* GoogleAuthUtilities.framework */; };
-		BF_634690038552 /* empty-main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_362912493533 /* empty-main.m */; };
-		BF_636965392308 /* stp_card_visa.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_365700562027 /* stp_card_visa.png */; };
-		BF_638459995462 /* stp_card_amex_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_351223294806 /* stp_card_amex_template.png */; };
-		BF_639277334305 /* stp_card_cvc_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_384110904147 /* stp_card_cvc_amex.png */; };
-		BF_641275083979 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_849310420444 /* libStripe-ios-9.0.a */; };
-		BF_644094008036 /* stp_card_visa_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_321921907264 /* stp_card_visa_template.png */; };
-		BF_644208232226 /* stp_icon_checkmark@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_515852211545 /* stp_icon_checkmark@2x.png */; };
-		BF_644467675530 /* stp_card_cvc_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_222933926124 /* stp_card_cvc_amex@2x.png */; };
-		BF_645395559337 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_431621881643 /* stp_card_amex@3x.png */; };
-		BF_645910526538 /* stp_icon_add.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_168201804537 /* stp_icon_add.png */; };
-		BF_651270065354 = {isa = PBXBuildFile; fileRef = FR_406521029219 /* share-extension.appex */; };
-		BF_651740250714 /* STPSourceOwner.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_821560233640 /* STPSourceOwner.m */; };
-		BF_652621184570 /* stp_card_mastercard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_134545133893 /* stp_card_mastercard@2x.png */; };
-		BF_658466512126 /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_603505517320 /* stp_card_applepay.png */; };
-		BF_658517670157 /* stp_card_jcb@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_152255977769 /* stp_card_jcb@3x.png */; };
-		BF_658661428653 /* stp_card_jcb_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_304102532309 /* stp_card_jcb_template@2x.png */; };
-		BF_659595653922 /* STPPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_331287642191 /* STPPromise.m */; };
-		BF_660281679876 = {isa = PBXBuildFile; fileRef = FR_954961411422 /* siri-extension.appex */; };
-		BF_660383706439 /* stp_card_error@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_865204967261 /* stp_card_error@2x.png */; };
-		BF_663064820065 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_826804962981 /* GoogleAppIndexingResources.bundle */; };
-		BF_666754536474 /* STPColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_885437122687 /* STPColorUtils.m */; };
-		BF_668070357035 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_849310420444 /* libStripe-ios-9.0.a */; };
-		BF_668172114664 /* stp_icon_checkmark@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_515852211545 /* stp_icon_checkmark@2x.png */; };
-		BF_671407416528 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_854600736464 /* GoogleSymbolUtilities.framework */; };
-		BF_671920274269 /* libUrlGetClasses-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_193583997594 /* libUrlGetClasses-ios-12.0.a */; };
-		BF_671995804046 /* stp_card_jcb@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_152255977769 /* stp_card_jcb@3x.png */; };
-		BF_674771939222 /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_374760221277 /* STPAddressFieldTableViewCell.m */; };
-		BF_678407634641 /* STPPaymentCardTextFieldViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_301311350687 /* STPPaymentCardTextFieldViewModel.m */; };
-		BF_681339998507 /* NSString+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_129103540819 /* NSString+Stripe.m */; };
-		BF_681822233576 /* STPAddressViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_923168362961 /* STPAddressViewModel.m */; };
-		BF_684105594855 /* STPFormEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_667620021817 /* STPFormEncoder.m */; };
-		BF_684731147515 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_181204666019 /* STPStringUtils.m */; };
-		BF_685020284145 /* NSArray+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_760953752264 /* NSArray+Stripe.m */; };
-		BF_687822364709 /* UINavigationController+Stripe_Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_725982103443 /* UINavigationController+Stripe_Completion.m */; };
-		BF_688646249911 /* STPPaymentMethodTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_358026470844 /* STPPaymentMethodTuple.m */; };
-		BF_688863603246 /* STPTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_792160814884 /* STPTheme.m */; };
-		BF_690477533380 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_212516784466 /* libUrlGetClasses-ios-9.0.a */; };
-		BF_692924768908 /* STPCustomer+SourceTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_670075701234 /* STPCustomer+SourceTuple.m */; };
-		BF_693488309939 /* stp_card_discover_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_723722683585 /* stp_card_discover_template.png */; };
-		BF_694055106197 /* UIBarButtonItem+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_416373643255 /* UIBarButtonItem+Stripe.m */; };
-		BF_694891200528 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_398590689728 /* PINMemoryCache.m */; };
-		BF_699699725999 /* stp_card_mastercard_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_764521294758 /* stp_card_mastercard_template@2x.png */; };
-		BF_700314907952 /* stp_card_error@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_900806134110 /* stp_card_error@3x.png */; };
-		BF_700378609220 /* STPShippingAddressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_919742180124 /* STPShippingAddressViewController.m */; };
-		BF_701520676613 /* stp_icon_add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_441528659827 /* stp_icon_add@3x.png */; };
-		BF_704606397648 = {isa = PBXBuildFile; fileRef = FR_542815357791 /* UrlGetClasses-ios-9.0.a */; };
-		BF_706447119810 /* stp_card_cvc@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_305781761228 /* stp_card_cvc@3x.png */; };
-		BF_706868895649 /* stp_card_diners.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_367189898554 /* stp_card_diners.png */; };
-		BF_709718469977 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_905942270940 /* stp_card_amex@2x.png */; };
-		BF_709949473572 /* STPCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_588629070354 /* STPCustomerContext.m */; };
-		BF_710773766335 /* stp_card_discover.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_233463993954 /* stp_card_discover.png */; };
-		BF_712386002629 /* stp_card_diners_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_890612956832 /* stp_card_diners_template@3x.png */; };
-		BF_716146555260 /* STPTelemetryClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_401389674811 /* STPTelemetryClient.m */; };
-		BF_717229444807 /* stp_card_unionpay_template_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_700870847596 /* stp_card_unionpay_template_en.png */; };
-		BF_717459077016 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_887912048029 /* STPPaymentContextAmountModel.m */; };
-		BF_717739686355 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_653012245890 /* AppDelegate.m */; };
-		BF_717854369550 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_536507582456 /* PKPayment+Stripe.m */; };
-		BF_722312549299 /* stp_card_discover_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_600826957346 /* stp_card_discover_template@3x.png */; };
-		BF_724404388963 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_750021784507 /* main.m */; };
-		BF_727339949695 = {isa = PBXBuildFile; fileRef = FR_903524758896 /* HeaderLib-ios-9.0.a */; };
-		BF_733219284589 /* stp_card_applepay@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_277947155239 /* stp_card_applepay@3x.png */; };
-		BF_735729279605 /* stp_shipping_form@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_720785863149 /* stp_shipping_form@2x.png */; };
-		BF_741374908450 /* stp_card_applepay@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_224516879435 /* stp_card_applepay@2x.png */; };
-		BF_741839336888 /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_281509917340 /* STPValidatedTextField.m */; };
-		BF_744238514087 /* libios-app-bin-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_571118315125 /* libios-app-bin-ios-12.0.a */; };
-		BF_744545583275 /* libPINOperation-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_127927644982 /* libPINOperation-ios-12.0.a */; };
-		BF_747326481621 /* STPPhoneNumberValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_209621477518 /* STPPhoneNumberValidator.m */; };
-		BF_749296953649 /* STPDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_685562832071 /* STPDelegateProxy.m */; };
-		BF_750587250854 /* stp_card_visa_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_682789186016 /* stp_card_visa_template@3x.png */; };
-		BF_754839459209 /* UIToolbar+Stripe_InputAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_652869617708 /* UIToolbar+Stripe_InputAccessory.m */; };
-		BF_761106931406 /* stp_card_mastercard.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_721269067802 /* stp_card_mastercard.png */; };
-		BF_761751358527 /* stp_card_diners_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_116888220100 /* stp_card_diners_template@2x.png */; };
-		BF_762619699159 /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_732694155215 /* STPPostalCodeValidator.m */; };
-		BF_762901813901 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_714589191537 /* STPAddress.m */; };
-		BF_765883201183 /* STPPaymentMethodsInternalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_299182598435 /* STPPaymentMethodsInternalViewController.m */; };
-		BF_771058537523 /* NSMutableURLRequest+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_900155382855 /* NSMutableURLRequest+Stripe.m */; };
-		BF_774518809346 /* STPPaymentActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_333624610927 /* STPPaymentActivityIndicatorView.m */; };
-		BF_775562182682 /* STPPaymentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_459740821355 /* STPPaymentContext.m */; };
-		BF_776288618153 /* STPCoreTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_149930208538 /* STPCoreTableViewController.m */; };
-		BF_778116345176 /* STPMultipartFormDataPart.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_442086127483 /* STPMultipartFormDataPart.m */; };
-		BF_782481236915 /* SiriExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_188215767539 /* SiriExtension-Info.plist */; };
-		BF_782481571388 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_405349128011 /* STPURLCallbackHandler.m */; };
-		BF_784420904480 /* stp_card_applepay@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_277947155239 /* stp_card_applepay@3x.png */; };
-		BF_786763717602 /* stp_card_cvc@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_305781761228 /* stp_card_cvc@3x.png */; };
-		BF_789772667851 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_840677560290 /* STPSource.m */; };
-		BF_792141876040 /* NSError+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_444626220675 /* NSError+Stripe.m */; };
-		BF_792780296590 /* STPApplePayPaymentMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_949688277225 /* STPApplePayPaymentMethod.m */; };
-		BF_794851605037 /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_466487462811 /* STPAPIClient+ApplePay.m */; };
-		BF_795635276960 /* STPCustomer.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_877683079452 /* STPCustomer.m */; };
-		BF_800102620410 = {isa = PBXBuildFile; fileRef = FR_420127068589 /* strings-ext-bin.a */; };
-		BF_801891862929 /* stp_card_error_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_903119597428 /* stp_card_error_amex.png */; };
-		BF_802286475739 /* stp_test_upload_image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = FR_474718748706 /* stp_test_upload_image.jpeg */; };
-		BF_806612012743 /* STPColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_885437122687 /* STPColorUtils.m */; };
-		BF_810836455395 /* stp_card_visa_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_321921907264 /* stp_card_visa_template.png */; };
-		BF_811858844530 /* stp_test_upload_image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = FR_474718748706 /* stp_test_upload_image.jpeg */; };
-		BF_816549455071 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_201794194523 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
-		BF_818100860778 /* share-extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FR_406521029219 /* share-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		BF_821198094022 /* stp_card_unknown.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_896260771039 /* stp_card_unknown.png */; };
-		BF_821662620929 /* stp_card_jcb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_250835929950 /* stp_card_jcb@2x.png */; };
-		BF_824131982577 /* stp_card_form_back@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_608546669129 /* stp_card_form_back@2x.png */; };
-		BF_824727108130 /* NSError+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_444626220675 /* NSError+Stripe.m */; };
-		BF_829125851855 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_800458577779 /* libPINCache-Core-ios-9.0.a */; };
-		BF_829899373145 /* stp_card_error_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_903119597428 /* stp_card_error_amex.png */; };
-		BF_829996789142 /* STPPaymentMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_244801847772 /* STPPaymentMethodsViewController.m */; };
-		BF_830707417459 /* STPCoreTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_149930208538 /* STPCoreTableViewController.m */; };
-		BF_830785039128 /* AppJerry.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_813232904291 /* AppJerry.m */; };
-		BF_831428181811 /* stp_card_mastercard@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_573348568627 /* stp_card_mastercard@3x.png */; };
-		BF_831554238419 /* STPTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_792160814884 /* STPTheme.m */; };
-		BF_832762337643 /* stp_card_unknown.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_896260771039 /* stp_card_unknown.png */; };
-		BF_836567493548 /* STPAddCardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_768451756079 /* STPAddCardViewController.m */; };
-		BF_840912639158 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_582914940802 /* STPPaymentResult.m */; };
-		BF_846266256497 /* stp_card_form_front@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_188039461400 /* stp_card_form_front@3x.png */; };
-		BF_846807679897 /* STPEphemeralKeyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_259766013406 /* STPEphemeralKeyManager.m */; };
-		BF_850485617255 /* UIViewController+Stripe_Promises.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_499853310274 /* UIViewController+Stripe_Promises.m */; };
-		BF_851459631362 /* stp_card_jcb_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_304102532309 /* stp_card_jcb_template@2x.png */; };
-		BF_853779262143 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_268644933511 /* NSBundle+Stripe_AppName.m */; };
-		BF_853830505770 /* stp_card_discover_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_600826957346 /* stp_card_discover_template@3x.png */; };
-		BF_854573230512 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_181204666019 /* STPStringUtils.m */; };
-		BF_854645228836 = {isa = PBXBuildFile; fileRef = FR_515456468255 /* PINCache-Arc-exception-safe-ios-12.0.a */; };
-		BF_857739777837 = {isa = PBXBuildFile; fileRef = FR_722755400736 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */; };
-		BF_859496121002 /* stp_card_error_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_163201521832 /* stp_card_error_amex@2x.png */; };
-		BF_859645923890 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_758089556382 /* stp_card_amex.png */; };
-		BF_863030455665 /* NSMutableURLRequest+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_900155382855 /* NSMutableURLRequest+Stripe.m */; };
-		BF_864173425247 /* STPShippingMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_574931413907 /* STPShippingMethodTableViewCell.m */; };
-		BF_864531662511 /* STPUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_378986667073 /* STPUserInformation.m */; };
-		BF_866026142598 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_653012245890 /* AppDelegate.m */; };
-		BF_866343933368 /* stp_card_cvc_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_510961761073 /* stp_card_cvc_amex@3x.png */; };
-		BF_866458893589 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_423034687929 /* STPBankAccountParams.m */; };
-		BF_868002786765 /* stp_card_discover@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_393570962306 /* stp_card_discover@2x.png */; };
-		BF_868227706673 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_474020775691 /* STPSectionHeaderView.m */; };
-		BF_868707412367 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_826804962981 /* GoogleAppIndexingResources.bundle */; };
-		BF_870532528736 /* NSArray+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_760953752264 /* NSArray+Stripe.m */; };
-		BF_873260921632 /* stp_card_jcb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_250835929950 /* stp_card_jcb@2x.png */; };
-		BF_873274540292 /* STPLegalEntityParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_160651095057 /* STPLegalEntityParams.m */; };
-		BF_876436210306 /* STPAspects.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_143462498570 /* STPAspects.m */; };
-		BF_877506999100 /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_121139739215 /* PINCache.m */; };
-		BF_877574233419 /* STPFile.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_140591238195 /* STPFile.m */; };
-		BF_879803241770 /* UIToolbar+Stripe_InputAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_652869617708 /* UIToolbar+Stripe_InputAccessory.m */; };
-		BF_880308943657 /* STPShippingAddressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_919742180124 /* STPShippingAddressViewController.m */; };
-		BF_884680354641 /* STPSourceReceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_391523138388 /* STPSourceReceiver.m */; };
-		BF_885266926004 /* STPSourceParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_635722256605 /* STPSourceParams.m */; };
-		BF_886805532652 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_714589191537 /* STPAddress.m */; };
-		BF_890330557077 /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_732694155215 /* STPPostalCodeValidator.m */; };
-		BF_891898890632 /* STPEmailAddressValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_571164217949 /* STPEmailAddressValidator.m */; };
-		BF_892293230903 /* STPAspects.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_143462498570 /* STPAspects.m */; };
-		BF_895462989558 /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_680376588314 /* stp_card_visa@2x.png */; };
-		BF_895946163682 /* NSDecimalNumber+Stripe_Currency.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_133536345426 /* NSDecimalNumber+Stripe_Currency.m */; };
-		BF_899887368282 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_758089556382 /* stp_card_amex.png */; };
-		BF_900333015026 = {isa = PBXBuildFile; fileRef = FR_606050766824 /* UnitTests.xctest */; };
-		BF_900665729924 /* stp_card_unionpay_template_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_357471098469 /* stp_card_unionpay_template_zh@2x.png */; };
-		BF_901299363102 = {isa = PBXBuildFile; fileRef = FR_409503237802 /* strings-extension.appex */; };
-		BF_905434179310 /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_603505517320 /* stp_card_applepay.png */; };
-		BF_905699555770 /* STPShippingMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_292133108427 /* STPShippingMethodsViewController.m */; };
-		BF_905923166361 /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_693100679042 /* stp_shipping_form.png */; };
-		BF_906623330959 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_854600736464 /* GoogleSymbolUtilities.framework */; };
-		BF_910355536240 /* STPSourceVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_533049156564 /* STPSourceVerification.m */; };
-		BF_910956119925 /* stp_card_form_front@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_188039461400 /* stp_card_form_front@3x.png */; };
-		BF_913254331471 /* UrlGetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_893633932801 /* UrlGetViewController.m */; };
-		BF_914420886758 /* STPLegalEntityParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_160651095057 /* STPLegalEntityParams.m */; };
-		BF_915120825897 /* STPSourceCardDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_264105247925 /* STPSourceCardDetails.m */; };
-		BF_918611492613 /* STPFormTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_882491438659 /* STPFormTextField.m */; };
-		BF_918717765723 /* stp_card_jcb_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_651709914966 /* stp_card_jcb_template.png */; };
-		BF_918810591389 /* STPAddCardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_768451756079 /* STPAddCardViewController.m */; };
-		BF_920145620820 /* stp_card_discover@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_393570962306 /* stp_card_discover@2x.png */; };
-		BF_920949703527 /* STPShippingMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_574931413907 /* STPShippingMethodTableViewCell.m */; };
-		BF_921453502635 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_840677560290 /* STPSource.m */; };
-		BF_922087642865 = {isa = PBXBuildFile; fileRef = FR_210478864884 /* ios-app.app */; };
-		BF_922087774493 /* libsiri-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_538830033660 /* libsiri-ext-bin.a */; };
-		BF_942886377746 /* StripeError.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_682270288359 /* StripeError.m */; };
-		BF_944282656193 /* NoArc.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_914926894106 /* NoArc.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
-		BF_947884094924 /* stp_card_error.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_918544604518 /* stp_card_error.png */; };
-		BF_994959222749 /* StripeError.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_682270288359 /* StripeError.m */; };
-		BF_996964839134 /* stp_card_unionpay_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_805132164928 /* stp_card_unionpay_zh@3x.png */; };
+		BF_100274673343 /* STPLocalizationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_804931815947 /* STPLocalizationUtils.m */; };
+		BF_101124874614 /* stp_card_unionpay_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_903389206028 /* stp_card_unionpay_en.png */; };
+		BF_101696638053 /* UIToolbar+Stripe_InputAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_671973988729 /* UIToolbar+Stripe_InputAccessory.m */; };
+		BF_103245487545 /* stp_card_jcb@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_845546175975 /* stp_card_jcb@3x.png */; };
+		BF_103694247729 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_893676537074 /* UIImage+Stripe.m */; };
+		BF_105517386350 /* UINavigationBar+Stripe_Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_444167311156 /* UINavigationBar+Stripe_Theme.m */; };
+		BF_107108550206 /* stp_card_jcb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_850087254357 /* stp_card_jcb@2x.png */; };
+		BF_108316715201 /* stp_card_diners@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_627381929349 /* stp_card_diners@2x.png */; };
+		BF_108610441744 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_279407611271 /* GoogleAppIndexing.framework */; };
+		BF_109258723947 /* stp_card_unionpay_template_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_850832029853 /* stp_card_unionpay_template_en@2x.png */; };
+		BF_109764027775 /* NSDecimalNumber+Stripe_Currency.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_458195826767 /* NSDecimalNumber+Stripe_Currency.m */; };
+		BF_109966380663 /* UINavigationController+Stripe_Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_346528843102 /* UINavigationController+Stripe_Completion.m */; };
+		BF_113413991490 /* stp_card_unknown@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_712193767199 /* stp_card_unknown@2x.png */; };
+		BF_114850185058 /* stp_card_unknown.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_105312376394 /* stp_card_unknown.png */; };
+		BF_114932459163 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_203221802802 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */; };
+		BF_117502561685 /* STPCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_737402177737 /* STPCustomerContext.m */; };
+		BF_119645591539 /* stp_card_error_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_484197994638 /* stp_card_error_amex.png */; };
+		BF_121480881992 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_536395162937 /* Tests2.m */; };
+		BF_123753384584 /* STPPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_262712408620 /* STPPromise.m */; };
+		BF_125972534564 /* STPSourceParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_232273873872 /* STPSourceParams.m */; };
+		BF_128971879565 /* NSArray+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_756148561161 /* NSArray+Stripe.m */; };
+		BF_130673719455 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_442182732790 /* stp_card_amex.png */; };
+		BF_131133471911 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_358371710400 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_131339518258 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_266084204646 /* GoogleNetworkingUtilities.framework */; };
+		BF_133598338587 /* stp_icon_checkmark.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_899762404898 /* stp_icon_checkmark.png */; };
+		BF_134442304375 /* STPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_307775792133 /* STPAPIClient.m */; };
+		BF_134718521602 /* STPSourceReceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_748789438654 /* STPSourceReceiver.m */; };
+		BF_135400479659 = {isa = PBXBuildFile; fileRef = FR_158773525708 /* Stripe-ios-9.0.a */; };
+		BF_136565438106 = {isa = PBXBuildFile; fileRef = FR_490180650504 /* HeaderLib-ios-9.0.a */; };
+		BF_140074296679 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_920585382813 /* STPURLCallbackHandler.m */; };
+		BF_142196224122 /* STPPaymentCardTextFieldViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_758823072707 /* STPPaymentCardTextFieldViewModel.m */; };
+		BF_142425411680 /* STPCategoryLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_292969540570 /* STPCategoryLoader.m */; };
+		BF_147606888253 /* STPPaymentCardTextFieldViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_758823072707 /* STPPaymentCardTextFieldViewModel.m */; };
+		BF_155219890949 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_983905050479 /* libStripe-ios-9.0.a */; };
+		BF_159799755155 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_400311668699 /* UrlGetViewController.xib */; };
+		BF_160063044439 /* stp_card_visa_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_603413644505 /* stp_card_visa_template@3x.png */; };
+		BF_164430738197 /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_137435447838 /* stp_card_applepay.png */; };
+		BF_164915460778 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_121714099050 /* NSURLComponents+Stripe.m */; };
+		BF_165600087343 /* stp_card_amex_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_888354852550 /* stp_card_amex_template@3x.png */; };
+		BF_166442928755 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_358371710400 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_167030847429 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_486189815482 /* UIViewController+Stripe_KeyboardAvoiding.m */; };
+		BF_168857660714 /* stp_card_diners.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_729823338412 /* stp_card_diners.png */; };
+		BF_171630640450 /* STPBINRange.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_493600713592 /* STPBINRange.m */; };
+		BF_172899996745 /* STPPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_262712408620 /* STPPromise.m */; };
+		BF_172927922956 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_315742577216 /* GoogleAppIndexingResources.bundle */; };
+		BF_173202650643 /* stp_card_jcb_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_658835132655 /* stp_card_jcb_template@2x.png */; };
+		BF_173813426925 /* STPSourceOwner.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_244673885284 /* STPSourceOwner.m */; };
+		BF_177307157856 /* stp_card_discover_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_453308441391 /* stp_card_discover_template.png */; };
+		BF_178296374184 /* STPBankAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_877692020624 /* STPBankAccount.m */; };
+		BF_178534895222 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_315742577216 /* GoogleAppIndexingResources.bundle */; };
+		BF_183102629175 /* STPMultipartFormDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_125415528864 /* STPMultipartFormDataEncoder.m */; };
+		BF_183600234372 /* STPCard.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_884510017797 /* STPCard.m */; };
+		BF_184896725550 /* NSMutableURLRequest+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_645419483261 /* NSMutableURLRequest+Stripe.m */; };
+		BF_185178162233 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_315742577216 /* GoogleAppIndexingResources.bundle */; };
+		BF_185332479298 /* STPUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_121783217597 /* STPUserInformation.m */; };
+		BF_186089854896 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_504407375548 /* main.m */; };
+		BF_187006970888 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_279407611271 /* GoogleAppIndexing.framework */; };
+		BF_187422130445 /* STPPaymentMethodsInternalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_586728708045 /* STPPaymentMethodsInternalViewController.m */; };
+		BF_188335189101 /* STPShippingAddressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_671168073175 /* STPShippingAddressViewController.m */; };
+		BF_189548205092 /* UINavigationController+Stripe_Completion.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_346528843102 /* UINavigationController+Stripe_Completion.m */; };
+		BF_192535636513 /* stp_icon_add@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_572570595015 /* stp_icon_add@2x.png */; };
+		BF_196128104624 /* STPColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_920605117287 /* STPColorUtils.m */; };
+		BF_196950904168 /* stp_card_mastercard_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_172053165053 /* stp_card_mastercard_template.png */; };
+		BF_199117639807 /* libios-app-bin-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_315250298335 /* libios-app-bin-ios-12.0.a */; };
+		BF_199660305922 /* stp_card_applepay@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_738901483927 /* stp_card_applepay@3x.png */; };
+		BF_200319378214 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_223058608906 /* GoogleAuthUtilities.framework */; };
+		BF_201607326392 /* STPPaymentCardTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_163191866606 /* STPPaymentCardTextField.m */; };
+		BF_204056941971 /* libPINCache-Core-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_362487785619 /* libPINCache-Core-ios-12.0.a */; };
+		BF_207307727233 /* STPPaymentCardTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_180176959680 /* STPPaymentCardTextFieldCell.m */; };
+		BF_208174339023 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = VG_786904937064 /* AppIntentVocabulary.plist */; };
+		BF_208200642556 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_256989447831 /* STPCardParams.m */; };
+		BF_212568242204 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_819003985091 /* stp_card_amex@2x.png */; };
+		BF_216038054570 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_315742577216 /* GoogleAppIndexingResources.bundle */; };
+		BF_216421196016 /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_685465727036 /* STPAddressFieldTableViewCell.m */; };
+		BF_219546294511 /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_296070546472 /* STPValidatedTextField.m */; };
+		BF_219941413000 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_418726020237 /* PKPayment+Stripe.m */; };
+		BF_220255122560 /* libsiri-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_319425446576 /* libsiri-ext-bin.a */; };
+		BF_222528507364 /* stp_card_jcb_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_514487626366 /* stp_card_jcb_template@3x.png */; };
+		BF_222668415136 /* stp_card_applepay@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_575533640387 /* stp_card_applepay@2x.png */; };
+		BF_224938006679 /* STPCoreTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_413344087887 /* STPCoreTableViewController.m */; };
+		BF_226661331092 /* stp_card_error_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_521763319067 /* stp_card_error_amex@2x.png */; };
+		BF_226981093908 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_536395162937 /* Tests2.m */; };
+		BF_228195677607 /* stp_card_cvc_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_235580276653 /* stp_card_cvc_amex.png */; };
+		BF_229308595261 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_358371710400 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_230551849999 /* STPSourceVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_537691850882 /* STPSourceVerification.m */; };
+		BF_230644991492 /* stp_card_error_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_266277694519 /* stp_card_error_amex@3x.png */; };
+		BF_231774139577 /* libstrings-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_444421953328 /* libstrings-ext-bin.a */; };
+		BF_232883660073 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_103239545125 /* STPBankAccountParams.m */; };
+		BF_232927852310 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_483720092972 /* Tests.m */; };
+		BF_234401736452 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_592203597580 /* PINDiskCache.m */; };
+		BF_235695427968 /* stp_card_discover_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_453308441391 /* stp_card_discover_template.png */; };
+		BF_238657646724 /* SiriExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_431351183220 /* SiriExtension-Info.plist */; };
+		BF_239510425645 /* stp_card_error@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_511984329756 /* stp_card_error@3x.png */; };
+		BF_241045157010 /* STPPaymentMethodTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_542871956439 /* STPPaymentMethodTuple.m */; };
+		BF_241548171115 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_354572980175 /* STPSource.m */; };
+		BF_243036252140 /* STPPaymentMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_243169012465 /* STPPaymentMethodsViewController.m */; };
+		BF_248414016722 /* stp_card_unionpay_template_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_857085055871 /* stp_card_unionpay_template_zh@3x.png */; };
+		BF_249067817230 /* libUrlGetClasses-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_761481658638 /* libUrlGetClasses-ios-12.0.a */; };
+		BF_250759401629 /* UITableViewCell+Stripe_Borders.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_594028262377 /* UITableViewCell+Stripe_Borders.m */; };
+		BF_252211499394 /* share-extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FR_339590863894 /* share-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		BF_254374484218 /* stp_card_visa_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_309931703660 /* stp_card_visa_template@2x.png */; };
+		BF_255476020818 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_195771909498 /* UIViewController+Stripe_NavigationItemProxy.m */; };
+		BF_257491728292 /* STPCardIOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_641447449553 /* STPCardIOProxy.m */; };
+		BF_258022929512 /* stp_card_jcb.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_802404793893 /* stp_card_jcb.png */; };
+		BF_258237757952 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_203221802802 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */; };
+		BF_259477981462 /* UIView+Stripe_FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_138052789861 /* UIView+Stripe_FirstResponder.m */; };
+		BF_259633161334 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_541854991234 /* STPAddress.m */; };
+		BF_260518559305 = {isa = PBXBuildFile; fileRef = FR_442378964830 /* UrlGetClasses-ios-9.0.a */; };
+		BF_260820706082 /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_387881769002 /* STPAPIClient+ApplePay.m */; };
+		BF_260924159513 /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_362145144513 /* stp_card_visa@3x.png */; };
+		BF_261816938453 /* UIView+Stripe_FirstResponder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_138052789861 /* UIView+Stripe_FirstResponder.m */; };
+		BF_261997361195 /* stp_card_unionpay_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_157313604927 /* stp_card_unionpay_en@3x.png */; };
+		BF_264893894510 /* STPCoreViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_326732228556 /* STPCoreViewController.m */; };
+		BF_265888526563 = {isa = PBXBuildFile; fileRef = FR_538821595566 /* ios-ext-bin.a */; };
+		BF_267173406940 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_738184609669 /* STPRedirectContext.m */; };
+		BF_269150351537 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_619129721469 /* NSDictionary+Stripe.m */; };
+		BF_270065822659 /* stp_card_cvc_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_401009960707 /* stp_card_cvc_amex@2x.png */; };
+		BF_270167025452 /* stp_card_unionpay_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_575113983346 /* stp_card_unionpay_zh@2x.png */; };
+		BF_271526159025 /* stp_card_diners.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_729823338412 /* stp_card_diners.png */; };
+		BF_272113176119 /* StripeError.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_173522648416 /* StripeError.m */; };
+		BF_275638145040 /* UITableViewCell+Stripe_Borders.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_594028262377 /* UITableViewCell+Stripe_Borders.m */; };
+		BF_277322724152 = {isa = PBXBuildFile; fileRef = FR_426131539244 /* PINOperation-ios-9.0.a */; };
+		BF_279334644411 /* STPSourceVerification.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_537691850882 /* STPSourceVerification.m */; };
+		BF_280227026388 /* STPTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_345350465673 /* STPTheme.m */; };
+		BF_281523435484 /* STPMultipartFormDataPart.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_800682286459 /* STPMultipartFormDataPart.m */; };
+		BF_285772620346 /* libPINCache-Arc-exception-safe-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_693961626544 /* libPINCache-Arc-exception-safe-ios-12.0.a */; };
+		BF_289141294143 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_157144616729 /* STPDispatchFunctions.m */; };
+		BF_289830003162 /* stp_shipping_form@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_711215481061 /* stp_shipping_form@3x.png */; };
+		BF_290918553966 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_486189815482 /* UIViewController+Stripe_KeyboardAvoiding.m */; };
+		BF_291239156030 /* STPImageLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_758328319458 /* STPImageLibrary.m */; };
+		BF_292698780858 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_358371710400 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_292726349028 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_384868030190 /* STPPaymentResult.m */; };
+		BF_294887808906 /* stp_card_error@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_622346843396 /* stp_card_error@2x.png */; };
+		BF_296620143340 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_315742577216 /* GoogleAppIndexingResources.bundle */; };
+		BF_298563852136 /* stp_icon_checkmark@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_108219390614 /* stp_icon_checkmark@3x.png */; };
+		BF_298654210237 /* STPCustomer+SourceTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_145973180178 /* STPCustomer+SourceTuple.m */; };
+		BF_301552859288 /* stp_card_mastercard_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_207425658966 /* stp_card_mastercard_template@3x.png */; };
+		BF_303588280111 /* stp_card_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_442182732790 /* stp_card_amex.png */; };
+		BF_305167951630 /* STPAddressFieldTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_685465727036 /* STPAddressFieldTableViewCell.m */; };
+		BF_305414781984 /* stp_card_cvc.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_136210399342 /* stp_card_cvc.png */; };
+		BF_305502748954 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_759813942983 /* stp_card_amex@3x.png */; };
+		BF_307104635179 /* STPSourceSEPADebitDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_641806051736 /* STPSourceSEPADebitDetails.m */; };
+		BF_307155949021 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_903485295144 /* libPINOperation-ios-9.0.a */; };
+		BF_307219991943 /* stp_card_unionpay_template_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_850832029853 /* stp_card_unionpay_template_en@2x.png */; };
+		BF_309012133583 /* STPSourceRedirect.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_248552697129 /* STPSourceRedirect.m */; };
+		BF_309887196265 /* stp_shipping_form@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_711764376983 /* stp_shipping_form@2x.png */; };
+		BF_311988154246 /* STPBankAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_103239545125 /* STPBankAccountParams.m */; };
+		BF_312927315865 /* stp_card_mastercard@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_871811812819 /* stp_card_mastercard@3x.png */; };
+		BF_313912264532 /* stp_card_jcb_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_193764108659 /* stp_card_jcb_template.png */; };
+		BF_313963402708 /* STPPaymentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_184070624316 /* STPPaymentContext.m */; };
+		BF_315928120735 /* STPRedirectContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_738184609669 /* STPRedirectContext.m */; };
+		BF_316621845845 /* STPAddCardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_643601304366 /* STPAddCardViewController.m */; };
+		BF_319029929518 /* STPEphemeralKey.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_253971462755 /* STPEphemeralKey.m */; };
+		BF_320028920961 /* stp_card_error.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_803217793216 /* stp_card_error.png */; };
+		BF_321919324151 /* stp_card_form_front@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_396079641272 /* stp_card_form_front@3x.png */; };
+		BF_322268505656 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_304125809938 /* STPStringUtils.m */; };
+		BF_322952319846 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_504407375548 /* main.m */; };
+		BF_324500998307 /* stp_card_form_front.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_875062748093 /* stp_card_form_front.png */; };
+		BF_330933072418 /* stp_card_visa_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_603413644505 /* stp_card_visa_template@3x.png */; };
+		BF_330945938768 /* stp_card_visa_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_826786322062 /* stp_card_visa_template.png */; };
+		BF_332204318117 /* StringsExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_603748432416 /* StringsExtension-Info.plist */; };
+		BF_334033244059 /* STPStringUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_304125809938 /* STPStringUtils.m */; };
+		BF_336658452108 /* stp_card_discover@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_114970438289 /* stp_card_discover@2x.png */; };
+		BF_338809556807 /* empty-main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_632648320726 /* empty-main.m */; };
+		BF_340779968144 /* PINOperationGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_847516745795 /* PINOperationGroup.m */; };
+		BF_340837542068 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_279407611271 /* GoogleAppIndexing.framework */; };
+		BF_341917218902 /* stp_card_discover_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_654523445914 /* stp_card_discover_template@3x.png */; };
+		BF_342817674102 /* STPSourceSEPADebitDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_641806051736 /* STPSourceSEPADebitDetails.m */; };
+		BF_343062773610 /* NSURLComponents+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_121714099050 /* NSURLComponents+Stripe.m */; };
+		BF_346790367319 = {isa = PBXBuildFile; fileRef = FR_140640746934 /* ios-app-bin-ios-12.0-Bazel.a */; };
+		BF_348558215255 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_843603205312 /* InfoPlist.strings */; };
+		BF_348622537075 /* NSError+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_688759072197 /* NSError+Stripe.m */; };
+		BF_349434446956 = {isa = PBXBuildFile; fileRef = FR_891271893429 /* share-extension-Bazel.appex */; };
+		BF_354403598900 /* stp_icon_add@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_572570595015 /* stp_icon_add@2x.png */; };
+		BF_356314905143 /* STPConnectAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_717345258349 /* STPConnectAccountParams.m */; };
+		BF_357875023006 /* STPApplePayPaymentMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_476535447008 /* STPApplePayPaymentMethod.m */; };
+		BF_358882162875 /* STPCardParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_256989447831 /* STPCardParams.m */; };
+		BF_359469183277 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_855525910280 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
+		BF_360519124898 /* STPLegalEntityParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_916780536843 /* STPLegalEntityParams.m */; };
+		BF_364211303092 /* STPTelemetryClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_608836942526 /* STPTelemetryClient.m */; };
+		BF_368597544029 /* NSCharacterSet+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_463700594726 /* NSCharacterSet+Stripe.m */; };
+		BF_369008538290 /* stp_card_form_front.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_875062748093 /* stp_card_form_front.png */; };
+		BF_373917923789 /* STPCustomerContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_737402177737 /* STPCustomerContext.m */; };
+		BF_377593636507 /* stp_icon_checkmark@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_108219390614 /* stp_icon_checkmark@3x.png */; };
+		BF_382837408791 /* STPFormTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_169667767185 /* STPFormTextField.m */; };
+		BF_384834315673 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_692892454609 /* STPPaymentMethodTableViewCell.m */; };
+		BF_386112719566 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_400311668699 /* UrlGetViewController.xib */; };
+		BF_386820352239 /* StripeError.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_173522648416 /* StripeError.m */; };
+		BF_393006822716 /* stp_card_visa_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_309931703660 /* stp_card_visa_template@2x.png */; };
+		BF_393120345753 /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_201870136181 /* STPPostalCodeValidator.m */; };
+		BF_397849206281 = {isa = PBXBuildFile; fileRef = FR_617004790111 /* strings-ext-bin.a */; };
+		BF_401587573828 /* stp_card_mastercard_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_199879867824 /* stp_card_mastercard_template@2x.png */; };
+		BF_404321197298 = {isa = PBXBuildFile; fileRef = FR_393790783742 /* ios-app.app */; };
+		BF_405532512588 /* stp_card_discover.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_152009236735 /* stp_card_discover.png */; };
+		BF_405876690622 = {isa = PBXBuildFile; fileRef = FR_708974059261 /* Stripe-ios-12.0.a */; };
+		BF_407054767379 /* stp_card_unionpay_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_331262609749 /* stp_card_unionpay_zh@3x.png */; };
+		BF_407107487779 = {isa = PBXBuildFile; fileRef = FR_132248253085 /* UnitTestsWithHost.xctest */; };
+		BF_407383359390 /* STPCoreTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_413344087887 /* STPCoreTableViewController.m */; };
+		BF_408463999523 /* stp_card_form_back.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_211689055946 /* stp_card_form_back.png */; };
+		BF_409555442064 /* stp_card_discover@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_613129380815 /* stp_card_discover@3x.png */; };
+		BF_409849167455 /* STPSourceRedirect.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_248552697129 /* STPSourceRedirect.m */; };
+		BF_410258682644 /* stp_card_mastercard_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_207425658966 /* stp_card_mastercard_template@3x.png */; };
+		BF_412832480211 /* STPEmailAddressValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_891436639477 /* STPEmailAddressValidator.m */; };
+		BF_416902096517 = {isa = PBXBuildFile; fileRef = FR_521258380702 /* ios-app-Bazel.app */; };
+		BF_417206245222 /* UIViewController+Stripe_ParentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_744031881443 /* UIViewController+Stripe_ParentViewController.m */; };
+		BF_418197180649 = {isa = PBXBuildFile; fileRef = FR_896024321091 /* PINCache-Core-ios-9.0.a */; };
+		BF_418648864791 /* stp_card_cvc.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_136210399342 /* stp_card_cvc.png */; };
+		BF_418811959052 /* NSDictionary+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_619129721469 /* NSDictionary+Stripe.m */; };
+		BF_421289082512 /* stp_card_unionpay_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_725419030615 /* stp_card_unionpay_zh.png */; };
+		BF_423791838134 /* stp_card_form_front@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_670858721125 /* stp_card_form_front@2x.png */; };
+		BF_425605995076 /* stp_card_diners_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_244552489410 /* stp_card_diners_template.png */; };
+		BF_426168367035 /* stp_card_cvc_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_401009960707 /* stp_card_cvc_amex@2x.png */; };
+		BF_428775638150 /* STPSourceParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_232273873872 /* STPSourceParams.m */; };
+		BF_429600621564 /* stp_card_unionpay_template_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_288246765774 /* stp_card_unionpay_template_en.png */; };
+		BF_430089136754 = {isa = PBXBuildFile; fileRef = FR_339590863894 /* share-extension.appex */; };
+		BF_430283935178 /* STPPaymentMethodTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_542871956439 /* STPPaymentMethodTuple.m */; };
+		BF_436498784082 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_223058608906 /* GoogleAuthUtilities.framework */; };
+		BF_440319957567 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_585192593384 /* GoogleSymbolUtilities.framework */; };
+		BF_441260908951 /* stp_card_amex_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_155216169727 /* stp_card_amex_template@2x.png */; };
+		BF_444528772797 /* STPPaymentMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_692892454609 /* STPPaymentMethodTableViewCell.m */; };
+		BF_449328693163 /* UIViewController+Stripe_Promises.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_747618226391 /* UIViewController+Stripe_Promises.m */; };
+		BF_449813988220 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_983905050479 /* libStripe-ios-9.0.a */; };
+		BF_451757939373 /* stp_icon_add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_853994749600 /* stp_icon_add@3x.png */; };
+		BF_451864181836 /* stp_card_unionpay_template_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_187515162480 /* stp_card_unionpay_template_en@3x.png */; };
+		BF_452681027169 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_504407375548 /* main.m */; };
+		BF_455098719663 /* STPEmailAddressValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_891436639477 /* STPEmailAddressValidator.m */; };
+		BF_457006557174 /* stp_card_amex_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_152702596118 /* stp_card_amex_template.png */; };
+		BF_457671294607 /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_830275844486 /* PINCache.m */; };
+		BF_461602219286 /* STPCustomer.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_737326472839 /* STPCustomer.m */; };
+		BF_462762841132 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_585192593384 /* GoogleSymbolUtilities.framework */; };
+		BF_463603276620 /* stp_card_unknown@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_521388462865 /* stp_card_unknown@3x.png */; };
+		BF_467710876165 /* STPPaymentActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_677319161634 /* STPPaymentActivityIndicatorView.m */; };
+		BF_468441695289 /* stp_card_cvc_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_759500150446 /* stp_card_cvc_amex@3x.png */; };
+		BF_469038964441 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_524961920525 /* libUrlGetClasses-ios-9.0.a */; };
+		BF_469523812575 /* stp_card_mastercard.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_385170037705 /* stp_card_mastercard.png */; };
+		BF_469844427557 /* libios-ext-bin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_448796637040 /* libios-ext-bin.a */; };
+		BF_474165361269 /* AppJerry.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_850772742307 /* AppJerry.m */; };
+		BF_474704292690 /* stp_card_mastercard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_365735314709 /* stp_card_mastercard@2x.png */; };
+		BF_476314191379 /* libStripe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_983905050479 /* libStripe-ios-9.0.a */; };
+		BF_477334483946 /* stp_card_diners_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_244552489410 /* stp_card_diners_template.png */; };
+		BF_478661797903 /* STPEphemeralKeyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_648604114055 /* STPEphemeralKeyManager.m */; };
+		BF_483091065104 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_483720092972 /* Tests.m */; };
+		BF_485594525880 /* UrlGetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_822622224200 /* UrlGetViewController.m */; };
+		BF_486856572102 /* STPTelemetryClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_608836942526 /* STPTelemetryClient.m */; };
+		BF_490254727257 = {isa = PBXBuildFile; fileRef = FR_500728372472 /* UrlGetClasses-ios-12.0.a */; };
+		BF_491370786528 /* UIToolbar+Stripe_InputAccessory.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_671973988729 /* UIToolbar+Stripe_InputAccessory.m */; };
+		BF_491638567810 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_791443385444 /* PINMemoryCache.m */; };
+		BF_494156707061 /* stp_card_mastercard@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_365735314709 /* stp_card_mastercard@2x.png */; };
+		BF_495704164110 /* stp_card_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_819003985091 /* stp_card_amex@2x.png */; };
+		BF_500228453026 /* STPAPIClient+ApplePay.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_387881769002 /* STPAPIClient+ApplePay.m */; };
+		BF_500739021385 /* STPEphemeralKeyManager.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_648604114055 /* STPEphemeralKeyManager.m */; };
+		BF_502034129964 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_389377991035 /* Localizable.strings */; };
+		BF_502725164754 /* STPAspects.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_386981154662 /* STPAspects.m */; };
+		BF_503266929639 /* STPURLCallbackHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_920585382813 /* STPURLCallbackHandler.m */; };
+		BF_503713314754 /* stp_card_cvc_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_759500150446 /* stp_card_cvc_amex@3x.png */; };
+		BF_504787206920 /* stp_icon_checkmark@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_243638250146 /* stp_icon_checkmark@2x.png */; };
+		BF_505787559960 /* stp_card_form_back@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_225702220465 /* stp_card_form_back@2x.png */; };
+		BF_506585654635 /* STPCardIOProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_641447449553 /* STPCardIOProxy.m */; };
+		BF_507288906199 /* STPEphemeralKey.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_253971462755 /* STPEphemeralKey.m */; };
+		BF_510438721460 /* stp_card_form_back.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_211689055946 /* stp_card_form_back.png */; };
+		BF_511180956135 /* stp_icon_checkmark@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_243638250146 /* stp_icon_checkmark@2x.png */; };
+		BF_516695223179 /* STPBankAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_877692020624 /* STPBankAccount.m */; };
+		BF_521527232130 /* strings-extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FR_207408458888 /* strings-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		BF_521717838213 /* STPCustomer.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_737326472839 /* STPCustomer.m */; };
+		BF_524325989975 /* NoArc.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_414139705988 /* NoArc.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BF_525794329434 /* STPLocalizationUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_804931815947 /* STPLocalizationUtils.m */; };
+		BF_527066927242 /* STPUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_121783217597 /* STPUserInformation.m */; };
+		BF_531955342698 /* stp_card_unionpay_template_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_288246765774 /* stp_card_unionpay_template_en.png */; };
+		BF_534610655903 /* STPPaymentContext.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_184070624316 /* STPPaymentContext.m */; };
+		BF_539166562665 /* stp_card_unionpay_template_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_730057302106 /* stp_card_unionpay_template_zh@2x.png */; };
+		BF_539727742658 /* stp_card_unionpay_template_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_214532835490 /* stp_card_unionpay_template_zh.png */; };
+		BF_543099485300 /* stp_card_discover@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_613129380815 /* stp_card_discover@3x.png */; };
+		BF_543394716926 /* STPBINRange.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_493600713592 /* STPBINRange.m */; };
+		BF_547904238334 /* PINOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_660084857839 /* PINOperationQueue.m */; };
+		BF_550865330733 /* UrlGetViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FR_400311668699 /* UrlGetViewController.xib */; };
+		BF_551919418156 /* AppIntent.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_806196035267 /* AppIntent.m */; };
+		BF_555078373532 /* stp_card_discover@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_114970438289 /* stp_card_discover@2x.png */; };
+		BF_557951516545 = {isa = PBXBuildFile; fileRef = FR_643129213697 /* siri-ext-bin.a */; };
+		BF_558520883968 /* stp_card_unionpay_template_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_187515162480 /* stp_card_unionpay_template_en@3x.png */; };
+		BF_558654487641 = {isa = PBXBuildFile; fileRef = FR_207408458888 /* strings-extension.appex */; };
+		BF_559184343028 /* NSDecimalNumber+Stripe_Currency.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_458195826767 /* NSDecimalNumber+Stripe_Currency.m */; };
+		BF_562531982929 = {isa = PBXBuildFile; fileRef = FR_907005147347 /* siri-extension.appex */; };
+		BF_563065676105 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_223058608906 /* GoogleAuthUtilities.framework */; };
+		BF_563679749270 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_855525910280 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
+		BF_564028199175 /* NoArc.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_414139705988 /* NoArc.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		BF_565261435797 /* stp_icon_add@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_853994749600 /* stp_icon_add@3x.png */; };
+		BF_565970987923 = {isa = PBXBuildFile; fileRef = FR_765731174060 /* PINCache-Arc-exception-safe-ios-12.0.a */; };
+		BF_565996804856 /* stp_card_visa_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_826786322062 /* stp_card_visa_template.png */; };
+		BF_568722685766 /* STPPaymentConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_259116261371 /* STPPaymentConfiguration.m */; };
+		BF_575004115082 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_252085585404 /* libPINCache-Core-ios-9.0.a */; };
+		BF_575138512021 /* STPPhoneNumberValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_607013564544 /* STPPhoneNumberValidator.m */; };
+		BF_575330527930 /* NSCharacterSet+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_463700594726 /* NSCharacterSet+Stripe.m */; };
+		BF_576094170042 /* UIViewController+Stripe_ParentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_744031881443 /* UIViewController+Stripe_ParentViewController.m */; };
+		BF_576960597097 /* stp_card_amex_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_155216169727 /* stp_card_amex_template@2x.png */; };
+		BF_579500660081 /* ShareExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_208509687828 /* ShareExtension-Info.plist */; };
+		BF_580367071544 /* STPColorUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_920605117287 /* STPColorUtils.m */; };
+		BF_581598615267 /* STPAPIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_307775792133 /* STPAPIClient.m */; };
+		BF_582033751612 /* stp_card_error.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_803217793216 /* stp_card_error.png */; };
+		BF_585752695549 /* STPValidatedTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_296070546472 /* STPValidatedTextField.m */; };
+		BF_586263945370 /* STPFormTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_169667767185 /* STPFormTextField.m */; };
+		BF_587542324291 /* STPAnalyticsClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_610462910989 /* STPAnalyticsClient.m */; };
+		BF_588105762560 /* NSError+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_688759072197 /* NSError+Stripe.m */; };
+		BF_590679607604 /* stp_card_discover_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_419545860786 /* stp_card_discover_template@2x.png */; };
+		BF_591415951505 /* stp_card_diners@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_627381929349 /* stp_card_diners@2x.png */; };
+		BF_597481577995 /* stp_card_cvc@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_155070680239 /* stp_card_cvc@2x.png */; };
+		BF_599011362417 /* STPLegalEntityParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_916780536843 /* STPLegalEntityParams.m */; };
+		BF_599854589984 /* stp_card_jcb_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_193764108659 /* stp_card_jcb_template.png */; };
+		BF_602469051456 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_359007197538 /* STPSectionHeaderView.m */; };
+		BF_607249397858 /* STPMultipartFormDataPart.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_800682286459 /* STPMultipartFormDataPart.m */; };
+		BF_608543729113 /* NSString+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_742311769633 /* NSString+Stripe.m */; };
+		BF_609056729243 /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_483720092972 /* Tests.m */; };
+		BF_610173930762 /* STPApplePayPaymentMethod.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_476535447008 /* STPApplePayPaymentMethod.m */; };
+		BF_611121166475 /* StringsExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_603748432416 /* StringsExtension-Info.plist */; };
+		BF_615973472428 /* stp_card_unionpay_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_721965906259 /* stp_card_unionpay_en@2x.png */; };
+		BF_618672817923 /* stp_card_diners@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_276438809486 /* stp_card_diners@3x.png */; };
+		BF_619488116763 /* stp_card_form_back@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_225702220465 /* stp_card_form_back@2x.png */; };
+		BF_620710219927 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_903485295144 /* libPINOperation-ios-9.0.a */; };
+		BF_624321049043 /* STPConnectAccountParams.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_717345258349 /* STPConnectAccountParams.m */; };
+		BF_625116946688 /* STPBundleLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_724415273822 /* STPBundleLocator.m */; };
+		BF_627085115907 /* STPFormEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_898478279498 /* STPFormEncoder.m */; };
+		BF_628665229218 /* STPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_533629523548 /* STPToken.m */; };
+		BF_628907856271 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_358371710400 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_629330710435 /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_830275844486 /* PINCache.m */; };
+		BF_630893698289 /* stp_card_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_759813942983 /* stp_card_amex@3x.png */; };
+		BF_633442669538 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_592203597580 /* PINDiskCache.m */; };
+		BF_634761092432 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_266084204646 /* GoogleNetworkingUtilities.framework */; };
+		BF_636805722397 /* STPPaymentResult.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_384868030190 /* STPPaymentResult.m */; };
+		BF_638767995750 /* stp_card_visa.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_222145928215 /* stp_card_visa.png */; };
+		BF_642433567139 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_252085585404 /* libPINCache-Core-ios-9.0.a */; };
+		BF_643520686279 /* libPINCache-Core-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_252085585404 /* libPINCache-Core-ios-9.0.a */; };
+		BF_643667811122 /* stp_icon_add.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_714158383804 /* stp_icon_add.png */; };
+		BF_644049822046 /* STPAddressViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_193437629670 /* STPAddressViewModel.m */; };
+		BF_647071152864 /* stp_card_diners_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_129901347196 /* stp_card_diners_template@2x.png */; };
+		BF_647643282752 /* stp_card_amex_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_152702596118 /* stp_card_amex_template.png */; };
+		BF_648319392308 = {isa = PBXBuildFile; fileRef = FR_140209500333 /* ios-app-bin-ios-12.0.a */; };
+		BF_648450929643 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_376219813331 /* STPPaymentContextAmountModel.m */; };
+		BF_649315534907 /* stp_card_unionpay_en.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_903389206028 /* stp_card_unionpay_en.png */; };
+		BF_649865701797 /* Tests2.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_536395162937 /* Tests2.m */; };
+		BF_650318570904 /* stp_card_jcb.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_802404793893 /* stp_card_jcb.png */; };
+		BF_651911975680 /* STPFile.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_620106212103 /* STPFile.m */; };
+		BF_656749250306 /* UrlGet-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_406016197234 /* UrlGet-Info.plist */; };
+		BF_657271727726 = {isa = PBXBuildFile; fileRef = FR_852796935086 /* PINCache-Arc-exception-safe-ios-9.0.a */; };
+		BF_657939179964 /* STPTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_345350465673 /* STPTheme.m */; };
+		BF_658995553344 /* stp_card_discover_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_654523445914 /* stp_card_discover_template@3x.png */; };
+		BF_663849778103 /* stp_test_upload_image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = FR_492186305663 /* stp_test_upload_image.jpeg */; };
+		BF_663888141921 /* PINOperationGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_847516745795 /* PINOperationGroup.m */; };
+		BF_666060374727 /* STPShippingAddressViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_671168073175 /* STPShippingAddressViewController.m */; };
+		BF_667256003443 /* stp_card_mastercard_template.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_172053165053 /* stp_card_mastercard_template.png */; };
+		BF_669487613180 /* stp_card_unionpay_en@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_157313604927 /* stp_card_unionpay_en@3x.png */; };
+		BF_672644340006 /* STPAddCardViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_643601304366 /* STPAddCardViewController.m */; };
+		BF_673627856323 /* STPCoreViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_326732228556 /* STPCoreViewController.m */; };
+		BF_673837164753 /* stp_card_error_amex@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_521763319067 /* stp_card_error_amex@2x.png */; };
+		BF_674246997961 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_585192593384 /* GoogleSymbolUtilities.framework */; };
+		BF_678944982147 /* stp_card_form_front@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_396079641272 /* stp_card_form_front@3x.png */; };
+		BF_679272434237 /* stp_shipping_form@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_711215481061 /* stp_shipping_form@3x.png */; };
+		BF_679277052808 /* STPShippingMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_414479750077 /* STPShippingMethodsViewController.m */; };
+		BF_679357323097 /* stp_card_unknown.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_105312376394 /* stp_card_unknown.png */; };
+		BF_684471668015 /* STPPaymentCardTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_180176959680 /* STPPaymentCardTextFieldCell.m */; };
+		BF_685436250069 /* stp_card_unionpay_template_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_857085055871 /* stp_card_unionpay_template_zh@3x.png */; };
+		BF_685721334739 /* STPPhoneNumberValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_607013564544 /* STPPhoneNumberValidator.m */; };
+		BF_687037225350 /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_650327201175 /* stp_shipping_form.png */; };
+		BF_688576102639 /* stp_card_cvc_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_235580276653 /* stp_card_cvc_amex.png */; };
+		BF_690196366010 /* PKPayment+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_418726020237 /* PKPayment+Stripe.m */; };
+		BF_690965970870 /* stp_shipping_form.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_650327201175 /* stp_shipping_form.png */; };
+		BF_697350601610 /* stp_card_error@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_622346843396 /* stp_card_error@2x.png */; };
+		BF_697995507556 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_524961920525 /* libUrlGetClasses-ios-9.0.a */; };
+		BF_698602061822 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_506673325060 /* NSBundle+Stripe_AppName.m */; };
+		BF_700087754499 /* libStripe-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_822311040905 /* libStripe-ios-12.0.a */; };
+		BF_700868733775 /* STPSourceCardDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_361180168062 /* STPSourceCardDetails.m */; };
+		BF_701211932660 /* STPShippingMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_400952142106 /* STPShippingMethodTableViewCell.m */; };
+		BF_701234805690 /* STPCategoryLoader.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_292969540570 /* STPCategoryLoader.m */; };
+		BF_704563056890 /* UINavigationBar+Stripe_Theme.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_444167311156 /* UINavigationBar+Stripe_Theme.m */; };
+		BF_704710779821 /* stp_card_jcb@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_850087254357 /* stp_card_jcb@2x.png */; };
+		BF_708126553435 /* UrlGetViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_822622224200 /* UrlGetViewController.m */; };
+		BF_710215877948 /* NSString+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_742311769633 /* NSString+Stripe.m */; };
+		BF_710512128781 /* libPINOperation-ios-12.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_775707534446 /* libPINOperation-ios-12.0.a */; };
+		BF_710837560816 /* STPPaymentContextAmountModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_376219813331 /* STPPaymentContextAmountModel.m */; };
+		BF_712915253604 /* stp_card_visa@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_362145144513 /* stp_card_visa@3x.png */; };
+		BF_714368613035 /* stp_card_form_back@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_168442315296 /* stp_card_form_back@3x.png */; };
+		BF_716153568345 /* STPAspects.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_386981154662 /* STPAspects.m */; };
+		BF_717047716788 = {isa = PBXBuildFile; fileRef = FR_140931474443 /* UnitTests.xctest */; };
+		BF_718867892239 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_387987486934 /* AppDelegate.m */; };
+		BF_720181823145 /* NSBundle+Stripe_AppName.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_506673325060 /* NSBundle+Stripe_AppName.m */; };
+		BF_721358360726 /* STPSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_359007197538 /* STPSectionHeaderView.m */; };
+		BF_727849743157 /* stp_card_unknown@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_521388462865 /* stp_card_unknown@3x.png */; };
+		BF_734779984104 /* stp_card_cvc@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_346968037020 /* stp_card_cvc@3x.png */; };
+		BF_735320918610 /* UIView+Stripe_SafeAreaBounds.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_733844630235 /* UIView+Stripe_SafeAreaBounds.m */; };
+		BF_735490463247 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_266084204646 /* GoogleNetworkingUtilities.framework */; };
+		BF_740567332917 /* STPMultipartFormDataEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_125415528864 /* STPMultipartFormDataEncoder.m */; };
+		BF_741183958772 = {isa = PBXBuildFile; fileRef = FR_275539566864 /* Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle */; };
+		BF_742743427862 /* libUrlGetClasses-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_524961920525 /* libUrlGetClasses-ios-9.0.a */; };
+		BF_749484612661 /* STPPaymentCardTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_163191866606 /* STPPaymentCardTextField.m */; };
+		BF_749714141323 = {isa = PBXBuildFile; fileRef = FR_561293049977 /* PINCache-Core-ios-12.0.a */; };
+		BF_750828403759 /* stp_card_applepay.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_137435447838 /* stp_card_applepay.png */; };
+		BF_757939644928 /* STPBundleLocator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_724415273822 /* STPBundleLocator.m */; };
+		BF_759782369722 /* stp_icon_checkmark.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_899762404898 /* stp_icon_checkmark.png */; };
+		BF_762034813425 /* stp_shipping_form@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_711764376983 /* stp_shipping_form@2x.png */; };
+		BF_762847527121 /* STPShippingMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_414479750077 /* STPShippingMethodsViewController.m */; };
+		BF_763269786008 /* stp_card_error@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_511984329756 /* stp_card_error@3x.png */; };
+		BF_764164773486 /* stp_card_discover.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_152009236735 /* stp_card_discover.png */; };
+		BF_764562302069 /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_751267158973 /* stp_card_visa@2x.png */; };
+		BF_766291129155 /* stp_card_form_front@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_670858721125 /* stp_card_form_front@2x.png */; };
+		BF_766680876200 /* stp_card_applepay@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_738901483927 /* stp_card_applepay@3x.png */; };
+		BF_768788420193 /* stp_card_unionpay_template_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_730057302106 /* stp_card_unionpay_template_zh@2x.png */; };
+		BF_769304845478 /* STPPostalCodeValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_201870136181 /* STPPostalCodeValidator.m */; };
+		BF_770734317014 /* STPSwitchTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_319823595011 /* STPSwitchTableViewCell.m */; };
+		BF_771515235132 /* STPShippingMethodTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_400952142106 /* STPShippingMethodTableViewCell.m */; };
+		BF_772265866226 /* AppIntentVocabulary.plist in Resources */ = {isa = PBXBuildFile; fileRef = VG_786904937064 /* AppIntentVocabulary.plist */; };
+		BF_773372457985 /* Some.cc in Sources */ = {isa = PBXBuildFile; fileRef = FR_597844010667 /* Some.cc */; };
+		BF_773761127283 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_195771909498 /* UIViewController+Stripe_NavigationItemProxy.m */; };
+		BF_778313442450 /* stp_card_diners@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_276438809486 /* stp_card_diners@3x.png */; };
+		BF_781461712867 /* STPAddress.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_541854991234 /* STPAddress.m */; };
+		BF_785895832047 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_389377991035 /* Localizable.strings */; };
+		BF_790199077922 /* SiriExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_431351183220 /* SiriExtension-Info.plist */; };
+		BF_790384308722 /* STPCustomer+SourceTuple.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_145973180178 /* STPCustomer+SourceTuple.m */; };
+		BF_791049119688 /* stp_card_error_amex@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_266277694519 /* stp_card_error_amex@3x.png */; };
+		BF_791149661131 /* STPCardValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_325961342376 /* STPCardValidator.m */; };
+		BF_792006449576 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_855525910280 /* libPINCache-Arc-exception-safe-ios-9.0.a */; };
+		BF_793117178537 /* stp_card_jcb_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_514487626366 /* stp_card_jcb_template@3x.png */; };
+		BF_794697457499 /* STPFile.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_620106212103 /* STPFile.m */; };
+		BF_796065761753 /* STPDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_796389677736 /* STPDelegateProxy.m */; };
+		BF_797659011793 /* stp_card_jcb@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_845546175975 /* stp_card_jcb@3x.png */; };
+		BF_801535514152 /* STPCoreScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_385123840418 /* STPCoreScrollViewController.m */; };
+		BF_802248202837 /* stp_card_unionpay_zh@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_331262609749 /* stp_card_unionpay_zh@3x.png */; };
+		BF_803169740875 = {isa = PBXBuildFile; fileRef = FR_729056130422 /* HeaderLib-ios-12.0.a */; };
+		BF_805966118789 /* GoogleSymbolUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_585192593384 /* GoogleSymbolUtilities.framework */; };
+		BF_806054835119 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_315742577216 /* GoogleAppIndexingResources.bundle */; };
+		BF_807235759265 /* stp_card_unionpay_template_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_214532835490 /* stp_card_unionpay_template_zh.png */; };
+		BF_808308483783 /* stp_card_error_amex.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_484197994638 /* stp_card_error_amex.png */; };
+		BF_812076692716 /* stp_card_mastercard_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_199879867824 /* stp_card_mastercard_template@2x.png */; };
+		BF_814672412075 /* UIBarButtonItem+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_571144748643 /* UIBarButtonItem+Stripe.m */; };
+		BF_814879537018 /* STPSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_354572980175 /* STPSource.m */; };
+		BF_815247147431 /* STPCoreScrollViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_385123840418 /* STPCoreScrollViewController.m */; };
+		BF_816944651747 /* stp_card_visa.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_222145928215 /* stp_card_visa.png */; };
+		BF_818659851625 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = VG_843603205312 /* InfoPlist.strings */; };
+		BF_818902966270 /* STPSourceOwner.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_244673885284 /* STPSourceOwner.m */; };
+		BF_825167454850 /* stp_card_diners_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_129901347196 /* stp_card_diners_template@2x.png */; };
+		BF_825771963343 /* ShareExtension-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = FR_208509687828 /* ShareExtension-Info.plist */; };
+		BF_827791661966 /* PINOperationQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_660084857839 /* PINOperationQueue.m */; };
+		BF_831330403855 /* stp_card_cvc@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_346968037020 /* stp_card_cvc@3x.png */; };
+		BF_835019889165 /* UIImage+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_893676537074 /* UIImage+Stripe.m */; };
+		BF_837786396469 /* STPCardValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_325961342376 /* STPCardValidator.m */; };
+		BF_841215260506 /* NSArray+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_756148561161 /* NSArray+Stripe.m */; };
+		BF_842548931220 /* Some.cc in Sources */ = {isa = PBXBuildFile; fileRef = FR_597844010667 /* Some.cc */; };
+		BF_843890752677 /* stp_icon_add.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_714158383804 /* stp_icon_add.png */; };
+		BF_843924727945 /* stp_card_visa@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_751267158973 /* stp_card_visa@2x.png */; };
+		BF_845850210483 /* stp_card_cvc@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_155070680239 /* stp_card_cvc@2x.png */; };
+		BF_846935922558 /* STPSourceCardDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_361180168062 /* STPSourceCardDetails.m */; };
+		BF_847957075797 /* STPAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_674683558842 /* STPAPIRequest.m */; };
+		BF_848140824504 /* UIViewController+Stripe_Promises.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_747618226391 /* UIViewController+Stripe_Promises.m */; };
+		BF_851511694779 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_227746174149 /* STPSourcePoller.m */; };
+		BF_855832788961 /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_791443385444 /* PINMemoryCache.m */; };
+		BF_857839835142 /* STPPaymentActivityIndicatorView.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_677319161634 /* STPPaymentActivityIndicatorView.m */; };
+		BF_860523227170 /* GoogleAuthUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_223058608906 /* GoogleAuthUtilities.framework */; };
+		BF_862184642948 /* Generated.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_270702652206 /* Generated.m */; };
+		BF_864375956715 /* stp_card_discover_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_419545860786 /* stp_card_discover_template@2x.png */; };
+		BF_865856056016 /* GoogleNetworkingUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_266084204646 /* GoogleNetworkingUtilities.framework */; };
+		BF_870269234462 /* STPDelegateProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_796389677736 /* STPDelegateProxy.m */; };
+		BF_870862087635 /* STPPaymentMethodsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_243169012465 /* STPPaymentMethodsViewController.m */; };
+		BF_871366012321 /* stp_card_applepay@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_575533640387 /* stp_card_applepay@2x.png */; };
+		BF_875094752518 /* STPFormEncoder.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_898478279498 /* STPFormEncoder.m */; };
+		BF_876958204132 = {isa = PBXBuildFile; fileRef = FR_655065637744 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */; };
+		BF_879222550178 /* stp_card_unionpay_zh.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_725419030615 /* stp_card_unionpay_zh.png */; };
+		BF_880020110019 /* STPDispatchFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_157144616729 /* STPDispatchFunctions.m */; };
+		BF_881482045340 /* STPAddressViewModel.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_193437629670 /* STPAddressViewModel.m */; };
+		BF_881947175560 /* STPPaymentConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_259116261371 /* STPPaymentConfiguration.m */; };
+		BF_885374270340 /* STPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_533629523548 /* STPToken.m */; };
+		BF_886743791456 /* STPAPIRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_674683558842 /* STPAPIRequest.m */; };
+		BF_887334060094 /* STPSourceReceiver.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_748789438654 /* STPSourceReceiver.m */; };
+		BF_888076940425 /* stp_card_mastercard.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_385170037705 /* stp_card_mastercard.png */; };
+		BF_888814325262 = {isa = PBXBuildFile; fileRef = FR_273845325521 /* PINOperation-ios-12.0.a */; };
+		BF_890212572892 /* stp_test_upload_image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = FR_492186305663 /* stp_test_upload_image.jpeg */; };
+		BF_894661147087 /* STPCard.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_884510017797 /* STPCard.m */; };
+		BF_896763847980 /* stp_card_mastercard@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_871811812819 /* stp_card_mastercard@3x.png */; };
+		BF_898558479131 /* stp_card_diners_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_279876855106 /* stp_card_diners_template@3x.png */; };
+		BF_898936898595 /* GoogleAppIndexingResources.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FR_315742577216 /* GoogleAppIndexingResources.bundle */; };
+		BF_899127884349 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_387987486934 /* AppDelegate.m */; };
+		BF_899468981458 = {isa = PBXBuildFile; fileRef = FR_413571327928 /* UITests.xctest */; };
+		BF_899491127373 /* GoogleAppIndexing.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_279407611271 /* GoogleAppIndexing.framework */; };
+		BF_903940243031 /* stp_card_jcb_template@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_658835132655 /* stp_card_jcb_template@2x.png */; };
+		BF_907297624925 /* UIView+Stripe_SafeAreaBounds.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_733844630235 /* UIView+Stripe_SafeAreaBounds.m */; };
+		BF_910973356391 /* stp_card_form_back@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_168442315296 /* stp_card_form_back@3x.png */; };
+		BF_913716101615 /* stp_card_unionpay_en@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_721965906259 /* stp_card_unionpay_en@2x.png */; };
+		BF_914082541498 /* NSMutableURLRequest+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_645419483261 /* NSMutableURLRequest+Stripe.m */; };
+		BF_914693708244 /* stp_card_unknown@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_712193767199 /* stp_card_unknown@2x.png */; };
+		BF_914859729409 /* STPImageLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_758328319458 /* STPImageLibrary.m */; };
+		BF_915430620448 /* siri-extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = FR_907005147347 /* siri-extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		BF_915774520596 /* stp_card_diners_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_279876855106 /* stp_card_diners_template@3x.png */; };
+		BF_916188019560 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_358371710400 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_916584786395 /* libPINOperation-ios-9.0.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_903485295144 /* libPINOperation-ios-9.0.a */; };
+		BF_917532833583 /* STPSwitchTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_319823595011 /* STPSwitchTableViewCell.m */; };
+		BF_920262823507 /* UIBarButtonItem+Stripe.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_571144748643 /* UIBarButtonItem+Stripe.m */; };
+		BF_952635031943 /* STPPaymentMethodsInternalViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_586728708045 /* STPPaymentMethodsInternalViewController.m */; };
+		BF_959817918427 /* STPAnalyticsClient.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_610462910989 /* STPAnalyticsClient.m */; };
+		BF_969844257432 /* stp_card_amex_template@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_888354852550 /* stp_card_amex_template@3x.png */; };
+		BF_977546105382 /* stp_card_unionpay_zh@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = FR_575113983346 /* stp_card_unionpay_zh@2x.png */; };
+		BF_997162057735 /* STPSourcePoller.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_227746174149 /* STPSourcePoller.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		CIP_12128160373 /* PBXContainerItemProxy */ = {
+		CIP_20751686913 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_5006007611764 /* Project object */;
+			containerPortal = P_3308596046809 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_406521029219;
-			remoteInfo = "share-extension";
+			remoteGlobalIDString = NT_393790783742;
+			remoteInfo = "ios-app";
 		};
-		CIP_26396562217 /* PBXContainerItemProxy */ = {
+		CIP_23399186490 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_5006007611764 /* Project object */;
+			containerPortal = P_3308596046809 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_409503237802;
+			remoteGlobalIDString = NT_907005147347;
+			remoteInfo = "siri-extension";
+		};
+		CIP_43636826012 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = P_3308596046809 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = NT_207408458888;
 			remoteInfo = "strings-extension";
 		};
-		CIP_35494299278 /* PBXContainerItemProxy */ = {
+		CIP_69656561550 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_5006007611764 /* Project object */;
+			containerPortal = P_3308596046809 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_210478864884;
-			remoteInfo = "ios-app";
+			remoteGlobalIDString = NT_339590863894;
+			remoteInfo = "share-extension";
 		};
-		CIP_40628309622 /* PBXContainerItemProxy */ = {
+		CIP_77409188282 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = P_5006007611764 /* Project object */;
+			containerPortal = P_3308596046809 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = NT_210478864884;
+			remoteGlobalIDString = NT_393790783742;
 			remoteInfo = "ios-app";
-		};
-		CIP_77065624846 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = P_5006007611764 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = NT_954961411422;
-			remoteInfo = "siri-extension";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		CFBP_1086377483 /* Embed App Extensions */ = {
+		CFBP_4729140647 /* Embed App Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 13;
 			files = (
-				BF_143169419803 /* strings-extension.appex in Embed App Extensions */,
-				BF_818100860778 /* share-extension.appex in Embed App Extensions */,
-				BF_598402182424 /* siri-extension.appex in Embed App Extensions */,
+				BF_915430620448 /* siri-extension.appex in Embed App Extensions */,
+				BF_252211499394 /* share-extension.appex in Embed App Extensions */,
+				BF_521527232130 /* strings-extension.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -561,1633 +561,1635 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		FR_100286439270 /* STPCoreTableViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreTableViewController.h; sourceTree = "<group>"; };
-		FR_101452471709 /* UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_103772008651 /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
-		FR_104592274494 /* UINavigationController+Stripe_Completion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+Stripe_Completion.h"; sourceTree = "<group>"; };
-		FR_106744743166 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_107366029463 /* STPBackendAPIAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBackendAPIAdapter.h; sourceTree = "<group>"; };
-		FR_108265599351 /* UITableViewCell+Stripe_Borders.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UITableViewCell+Stripe_Borders.m"; sourceTree = "<group>"; };
-		FR_109008019044 /* stp_card_unionpay_zh@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_zh@2x.png"; sourceTree = "<group>"; };
-		FR_111466561084 /* StringsExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "StringsExtension-Info.plist"; sourceTree = "<group>"; };
-		FR_111953531546 /* PINOperationGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationGroup.h; sourceTree = "<group>"; };
-		FR_114522988977 /* STPConnectAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPConnectAccountParams.h; sourceTree = "<group>"; };
-		FR_114608902985 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Base; path = Base.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
-		FR_114615400230 /* ios-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_116888220100 /* stp_card_diners_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners_template@2x.png"; sourceTree = "<group>"; };
-		FR_121139739215 /* PINCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINCache.m; sourceTree = "<group>"; };
-		FR_121877701792 /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
-		FR_122282325744 /* STPAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIResponseDecodable.h; sourceTree = "<group>"; };
-		FR_123818210598 /* STPPaymentConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentConfiguration+Private.h"; sourceTree = "<group>"; };
-		FR_127801604110 /* PINOperationTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationTypes.h; sourceTree = "<group>"; };
-		FR_127927644982 /* libPINOperation-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINOperation-ios-12.0.a"; sourceTree = "<group>"; };
-		FR_129103540819 /* NSString+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSString+Stripe.m"; sourceTree = "<group>"; };
-		FR_129106470870 /* PINOperationQueue.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINOperationQueue.m; sourceTree = "<group>"; };
-		FR_129216172055 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_129440935020 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_129519285691 /* STPPaymentConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentConfiguration.h; sourceTree = "<group>"; };
-		FR_131477545399 /* UIViewController+Stripe_KeyboardAvoiding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_KeyboardAvoiding.h"; sourceTree = "<group>"; };
-		FR_132341323032 /* STPMultipartFormDataEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataEncoder.h; sourceTree = "<group>"; };
-		FR_132874026439 /* STPImageLibrary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPImageLibrary.m; sourceTree = "<group>"; };
-		FR_133536345426 /* NSDecimalNumber+Stripe_Currency.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDecimalNumber+Stripe_Currency.m"; sourceTree = "<group>"; };
-		FR_134545133893 /* stp_card_mastercard@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard@2x.png"; sourceTree = "<group>"; };
-		FR_135115533237 /* PINOperation-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINOperation-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_136953339046 /* STPCustomer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomer.h; sourceTree = "<group>"; };
-		FR_137141565957 /* STPBundleLocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBundleLocator.h; sourceTree = "<group>"; };
-		FR_137752412410 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = cs; path = cs.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
-		FR_139695597457 /* PINOperationTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationTypes.h; sourceTree = "<group>"; };
-		FR_140034954402 /* STPAspects.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAspects.h; sourceTree = "<group>"; };
-		FR_140591238195 /* STPFile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFile.m; sourceTree = "<group>"; };
-		FR_141640256136 /* STPFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFile.h; sourceTree = "<group>"; };
-		FR_143096604872 /* STPFormEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncoder.h; sourceTree = "<group>"; };
-		FR_143462498570 /* STPAspects.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAspects.m; sourceTree = "<group>"; };
-		FR_145914995522 /* PINDiskCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINDiskCache.m; sourceTree = "<group>"; };
-		FR_148025955428 /* STPCustomer+SourceTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+SourceTuple.h"; sourceTree = "<group>"; };
-		FR_149015947095 /* STPFormTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormTextField.h; sourceTree = "<group>"; };
-		FR_149930208538 /* STPCoreTableViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreTableViewController.m; sourceTree = "<group>"; };
-		FR_151991304951 /* UIBarButtonItem+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBarButtonItem+Stripe.h"; sourceTree = "<group>"; };
-		FR_152255977769 /* stp_card_jcb@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb@3x.png"; sourceTree = "<group>"; };
-		FR_155022079262 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_155107299127 /* PINMemoryCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINMemoryCache.h; sourceTree = "<group>"; };
-		FR_155181785535 /* Fabric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
-		FR_155440772017 /* FauxPasAnnotations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FauxPasAnnotations.h; sourceTree = "<group>"; };
-		FR_156168063359 /* STPPaymentActivityIndicatorView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentActivityIndicatorView.h; sourceTree = "<group>"; };
-		FR_157547947389 /* STPCoreTableViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreTableViewController+Private.h"; sourceTree = "<group>"; };
-		FR_158610862646 /* PINCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCache.h; sourceTree = "<group>"; };
-		FR_159505340326 /* STPMultipartFormDataPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataPart.h; sourceTree = "<group>"; };
-		FR_159828199997 /* STPSourceParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceParams.h; sourceTree = "<group>"; };
-		FR_160616828485 /* NSCharacterSet+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSCharacterSet+Stripe.m"; sourceTree = "<group>"; };
-		FR_160651095057 /* STPLegalEntityParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPLegalEntityParams.m; sourceTree = "<group>"; };
-		FR_163201521832 /* stp_card_error_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error_amex@2x.png"; sourceTree = "<group>"; };
-		FR_168201804537 /* stp_icon_add.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_icon_add.png; sourceTree = "<group>"; };
-		FR_172654872023 /* ShareExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ShareExtension-Info.plist"; sourceTree = "<group>"; };
-		FR_180854351342 /* STPEphemeralKeyManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyManager.h; sourceTree = "<group>"; };
-		FR_181204666019 /* STPStringUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPStringUtils.m; sourceTree = "<group>"; };
-		FR_181527925903 /* STPFormTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormTextField.h; sourceTree = "<group>"; };
-		FR_186625950046 /* UIViewController+Stripe_NavigationItemProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_NavigationItemProxy.h"; sourceTree = "<group>"; };
-		FR_188039461400 /* stp_card_form_front@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_front@3x.png"; sourceTree = "<group>"; };
-		FR_188215767539 /* SiriExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "SiriExtension-Info.plist"; sourceTree = "<group>"; };
-		FR_188574106381 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
-		FR_191080603083 /* STPImageLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPImageLibrary.h; sourceTree = "<group>"; };
-		FR_193583997594 /* libUrlGetClasses-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libUrlGetClasses-ios-12.0.a"; sourceTree = "<group>"; };
-		FR_195382795454 /* stp_card_diners@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners@3x.png"; sourceTree = "<group>"; };
-		FR_195674470488 /* STPPaymentContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContext.h; sourceTree = "<group>"; };
-		FR_196111026094 /* STPSourceSEPADebitDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceSEPADebitDetails.h; sourceTree = "<group>"; };
-		FR_199269573806 /* STPCoreScrollViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreScrollViewController.h; sourceTree = "<group>"; };
-		FR_201794194523 /* libPINCache-Arc-exception-safe-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Arc-exception-safe-ios-9.0.a"; sourceTree = "<group>"; };
-		FR_202613678448 /* STPCardValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidator.h; sourceTree = "<group>"; };
-		FR_206010141299 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_207445636632 /* STPURLCallbackHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPURLCallbackHandler.h; sourceTree = "<group>"; };
-		FR_209621477518 /* STPPhoneNumberValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPhoneNumberValidator.m; sourceTree = "<group>"; };
-		FR_209688800430 /* STPDispatchFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDispatchFunctions.h; sourceTree = "<group>"; };
-		FR_210478864884 /* ios-app.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_211196868537 /* AppIntent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppIntent.m; sourceTree = "<group>"; };
-		FR_211759521425 /* stp_icon_checkmark.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_icon_checkmark.png; sourceTree = "<group>"; };
-		FR_212125637458 /* STPAnalyticsClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAnalyticsClient.m; sourceTree = "<group>"; };
-		FR_212516784466 /* libUrlGetClasses-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libUrlGetClasses-ios-9.0.a"; sourceTree = "<group>"; };
-		FR_214657321101 /* UIView+Stripe_SafeAreaBounds.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+Stripe_SafeAreaBounds.m"; sourceTree = "<group>"; };
-		FR_217007679238 /* STPSourceCardDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceCardDetails.h; sourceTree = "<group>"; };
-		FR_218535940030 /* PINCacheObjectSubscripting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheObjectSubscripting.h; sourceTree = "<group>"; };
-		FR_220146349829 /* STPImageLibrary+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPImageLibrary+Private.h"; sourceTree = "<group>"; };
-		FR_221599280939 /* STPCoreScrollViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreScrollViewController+Private.h"; sourceTree = "<group>"; };
-		FR_222933926124 /* stp_card_cvc_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc_amex@2x.png"; sourceTree = "<group>"; };
-		FR_224516879435 /* stp_card_applepay@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_applepay@2x.png"; sourceTree = "<group>"; };
-		FR_225452001627 /* stp_card_amex_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex_template@3x.png"; sourceTree = "<group>"; };
-		FR_228524083929 /* STPUserInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPUserInformation.h; sourceTree = "<group>"; };
-		FR_232130472703 /* STPCategoryLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
-		FR_232638777097 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_233463993954 /* stp_card_discover.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_discover.png; sourceTree = "<group>"; };
-		FR_236610832137 /* PINOperationQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationQueue.h; sourceTree = "<group>"; };
-		FR_238051608612 /* STPAPIRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIRequest.h; sourceTree = "<group>"; };
-		FR_241162817988 /* STPCustomerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomerContext.h; sourceTree = "<group>"; };
-		FR_243703993641 /* STPPromise.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPromise.h; sourceTree = "<group>"; };
-		FR_244508054852 /* STPSourceVerification+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceVerification+Private.h"; sourceTree = "<group>"; };
-		FR_244801847772 /* STPPaymentMethodsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodsViewController.m; sourceTree = "<group>"; };
-		FR_245329396039 /* stp_card_error_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error_amex@3x.png"; sourceTree = "<group>"; };
-		FR_246324868641 /* STPLocalizationUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPLocalizationUtils.m; sourceTree = "<group>"; };
-		FR_248353099271 /* NSBundle+Stripe_AppName.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+Stripe_AppName.h"; sourceTree = "<group>"; };
-		FR_248755332667 /* libPINOperation-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINOperation-ios-9.0.a"; sourceTree = "<group>"; };
-		FR_250835929950 /* stp_card_jcb@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb@2x.png"; sourceTree = "<group>"; };
-		FR_250884507592 /* STPSourceRedirect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceRedirect.h; sourceTree = "<group>"; };
-		FR_251322316326 /* UIViewController+Stripe_ParentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_ParentViewController.h"; sourceTree = "<group>"; };
-		FR_256159406193 /* STPAPIClient+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+Private.h"; sourceTree = "<group>"; };
-		FR_259766013406 /* STPEphemeralKeyManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEphemeralKeyManager.m; sourceTree = "<group>"; };
-		FR_262245891890 /* Some.cc */ = {isa = PBXFileReference; path = Some.cc; sourceTree = "<group>"; };
-		FR_262765526800 /* stp_card_mastercard_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_mastercard_template.png; sourceTree = "<group>"; };
-		FR_263478129584 /* STPShippingAddressViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingAddressViewController.h; sourceTree = "<group>"; };
-		FR_264105247925 /* STPSourceCardDetails.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceCardDetails.m; sourceTree = "<group>"; };
-		FR_268528132629 /* STPMultipartFormDataEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPMultipartFormDataEncoder.m; sourceTree = "<group>"; };
-		FR_268644933511 /* NSBundle+Stripe_AppName.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+Stripe_AppName.m"; sourceTree = "<group>"; };
-		FR_269106334444 /* STPSourceRedirect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceRedirect.h; sourceTree = "<group>"; };
-		FR_273923590342 /* ios-app-bin-ios-12.0-Bazel.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-app-bin-ios-12.0-Bazel.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_274521215767 /* STPAspects.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAspects.h; sourceTree = "<group>"; };
-		FR_277947155239 /* stp_card_applepay@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_applepay@3x.png"; sourceTree = "<group>"; };
-		FR_278392824234 /* UrlGet-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "UrlGet-Info.plist"; sourceTree = "<group>"; };
-		FR_279590091072 /* STPCoreViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreViewController+Private.h"; sourceTree = "<group>"; };
-		FR_279745772659 /* STPWeakStrongMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPWeakStrongMacros.h; sourceTree = "<group>"; };
-		FR_281509917340 /* STPValidatedTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPValidatedTextField.m; sourceTree = "<group>"; };
-		FR_283351945692 /* STPPaymentContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentContext+Private.h"; sourceTree = "<group>"; };
-		FR_286261044399 /* STPCard.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCard.m; sourceTree = "<group>"; };
-		FR_288321554063 /* STPSourcePoller.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourcePoller.m; sourceTree = "<group>"; };
-		FR_288738750739 /* GoogleNetworkingUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleNetworkingUtilities.framework; path = Vendor/GoogleNetworkingUtilities/Frameworks/frameworks/GoogleNetworkingUtilities.framework; sourceTree = "<group>"; };
-		FR_288982143251 /* STPSourceParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceParams+Private.h"; sourceTree = "<group>"; };
-		FR_289929860900 /* STPRedirectContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPRedirectContext.m; sourceTree = "<group>"; };
-		FR_292133108427 /* STPShippingMethodsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingMethodsViewController.m; sourceTree = "<group>"; };
-		FR_292374537681 /* NSMutableURLRequest+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Stripe.h"; sourceTree = "<group>"; };
-		FR_294706493915 /* Some.hpp */ = {isa = PBXFileReference; path = Some.hpp; sourceTree = "<group>"; };
-		FR_295195067470 /* STPCoreScrollViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreScrollViewController.m; sourceTree = "<group>"; };
-		FR_295701939216 /* STPPaymentMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTableViewCell.h; sourceTree = "<group>"; };
-		FR_298053197398 /* STPAPIClient+ApplePay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+ApplePay.h"; sourceTree = "<group>"; };
-		FR_298239715908 /* STPBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBlocks.h; sourceTree = "<group>"; };
-		FR_298308069312 /* STPCoreViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreViewController+Private.h"; sourceTree = "<group>"; };
-		FR_298510265968 /* NSDictionary+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+Stripe.m"; sourceTree = "<group>"; };
-		FR_299182598435 /* STPPaymentMethodsInternalViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodsInternalViewController.m; sourceTree = "<group>"; };
-		FR_301311350687 /* STPPaymentCardTextFieldViewModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextFieldViewModel.m; sourceTree = "<group>"; };
-		FR_304102532309 /* stp_card_jcb_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb_template@2x.png"; sourceTree = "<group>"; };
-		FR_305781761228 /* stp_card_cvc@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc@3x.png"; sourceTree = "<group>"; };
-		FR_309738637754 /* STPLocalizationUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLocalizationUtils.h; sourceTree = "<group>"; };
-		FR_311557376990 /* STPCoreTableViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreTableViewController.h; sourceTree = "<group>"; };
-		FR_312385741133 /* STPCoreViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreViewController.h; sourceTree = "<group>"; };
-		FR_313941452068 /* STPWeakStrongMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPWeakStrongMacros.h; sourceTree = "<group>"; };
-		FR_315911173146 /* PINOperationGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationGroup.h; sourceTree = "<group>"; };
-		FR_318744245772 /* STPPaymentContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentContext+Private.h"; sourceTree = "<group>"; };
-		FR_321188290181 /* NSArray+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSArray+Stripe.h"; sourceTree = "<group>"; };
-		FR_321921907264 /* stp_card_visa_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_visa_template.png; sourceTree = "<group>"; };
-		FR_322129515820 /* STPPaymentContextAmountModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContextAmountModel.h; sourceTree = "<group>"; };
-		FR_322504740038 /* STPPaymentCardTextFieldViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldViewModel.h; sourceTree = "<group>"; };
-		FR_323887596110 /* STPBINRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBINRange.h; sourceTree = "<group>"; };
-		FR_325796315490 /* STPBINRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBINRange.h; sourceTree = "<group>"; };
-		FR_325996419707 /* STPPaymentConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentConfiguration+Private.h"; sourceTree = "<group>"; };
-		FR_328355623393 /* STPCustomer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Private.h"; sourceTree = "<group>"; };
-		FR_330612961242 /* STPShippingMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodTableViewCell.h; sourceTree = "<group>"; };
-		FR_331287642191 /* STPPromise.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPromise.m; sourceTree = "<group>"; };
-		FR_332422960777 /* STPAPIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIClient.h; sourceTree = "<group>"; };
-		FR_333624610927 /* STPPaymentActivityIndicatorView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentActivityIndicatorView.m; sourceTree = "<group>"; };
-		FR_334874974082 /* STPPhoneNumberValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPhoneNumberValidator.h; sourceTree = "<group>"; };
-		FR_335380563722 /* stp_card_unionpay_template_zh@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_zh@3x.png"; sourceTree = "<group>"; };
-		FR_339403818705 /* STPPaymentMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTableViewCell.h; sourceTree = "<group>"; };
-		FR_342721641775 /* stp_card_jcb_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb_template@3x.png"; sourceTree = "<group>"; };
-		FR_346022409790 /* UrlGetViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UrlGetViewController.h; sourceTree = "<group>"; };
-		FR_346342066788 /* STPCoreScrollViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreScrollViewController+Private.h"; sourceTree = "<group>"; };
-		FR_347091572157 /* STPCardBrand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardBrand.h; sourceTree = "<group>"; };
-		FR_348836605145 /* STPSourcePoller.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourcePoller.h; sourceTree = "<group>"; };
-		FR_350076690277 /* STPStringUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
-		FR_350139185969 /* stp_card_discover_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover_template@2x.png"; sourceTree = "<group>"; };
-		FR_350835833985 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
-		FR_351223294806 /* stp_card_amex_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_amex_template.png; sourceTree = "<group>"; };
-		FR_355184773089 /* STPSourceVerification+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceVerification+Private.h"; sourceTree = "<group>"; };
-		FR_357471098469 /* stp_card_unionpay_template_zh@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_zh@2x.png"; sourceTree = "<group>"; };
-		FR_357987593239 /* stp_card_jcb.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_jcb.png; sourceTree = "<group>"; };
-		FR_358026470844 /* STPPaymentMethodTuple.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTuple.m; sourceTree = "<group>"; };
-		FR_359125113541 /* stp_card_unknown@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unknown@2x.png"; sourceTree = "<group>"; };
-		FR_360479079920 /* STPCoreViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreViewController.m; sourceTree = "<group>"; };
-		FR_362912493533 /* empty-main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "empty-main.m"; sourceTree = "<group>"; };
-		FR_363951351315 /* UnitTestsWithHost.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UnitTestsWithHost.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_365700562027 /* stp_card_visa.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_visa.png; sourceTree = "<group>"; };
-		FR_366960336468 /* Tests2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests2.m; sourceTree = "<group>"; };
-		FR_367189898554 /* stp_card_diners.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_diners.png; sourceTree = "<group>"; };
-		FR_374682488696 /* STPCustomer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Private.h"; sourceTree = "<group>"; };
-		FR_374760221277 /* STPAddressFieldTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddressFieldTableViewCell.m; sourceTree = "<group>"; };
-		FR_374847588504 /* STPSourceCardDetails+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceCardDetails+Private.h"; sourceTree = "<group>"; };
-		FR_378986667073 /* STPUserInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPUserInformation.m; sourceTree = "<group>"; };
-		FR_380964705581 /* STPSource+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSource+Private.h"; sourceTree = "<group>"; };
-		FR_381020398572 /* STPSourceReceiver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceReceiver.h; sourceTree = "<group>"; };
-		FR_381353028354 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "zh-Hans"; path = "zh-Hans.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
-		FR_382488979221 /* STPCustomer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomer.h; sourceTree = "<group>"; };
-		FR_384110904147 /* stp_card_cvc_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_cvc_amex.png; sourceTree = "<group>"; };
-		FR_385496779698 /* STPSourceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceProtocol.h; sourceTree = "<group>"; };
-		FR_385908145032 /* STPAddCardViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAddCardViewController+Private.h"; sourceTree = "<group>"; };
-		FR_386610645429 /* STPCardValidationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidationState.h; sourceTree = "<group>"; };
-		FR_388049849250 /* UIView+Stripe_SafeAreaBounds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_SafeAreaBounds.h"; sourceTree = "<group>"; };
-		FR_388506942031 /* UINavigationBar+Stripe_Theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+Stripe_Theme.h"; sourceTree = "<group>"; };
-		FR_388580610033 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_391523138388 /* STPSourceReceiver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceReceiver.m; sourceTree = "<group>"; };
-		FR_392811231591 /* STPMultipartFormDataPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataPart.h; sourceTree = "<group>"; };
-		FR_392935778985 /* stp_card_unionpay_template_en@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_en@2x.png"; sourceTree = "<group>"; };
-		FR_393570962306 /* stp_card_discover@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover@2x.png"; sourceTree = "<group>"; };
-		FR_394251211369 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.m"; sourceTree = "<group>"; };
-		FR_395459264864 /* STPPaymentCardTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextField.m; sourceTree = "<group>"; };
-		FR_398590689728 /* PINMemoryCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINMemoryCache.m; sourceTree = "<group>"; };
-		FR_399167766251 /* STPSectionHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSectionHeaderView.h; sourceTree = "<group>"; };
-		FR_401389674811 /* STPTelemetryClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPTelemetryClient.m; sourceTree = "<group>"; };
-		FR_401594702906 /* STPConnectAccountParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPConnectAccountParams.m; sourceTree = "<group>"; };
-		FR_401970492002 /* NSString+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+Stripe.h"; sourceTree = "<group>"; };
-		FR_404433001070 /* Stripe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "Stripe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_404486997170 /* NSMutableURLRequest+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Stripe.h"; sourceTree = "<group>"; };
-		FR_404502426469 /* stp_card_unionpay_en.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_en.png; sourceTree = "<group>"; };
-		FR_404853706608 /* STPSwitchTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSwitchTableViewCell.h; sourceTree = "<group>"; };
-		FR_404856632346 /* STPAddCardViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddCardViewController.h; sourceTree = "<group>"; };
-		FR_405349128011 /* STPURLCallbackHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPURLCallbackHandler.m; sourceTree = "<group>"; };
-		FR_406521029219 /* share-extension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = "share-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_406546668048 /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
-		FR_409503237802 /* strings-extension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = "strings-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_410374790759 /* STPSourceSEPADebitDetails.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceSEPADebitDetails.m; sourceTree = "<group>"; };
-		FR_411623523903 /* STPPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethod.h; sourceTree = "<group>"; };
-		FR_411849423046 /* Stub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Stub.m; sourceTree = "<group>"; };
-		FR_414892880882 /* STPDelegateProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDelegateProxy.h; sourceTree = "<group>"; };
-		FR_416373643255 /* UIBarButtonItem+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIBarButtonItem+Stripe.m"; sourceTree = "<group>"; };
-		FR_417555773173 /* NSDictionary+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+Stripe.h"; sourceTree = "<group>"; };
-		FR_418773092332 /* STPAnalyticsClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAnalyticsClient.h; sourceTree = "<group>"; };
-		FR_418981300576 /* STPFormEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncoder.h; sourceTree = "<group>"; };
-		FR_419705868654 /* STPAPIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIClient.h; sourceTree = "<group>"; };
-		FR_420127068589 /* strings-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "strings-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_420204909531 /* STPBankAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccountParams.h; sourceTree = "<group>"; };
-		FR_420351753711 /* STPEmailAddressValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEmailAddressValidator.h; sourceTree = "<group>"; };
-		FR_420913153337 /* stp_card_visa_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa_template@2x.png"; sourceTree = "<group>"; };
-		FR_423034687929 /* STPBankAccountParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBankAccountParams.m; sourceTree = "<group>"; };
-		FR_423248315424 /* Fabric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
-		FR_423454223633 /* STPCoreViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreViewController.h; sourceTree = "<group>"; };
-		FR_423624774639 /* STPSourceVerification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceVerification.h; sourceTree = "<group>"; };
-		FR_424126959875 /* STPShippingMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodsViewController.h; sourceTree = "<group>"; };
-		FR_425904257008 /* STPSourceRedirect.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceRedirect.m; sourceTree = "<group>"; };
-		FR_428784919258 /* STPInternalAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPInternalAPIResponseDecodable.h; sourceTree = "<group>"; };
-		FR_430371989691 /* STPSourceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceProtocol.h; sourceTree = "<group>"; };
-		FR_430541868205 /* UIViewController+Stripe_ParentViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_ParentViewController.m"; sourceTree = "<group>"; };
-		FR_431621881643 /* stp_card_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex@3x.png"; sourceTree = "<group>"; };
-		FR_431935522678 /* STPLegalEntityParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLegalEntityParams.h; sourceTree = "<group>"; };
-		FR_432522117665 /* STPPaymentMethodsInternalViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsInternalViewController.h; sourceTree = "<group>"; };
-		FR_433492106586 /* STPShippingMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodsViewController.h; sourceTree = "<group>"; };
-		FR_441077981283 /* STPShippingMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodTableViewCell.h; sourceTree = "<group>"; };
-		FR_441528659827 /* stp_icon_add@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_add@3x.png"; sourceTree = "<group>"; };
-		FR_442086127483 /* STPMultipartFormDataPart.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPMultipartFormDataPart.m; sourceTree = "<group>"; };
-		FR_444626220675 /* NSError+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSError+Stripe.m"; sourceTree = "<group>"; };
-		FR_445478471295 /* STPPaymentMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsViewController.h; sourceTree = "<group>"; };
-		FR_446505840808 /* PINCache-Core-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Core-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_453940417190 /* UIView+Stripe_FirstResponder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_FirstResponder.h"; sourceTree = "<group>"; };
-		FR_455050505758 /* ios-app-Bazel.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app-Bazel.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_459280268679 /* STPLocalizationUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLocalizationUtils.h; sourceTree = "<group>"; };
-		FR_459740821355 /* STPPaymentContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContext.m; sourceTree = "<group>"; };
-		FR_462191760454 /* NSURLComponents+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLComponents+Stripe.h"; sourceTree = "<group>"; };
-		FR_466487462811 /* STPAPIClient+ApplePay.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPAPIClient+ApplePay.m"; sourceTree = "<group>"; };
-		FR_470378515142 /* PINCacheMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheMacros.h; sourceTree = "<group>"; };
-		FR_472902154735 /* STPEphemeralKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEphemeralKey.m; sourceTree = "<group>"; };
-		FR_474020775691 /* STPSectionHeaderView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSectionHeaderView.m; sourceTree = "<group>"; };
-		FR_474718748706 /* stp_test_upload_image.jpeg */ = {isa = PBXFileReference; path = stp_test_upload_image.jpeg; sourceTree = "<group>"; };
-		FR_477653190877 /* STPInternalAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPInternalAPIResponseDecodable.h; sourceTree = "<group>"; };
-		FR_480004592247 /* Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Stripe.h; sourceTree = "<group>"; };
-		FR_482859520448 /* STPPaymentCardTextFieldViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldViewModel.h; sourceTree = "<group>"; };
-		FR_484445793271 /* PINCacheObjectSubscripting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheObjectSubscripting.h; sourceTree = "<group>"; };
-		FR_485682691696 /* STPSourceCardDetails+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceCardDetails+Private.h"; sourceTree = "<group>"; };
-		FR_485722511970 /* STPPaymentMethodTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTableViewCell.m; sourceTree = "<group>"; };
-		FR_489574871852 /* STPCard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCard.h; sourceTree = "<group>"; };
-		FR_491941513565 /* NSError+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+Stripe.h"; sourceTree = "<group>"; };
-		FR_496612823329 /* UIViewController+Stripe_Promises.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_Promises.h"; sourceTree = "<group>"; };
-		FR_499853310274 /* UIViewController+Stripe_Promises.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_Promises.m"; sourceTree = "<group>"; };
-		FR_500726537716 /* STPSourceReceiver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceReceiver.h; sourceTree = "<group>"; };
-		FR_503781061646 /* NSArray+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSArray+Stripe.h"; sourceTree = "<group>"; };
-		FR_504151002142 /* NSDecimalNumber+Stripe_Currency.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDecimalNumber+Stripe_Currency.h"; sourceTree = "<group>"; };
-		FR_504790352271 /* STPBundleLocator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBundleLocator.m; sourceTree = "<group>"; };
-		FR_505660890208 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
-		FR_508273787935 /* Fabric+FABKits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fabric+FABKits.h"; sourceTree = "<group>"; };
-		FR_510268330865 /* PINDiskCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINDiskCache.h; sourceTree = "<group>"; };
-		FR_510961761073 /* stp_card_cvc_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc_amex@3x.png"; sourceTree = "<group>"; };
-		FR_514135117544 /* STPAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddress.h; sourceTree = "<group>"; };
-		FR_514428095081 /* STPPaymentMethodTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTuple.h; sourceTree = "<group>"; };
-		FR_515456468255 /* PINCache-Arc-exception-safe-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Arc-exception-safe-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_515610011898 /* Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
-		FR_515852211545 /* stp_icon_checkmark@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_checkmark@2x.png"; sourceTree = "<group>"; };
-		FR_516941852563 /* STPSourceSEPADebitDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceSEPADebitDetails.h; sourceTree = "<group>"; };
-		FR_519449128250 /* PINDiskCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINDiskCache.h; sourceTree = "<group>"; };
-		FR_523252164916 /* STPRedirectContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPRedirectContext.h; sourceTree = "<group>"; };
-		FR_524174742878 /* libios-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-ext-bin.a"; sourceTree = "<group>"; };
-		FR_524827012853 /* PINOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperation.h; sourceTree = "<group>"; };
-		FR_525895464802 /* UIImage+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Stripe.m"; sourceTree = "<group>"; };
-		FR_525920755561 /* STPPaymentCardTextFieldCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldCell.h; sourceTree = "<group>"; };
-		FR_528265777249 /* STPImageLibrary+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPImageLibrary+Private.h"; sourceTree = "<group>"; };
-		FR_532738764551 /* UIView+Stripe_SafeAreaBounds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_SafeAreaBounds.h"; sourceTree = "<group>"; };
-		FR_533049156564 /* STPSourceVerification.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceVerification.m; sourceTree = "<group>"; };
-		FR_533405582252 /* STPFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPFile+Private.h"; sourceTree = "<group>"; };
-		FR_534115266600 /* libstrings-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libstrings-ext-bin.a"; sourceTree = "<group>"; };
-		FR_535352815691 /* STPCategoryLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCategoryLoader.m; sourceTree = "<group>"; };
-		FR_536507582456 /* PKPayment+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PKPayment+Stripe.m"; sourceTree = "<group>"; };
-		FR_536833584482 /* Generated.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Generated.m; sourceTree = "<group>"; };
-		FR_538830033660 /* libsiri-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libsiri-ext-bin.a"; sourceTree = "<group>"; };
-		FR_540659108168 /* Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.plug-in"; path = "Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_541504829408 /* STPCardIOProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardIOProxy.h; sourceTree = "<group>"; };
-		FR_542815357791 /* UrlGetClasses-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "UrlGetClasses-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_543005669959 /* STPAddCardViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAddCardViewController+Private.h"; sourceTree = "<group>"; };
-		FR_543689780104 /* UIView+Stripe_FirstResponder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_FirstResponder.h"; sourceTree = "<group>"; };
-		FR_544549138247 /* STPCardParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardParams.h; sourceTree = "<group>"; };
-		FR_545341058950 /* STPSwitchTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSwitchTableViewCell.h; sourceTree = "<group>"; };
-		FR_546761756616 /* STPFormEncodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncodable.h; sourceTree = "<group>"; };
-		FR_549986619017 /* stp_icon_checkmark@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_checkmark@3x.png"; sourceTree = "<group>"; };
-		FR_550956318664 /* HeaderLib.hpp */ = {isa = PBXFileReference; path = HeaderLib.hpp; sourceTree = "<group>"; };
-		FR_551790036270 /* Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Stripe.h; sourceTree = "<group>"; };
-		FR_559018671517 /* UIViewController+Stripe_Promises.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_Promises.h"; sourceTree = "<group>"; };
-		FR_560042372130 /* NSError+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+Stripe.h"; sourceTree = "<group>"; };
-		FR_560286231490 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		FR_560728635814 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
-		FR_561613473899 /* STPPaymentMethodsInternalViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsInternalViewController.h; sourceTree = "<group>"; };
-		FR_561627957161 /* STPColorUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPColorUtils.h; sourceTree = "<group>"; };
-		FR_562402903136 /* STPDispatchFunctions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPDispatchFunctions.m; sourceTree = "<group>"; };
-		FR_562520138872 /* STPPaymentResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentResult.h; sourceTree = "<group>"; };
-		FR_562943593105 /* STPFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFile.h; sourceTree = "<group>"; };
-		FR_564214461619 /* STPLegalEntityParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLegalEntityParams.h; sourceTree = "<group>"; };
-		FR_564512028139 /* stp_card_cvc@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc@2x.png"; sourceTree = "<group>"; };
-		FR_565338640322 /* UINavigationBar+Stripe_Theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+Stripe_Theme.h"; sourceTree = "<group>"; };
-		FR_568706760541 /* NSDecimalNumber+Stripe_Currency.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDecimalNumber+Stripe_Currency.h"; sourceTree = "<group>"; };
-		FR_571118315125 /* libios-app-bin-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-app-bin-ios-12.0.a"; sourceTree = "<group>"; };
-		FR_571164217949 /* STPEmailAddressValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEmailAddressValidator.m; sourceTree = "<group>"; };
-		FR_571217998206 /* STPBankAccount.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBankAccount.m; sourceTree = "<group>"; };
-		FR_573348568627 /* stp_card_mastercard@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard@3x.png"; sourceTree = "<group>"; };
-		FR_573374430468 /* StripeError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeError.h; sourceTree = "<group>"; };
-		FR_574090485879 /* STPSectionHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSectionHeaderView.h; sourceTree = "<group>"; };
-		FR_574931413907 /* STPShippingMethodTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingMethodTableViewCell.m; sourceTree = "<group>"; };
-		FR_575524244686 /* STPFormEncodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncodable.h; sourceTree = "<group>"; };
-		FR_575837856911 /* AppJerry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppJerry.h; sourceTree = "<group>"; };
-		FR_576766155188 /* AppIntent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppIntent.h; sourceTree = "<group>"; };
-		FR_576915136294 /* NSCharacterSet+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSCharacterSet+Stripe.h"; sourceTree = "<group>"; };
-		FR_580663685603 /* STPAPIRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAPIRequest.m; sourceTree = "<group>"; };
-		FR_581443142118 /* NSDictionary+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+Stripe.h"; sourceTree = "<group>"; };
-		FR_582914940802 /* STPPaymentResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentResult.m; sourceTree = "<group>"; };
-		FR_585940230866 /* STPSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSource.h; sourceTree = "<group>"; };
-		FR_586986624055 /* STPAddressViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressViewModel.h; sourceTree = "<group>"; };
-		FR_587985957033 /* STPUserInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPUserInformation.h; sourceTree = "<group>"; };
-		FR_588629070354 /* STPCustomerContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCustomerContext.m; sourceTree = "<group>"; };
-		FR_591087034932 /* STPBundleLocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBundleLocator.h; sourceTree = "<group>"; };
-		FR_591149101213 /* UIBarButtonItem+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBarButtonItem+Stripe.h"; sourceTree = "<group>"; };
-		FR_592268760850 /* STPTheme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTheme.h; sourceTree = "<group>"; };
-		FR_593273223553 /* STPSourceCardDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceCardDetails.h; sourceTree = "<group>"; };
-		FR_593400371332 /* STPSourceEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceEnums.h; sourceTree = "<group>"; };
-		FR_593438413731 /* stp_card_mastercard_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard_template@3x.png"; sourceTree = "<group>"; };
-		FR_594100986418 /* STPAnalyticsClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAnalyticsClient.h; sourceTree = "<group>"; };
-		FR_595096526234 /* STPPaymentResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentResult.h; sourceTree = "<group>"; };
-		FR_595384544521 /* PINCacheMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheMacros.h; sourceTree = "<group>"; };
-		FR_599090964629 /* STPSourceRedirect+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceRedirect+Private.h"; sourceTree = "<group>"; };
-		FR_599349326557 /* STPStringUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
-		FR_599387940932 /* UIImage+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Stripe.h"; sourceTree = "<group>"; };
-		FR_600685478634 /* stp_card_unionpay_template_en@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_en@3x.png"; sourceTree = "<group>"; };
-		FR_600826957346 /* stp_card_discover_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover_template@3x.png"; sourceTree = "<group>"; };
-		FR_603505517320 /* stp_card_applepay.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_applepay.png; sourceTree = "<group>"; };
-		FR_606050766824 /* UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_608546669129 /* stp_card_form_back@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_back@2x.png"; sourceTree = "<group>"; };
-		FR_611426224449 /* STPAddressViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressViewModel.h; sourceTree = "<group>"; };
-		FR_614599844040 /* STPSourceOwner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceOwner.h; sourceTree = "<group>"; };
-		FR_617051424034 /* STPToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPToken.h; sourceTree = "<group>"; };
-		FR_621770749327 /* libStripe-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libStripe-ios-12.0.a"; sourceTree = "<group>"; };
-		FR_623276489142 /* Stripe-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "Stripe-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_624367940457 /* STPSourceEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceEnums.h; sourceTree = "<group>"; };
-		FR_627507193231 /* STPSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSource.h; sourceTree = "<group>"; };
-		FR_628721409824 /* PINOperationQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationQueue.h; sourceTree = "<group>"; };
-		FR_629149074297 /* STPEmailAddressValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEmailAddressValidator.h; sourceTree = "<group>"; };
-		FR_629270262851 /* STPPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethod.h; sourceTree = "<group>"; };
-		FR_629548608649 /* HeaderLib-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "HeaderLib-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_629820978782 /* stp_icon_add@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_add@2x.png"; sourceTree = "<group>"; };
-		FR_629869520108 /* STPSourceVerification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceVerification.h; sourceTree = "<group>"; };
-		FR_633906012597 /* GoogleAuthUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleAuthUtilities.framework; path = Vendor/GoogleAuthUtilities/Frameworks/frameworks/GoogleAuthUtilities.framework; sourceTree = "<group>"; };
-		FR_634495254009 /* NSBundle+Stripe_AppName.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+Stripe_AppName.h"; sourceTree = "<group>"; };
-		FR_635722256605 /* STPSourceParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceParams.m; sourceTree = "<group>"; };
-		FR_643271429008 /* UIToolbar+Stripe_InputAccessory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIToolbar+Stripe_InputAccessory.h"; sourceTree = "<group>"; };
-		FR_645411521541 /* PINCache-Arc-exception-safe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Arc-exception-safe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_646329714542 /* STPPaymentCardTextFieldCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextFieldCell.m; sourceTree = "<group>"; };
-		FR_646401499000 /* stp_card_form_front.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_form_front.png; sourceTree = "<group>"; };
-		FR_647044893441 /* STPEphemeralKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKey.h; sourceTree = "<group>"; };
-		FR_647718745479 /* stp_card_discover@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover@3x.png"; sourceTree = "<group>"; };
-		FR_647919086969 /* PINOperationMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationMacros.h; sourceTree = "<group>"; };
-		FR_649238455296 /* STPPaymentCardTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextField.h; sourceTree = "<group>"; };
-		FR_651709914966 /* stp_card_jcb_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_jcb_template.png; sourceTree = "<group>"; };
-		FR_652869617708 /* UIToolbar+Stripe_InputAccessory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIToolbar+Stripe_InputAccessory.m"; sourceTree = "<group>"; };
-		FR_653012245890 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
-		FR_654701584642 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.h"; sourceTree = "<group>"; };
-		FR_657939000329 /* STPTelemetryClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTelemetryClient.h; sourceTree = "<group>"; };
-		FR_665937321012 /* STPPaymentConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentConfiguration.m; sourceTree = "<group>"; };
-		FR_667620021817 /* STPFormEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFormEncoder.m; sourceTree = "<group>"; };
-		FR_669453909057 /* STPCoreScrollViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreScrollViewController.h; sourceTree = "<group>"; };
-		FR_670075701234 /* STPCustomer+SourceTuple.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPCustomer+SourceTuple.m"; sourceTree = "<group>"; };
-		FR_670152390772 /* STPBankAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccountParams.h; sourceTree = "<group>"; };
-		FR_678627904183 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		FR_680376588314 /* stp_card_visa@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa@2x.png"; sourceTree = "<group>"; };
-		FR_682061921855 /* STPTheme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTheme.h; sourceTree = "<group>"; };
-		FR_682252300927 /* siri-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "siri-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_682270288359 /* StripeError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StripeError.m; sourceTree = "<group>"; };
-		FR_682789186016 /* stp_card_visa_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa_template@3x.png"; sourceTree = "<group>"; };
-		FR_683331153862 /* STPToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPToken.h; sourceTree = "<group>"; };
-		FR_683967887143 /* STPPaymentMethodsViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethodsViewController+Private.h"; sourceTree = "<group>"; };
-		FR_684842129661 /* STPCardIOProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardIOProxy.m; sourceTree = "<group>"; };
-		FR_685562832071 /* STPDelegateProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPDelegateProxy.m; sourceTree = "<group>"; };
-		FR_686356710930 /* STPSourceOwner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceOwner.h; sourceTree = "<group>"; };
-		FR_686700913758 /* STPSourceParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceParams+Private.h"; sourceTree = "<group>"; };
-		FR_688517925663 /* STPCustomer+SourceTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+SourceTuple.h"; sourceTree = "<group>"; };
-		FR_691495142809 /* STPPaymentConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentConfiguration.h; sourceTree = "<group>"; };
-		FR_693100679042 /* stp_shipping_form.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_shipping_form.png; sourceTree = "<group>"; };
-		FR_694106962702 /* UIViewController+Stripe_NavigationItemProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_NavigationItemProxy.h"; sourceTree = "<group>"; };
-		FR_694424347491 /* STPPromise.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPromise.h; sourceTree = "<group>"; };
-		FR_694773287744 /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
-		FR_696955024788 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		FR_698865802314 /* STPCardValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardValidator.m; sourceTree = "<group>"; };
-		FR_700870847596 /* stp_card_unionpay_template_en.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_template_en.png; sourceTree = "<group>"; };
-		FR_701536383989 /* STPBINRange.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBINRange.m; sourceTree = "<group>"; };
-		FR_706287541467 /* UINavigationController+Stripe_Completion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+Stripe_Completion.h"; sourceTree = "<group>"; };
-		FR_707702346637 /* STPSwitchTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSwitchTableViewCell.m; sourceTree = "<group>"; };
-		FR_707855371868 /* STPValidatedTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPValidatedTextField.h; sourceTree = "<group>"; };
-		FR_714589191537 /* STPAddress.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddress.m; sourceTree = "<group>"; };
-		FR_720237274209 /* STPShippingAddressViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingAddressViewController.h; sourceTree = "<group>"; };
-		FR_720785863149 /* stp_shipping_form@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_shipping_form@2x.png"; sourceTree = "<group>"; };
-		FR_721269067802 /* stp_card_mastercard.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_mastercard.png; sourceTree = "<group>"; };
-		FR_722755400736 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.plug-in"; path = "Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_723722683585 /* stp_card_discover_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_discover_template.png; sourceTree = "<group>"; };
-		FR_723941053046 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
-		FR_724373808324 /* STPSourceRedirect+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceRedirect+Private.h"; sourceTree = "<group>"; };
-		FR_725982103443 /* UINavigationController+Stripe_Completion.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UINavigationController+Stripe_Completion.m"; sourceTree = "<group>"; };
-		FR_726706439679 /* STPTelemetryClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTelemetryClient.h; sourceTree = "<group>"; };
-		FR_728026518839 /* STPAddCardViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddCardViewController.h; sourceTree = "<group>"; };
-		FR_729563592373 /* stp_card_diners_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_diners_template.png; sourceTree = "<group>"; };
-		FR_730682142522 /* stp_card_unionpay_en@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_en@3x.png"; sourceTree = "<group>"; };
-		FR_731776241747 /* STPPaymentActivityIndicatorView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentActivityIndicatorView.h; sourceTree = "<group>"; };
-		FR_731891552567 /* STPEphemeralKeyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyProvider.h; sourceTree = "<group>"; };
-		FR_732694155215 /* STPPostalCodeValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidator.m; sourceTree = "<group>"; };
-		FR_736955945348 /* STPEphemeralKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKey.h; sourceTree = "<group>"; };
-		FR_740669461234 /* STPSource+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSource+Private.h"; sourceTree = "<group>"; };
-		FR_747253515199 /* FauxPasAnnotations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FauxPasAnnotations.h; sourceTree = "<group>"; };
-		FR_747880172874 /* STPBankAccount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccount.h; sourceTree = "<group>"; };
-		FR_748370301216 /* STPPaymentCardTextFieldCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldCell.h; sourceTree = "<group>"; };
-		FR_748516206887 /* PINCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCache.h; sourceTree = "<group>"; };
-		FR_748822618665 /* STPBankAccount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccount.h; sourceTree = "<group>"; };
-		FR_750021784507 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		FR_750971871591 /* STPPaymentCardTextField+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentCardTextField+Private.h"; sourceTree = "<group>"; };
-		FR_756270580861 /* STPImageLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPImageLibrary.h; sourceTree = "<group>"; };
-		FR_758089556382 /* stp_card_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_amex.png; sourceTree = "<group>"; };
-		FR_758860821355 /* FABKitProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FABKitProtocol.h; sourceTree = "<group>"; };
-		FR_760953752264 /* NSArray+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Stripe.m"; sourceTree = "<group>"; };
-		FR_762256666880 /* STPAPIClient+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+Private.h"; sourceTree = "<group>"; };
-		FR_763548395573 /* PINOperationGroup.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINOperationGroup.m; sourceTree = "<group>"; };
-		FR_764521294758 /* stp_card_mastercard_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard_template@2x.png"; sourceTree = "<group>"; };
-		FR_765251530720 /* stp_card_cvc.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_cvc.png; sourceTree = "<group>"; };
-		FR_766714036471 /* stp_shipping_form@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_shipping_form@3x.png"; sourceTree = "<group>"; };
-		FR_768451756079 /* STPAddCardViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddCardViewController.m; sourceTree = "<group>"; };
-		FR_770709987754 /* STPApplePayPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPApplePayPaymentMethod.h; sourceTree = "<group>"; };
-		FR_774182455908 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
-		FR_780002710116 /* STPPaymentMethodTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTuple.h; sourceTree = "<group>"; };
-		FR_782498420325 /* STPBankAccountParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPBankAccountParams+Private.h"; sourceTree = "<group>"; };
-		FR_782705593529 /* STPPaymentContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContext.h; sourceTree = "<group>"; };
-		FR_783911409348 /* STPPaymentContextAmountModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContextAmountModel.h; sourceTree = "<group>"; };
-		FR_784242390380 /* STPValidatedTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPValidatedTextField.h; sourceTree = "<group>"; };
-		FR_785291574055 /* stp_card_form_back@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_back@3x.png"; sourceTree = "<group>"; };
-		FR_785336258264 /* StripeError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeError.h; sourceTree = "<group>"; };
-		FR_785617435345 /* PKPayment+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPayment+Stripe.h"; sourceTree = "<group>"; };
-		FR_786752301895 /* STPCoreTableViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreTableViewController+Private.h"; sourceTree = "<group>"; };
-		FR_789614747984 /* STPSourcePoller.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourcePoller.h; sourceTree = "<group>"; };
-		FR_789854558921 /* STPAPIClient+ApplePay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+ApplePay.h"; sourceTree = "<group>"; };
-		FR_790732552626 /* STPCustomerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomerContext.h; sourceTree = "<group>"; };
-		FR_790956405061 /* FABKitProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FABKitProtocol.h; sourceTree = "<group>"; };
-		FR_792160814884 /* STPTheme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPTheme.m; sourceTree = "<group>"; };
-		FR_792622417316 /* UIViewController+Stripe_ParentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_ParentViewController.h"; sourceTree = "<group>"; };
-		FR_795132420225 /* STPCardParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardParams.m; sourceTree = "<group>"; };
-		FR_795417469207 /* UINavigationBar+Stripe_Theme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UINavigationBar+Stripe_Theme.m"; sourceTree = "<group>"; };
-		FR_797237603389 /* NSCharacterSet+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSCharacterSet+Stripe.h"; sourceTree = "<group>"; };
-		FR_797436073728 /* STPCardValidationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidationState.h; sourceTree = "<group>"; };
-		FR_799056671175 /* NSURLComponents+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLComponents+Stripe.h"; sourceTree = "<group>"; };
-		FR_800458577779 /* libPINCache-Core-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Core-ios-9.0.a"; sourceTree = "<group>"; };
-		FR_802354542601 /* STPPhoneNumberValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPhoneNumberValidator.h; sourceTree = "<group>"; };
-		FR_805132164928 /* stp_card_unionpay_zh@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_zh@3x.png"; sourceTree = "<group>"; };
-		FR_807240866189 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.h"; sourceTree = "<group>"; };
-		FR_810092475433 /* stp_card_unknown@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unknown@3x.png"; sourceTree = "<group>"; };
-		FR_811655502329 /* GoogleAppIndexing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleAppIndexing.framework; path = Vendor/GoogleAppIndexing/Frameworks/GoogleAppIndexing.framework; sourceTree = "<group>"; };
-		FR_812073861033 /* UIViewController+Stripe_NavigationItemProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_NavigationItemProxy.m"; sourceTree = "<group>"; };
-		FR_813232904291 /* AppJerry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppJerry.m; sourceTree = "<group>"; };
-		FR_814450748520 /* STPCardIOProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardIOProxy.h; sourceTree = "<group>"; };
-		FR_815379450093 /* stp_card_unionpay_zh.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_zh.png; sourceTree = "<group>"; };
-		FR_815939899847 /* STPURLCallbackHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPURLCallbackHandler.h; sourceTree = "<group>"; };
-		FR_818505862395 /* STPPaymentCardTextField+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentCardTextField+Private.h"; sourceTree = "<group>"; };
-		FR_818774264549 /* STPAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIResponseDecodable.h; sourceTree = "<group>"; };
-		FR_819880206632 /* STPPaymentCardTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextField.h; sourceTree = "<group>"; };
-		FR_820412954877 /* UIViewController+Stripe_KeyboardAvoiding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_KeyboardAvoiding.h"; sourceTree = "<group>"; };
-		FR_820499346752 /* STPCard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCard.h; sourceTree = "<group>"; };
-		FR_821099591187 /* STPToken.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPToken.m; sourceTree = "<group>"; };
-		FR_821560233640 /* STPSourceOwner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceOwner.m; sourceTree = "<group>"; };
-		FR_821927058828 /* STPAPIRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIRequest.h; sourceTree = "<group>"; };
-		FR_823746509568 /* Diags.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Diags.xcconfig; sourceTree = "<group>"; };
-		FR_825197242686 /* STPDelegateProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDelegateProxy.h; sourceTree = "<group>"; };
-		FR_825630796487 /* Fabric+FABKits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fabric+FABKits.h"; sourceTree = "<group>"; };
-		FR_826359326254 /* PINCache-Core-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Core-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_826804962981 /* GoogleAppIndexingResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleAppIndexingResources.bundle; sourceTree = "<group>"; };
-		FR_826920421366 /* PKPayment+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPayment+Stripe.h"; sourceTree = "<group>"; };
-		FR_827303504770 /* STPColorUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPColorUtils.h; sourceTree = "<group>"; };
-		FR_831704377129 /* UIView+Stripe_FirstResponder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+Stripe_FirstResponder.m"; sourceTree = "<group>"; };
-		FR_832155225473 /* UIViewController+Stripe_KeyboardAvoiding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_KeyboardAvoiding.m"; sourceTree = "<group>"; };
-		FR_833832260348 /* STPFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPFile+Private.h"; sourceTree = "<group>"; };
-		FR_834529548017 /* UITableViewCell+Stripe_Borders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UITableViewCell+Stripe_Borders.h"; sourceTree = "<group>"; };
-		FR_836986626561 /* libPINCache-Arc-exception-safe-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Arc-exception-safe-ios-12.0.a"; sourceTree = "<group>"; };
-		FR_839061891305 /* libPINCache-Core-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Core-ios-12.0.a"; sourceTree = "<group>"; };
-		FR_840677560290 /* STPSource.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSource.m; sourceTree = "<group>"; };
-		FR_843574680132 /* stp_card_diners@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners@2x.png"; sourceTree = "<group>"; };
-		FR_847045712447 /* STPEphemeralKeyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyProvider.h; sourceTree = "<group>"; };
-		FR_848089631548 /* UIToolbar+Stripe_InputAccessory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIToolbar+Stripe_InputAccessory.h"; sourceTree = "<group>"; };
-		FR_848652416968 /* UrlGetClasses-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "UrlGetClasses-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_849271034348 /* STPPaymentMethodsViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethodsViewController+Private.h"; sourceTree = "<group>"; };
-		FR_849310420444 /* libStripe-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libStripe-ios-9.0.a"; sourceTree = "<group>"; };
-		FR_849623333700 /* STPRedirectContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPRedirectContext.h; sourceTree = "<group>"; };
-		FR_850949429257 /* STPCardValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidator.h; sourceTree = "<group>"; };
-		FR_854342266175 /* ios-app-bin-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-app-bin-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_854600736464 /* GoogleSymbolUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleSymbolUtilities.framework; path = Vendor/GoogleSymbolUtilities/Frameworks/frameworks/GoogleSymbolUtilities.framework; sourceTree = "<group>"; };
-		FR_856017749152 /* share-extension-Bazel.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = "share-extension-Bazel.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_858844900391 /* stp_card_form_back.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_form_back.png; sourceTree = "<group>"; };
-		FR_859647957539 /* UITableViewCell+Stripe_Borders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UITableViewCell+Stripe_Borders.h"; sourceTree = "<group>"; };
-		FR_859974805442 /* PINMemoryCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINMemoryCache.h; sourceTree = "<group>"; };
-		FR_861672862353 /* STPApplePayPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPApplePayPaymentMethod.h; sourceTree = "<group>"; };
-		FR_862109982380 /* stp_card_amex_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex_template@2x.png"; sourceTree = "<group>"; };
-		FR_863592367999 /* PINCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCaching.h; sourceTree = "<group>"; };
-		FR_865204967261 /* stp_card_error@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error@2x.png"; sourceTree = "<group>"; };
-		FR_869656627571 /* stp_card_unionpay_template_zh.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_template_zh.png; sourceTree = "<group>"; };
-		FR_871001035230 /* STPConnectAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPConnectAccountParams.h; sourceTree = "<group>"; };
-		FR_876379193786 /* STPBackendAPIAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBackendAPIAdapter.h; sourceTree = "<group>"; };
-		FR_877522748700 /* PINCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCaching.h; sourceTree = "<group>"; };
-		FR_877552865893 /* STPDispatchFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDispatchFunctions.h; sourceTree = "<group>"; };
-		FR_877683079452 /* STPCustomer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCustomer.m; sourceTree = "<group>"; };
-		FR_878614281729 /* STPSourceParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceParams.h; sourceTree = "<group>"; };
-		FR_879608332693 /* STPPaymentMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsViewController.h; sourceTree = "<group>"; };
-		FR_882491438659 /* STPFormTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFormTextField.m; sourceTree = "<group>"; };
-		FR_883882644277 /* STPBankAccountParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPBankAccountParams+Private.h"; sourceTree = "<group>"; };
-		FR_885437122687 /* STPColorUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPColorUtils.m; sourceTree = "<group>"; };
-		FR_887912048029 /* STPPaymentContextAmountModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContextAmountModel.m; sourceTree = "<group>"; };
-		FR_888995822461 /* PINOperation-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINOperation-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_890612956832 /* stp_card_diners_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners_template@3x.png"; sourceTree = "<group>"; };
-		FR_893575362148 /* STPCardParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardParams.h; sourceTree = "<group>"; };
-		FR_893633932801 /* UrlGetViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UrlGetViewController.m; sourceTree = "<group>"; };
-		FR_896260771039 /* stp_card_unknown.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unknown.png; sourceTree = "<group>"; };
-		FR_898308164695 /* UrlGetViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UrlGetViewController.xib; sourceTree = "<group>"; };
-		FR_900155382855 /* NSMutableURLRequest+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSMutableURLRequest+Stripe.m"; sourceTree = "<group>"; };
-		FR_900806134110 /* stp_card_error@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error@3x.png"; sourceTree = "<group>"; };
-		FR_902210249661 /* STPAPIClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAPIClient.m; sourceTree = "<group>"; };
-		FR_903119597428 /* stp_card_error_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_error_amex.png; sourceTree = "<group>"; };
-		FR_903524758896 /* HeaderLib-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "HeaderLib-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_904277097215 /* PINOperationMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationMacros.h; sourceTree = "<group>"; };
-		FR_904565042407 /* stp_card_unionpay_en@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_en@2x.png"; sourceTree = "<group>"; };
-		FR_905942270940 /* stp_card_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex@2x.png"; sourceTree = "<group>"; };
-		FR_910623067955 /* PINOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperation.h; sourceTree = "<group>"; };
-		FR_913750020022 /* stp_card_form_front@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_front@2x.png"; sourceTree = "<group>"; };
-		FR_914246773896 /* STPCategoryLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
-		FR_914874316924 /* STPMultipartFormDataEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataEncoder.h; sourceTree = "<group>"; };
-		FR_914926894106 /* NoArc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NoArc.m; sourceTree = "<group>"; };
-		FR_917066196830 /* NSString+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+Stripe.h"; sourceTree = "<group>"; };
-		FR_918544604518 /* stp_card_error.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_error.png; sourceTree = "<group>"; };
-		FR_919264268692 /* STPAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddress.h; sourceTree = "<group>"; };
-		FR_919742180124 /* STPShippingAddressViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingAddressViewController.m; sourceTree = "<group>"; };
-		FR_921508757598 /* STPBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBlocks.h; sourceTree = "<group>"; };
-		FR_921549316179 /* NSURLComponents+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURLComponents+Stripe.m"; sourceTree = "<group>"; };
-		FR_923168362961 /* STPAddressViewModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddressViewModel.m; sourceTree = "<group>"; };
-		FR_927073100198 /* UIImage+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Stripe.h"; sourceTree = "<group>"; };
-		FR_947777323233 /* stp_card_visa@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa@3x.png"; sourceTree = "<group>"; };
-		FR_949688277225 /* STPApplePayPaymentMethod.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPApplePayPaymentMethod.m; sourceTree = "<group>"; };
-		FR_954961411422 /* siri-extension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = "siri-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_957602751546 /* STPEphemeralKeyManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyManager.h; sourceTree = "<group>"; };
-		FR_987445166148 /* STPCardBrand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardBrand.h; sourceTree = "<group>"; };
+		FR_101130172000 /* STPShippingMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodsViewController.h; sourceTree = "<group>"; };
+		FR_103239545125 /* STPBankAccountParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBankAccountParams.m; sourceTree = "<group>"; };
+		FR_103939101377 /* Fabric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
+		FR_105312376394 /* stp_card_unknown.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unknown.png; sourceTree = "<group>"; };
+		FR_107828258449 /* UrlGetViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UrlGetViewController.h; sourceTree = "<group>"; };
+		FR_108219390614 /* stp_icon_checkmark@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_checkmark@3x.png"; sourceTree = "<group>"; };
+		FR_108718220097 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
+		FR_110679394668 /* STPCardParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardParams.h; sourceTree = "<group>"; };
+		FR_110902364758 /* STPAnalyticsClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAnalyticsClient.h; sourceTree = "<group>"; };
+		FR_114970438289 /* stp_card_discover@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover@2x.png"; sourceTree = "<group>"; };
+		FR_115188359612 /* Diags.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Diags.xcconfig; sourceTree = "<group>"; };
+		FR_115630106739 /* STPPaymentActivityIndicatorView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentActivityIndicatorView.h; sourceTree = "<group>"; };
+		FR_119002602353 /* NSArray+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSArray+Stripe.h"; sourceTree = "<group>"; };
+		FR_121714099050 /* NSURLComponents+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURLComponents+Stripe.m"; sourceTree = "<group>"; };
+		FR_121783217597 /* STPUserInformation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPUserInformation.m; sourceTree = "<group>"; };
+		FR_125415528864 /* STPMultipartFormDataEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPMultipartFormDataEncoder.m; sourceTree = "<group>"; };
+		FR_126465798583 /* STPSourceParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceParams+Private.h"; sourceTree = "<group>"; };
+		FR_129458307009 /* STPBackendAPIAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBackendAPIAdapter.h; sourceTree = "<group>"; };
+		FR_129519764473 /* STPBINRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBINRange.h; sourceTree = "<group>"; };
+		FR_129901347196 /* stp_card_diners_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners_template@2x.png"; sourceTree = "<group>"; };
+		FR_130722653257 /* STPBankAccount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccount.h; sourceTree = "<group>"; };
+		FR_131673468586 /* STPSourceCardDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceCardDetails.h; sourceTree = "<group>"; };
+		FR_132248253085 /* UnitTestsWithHost.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UnitTestsWithHost.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_132931449288 /* STPFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFile.h; sourceTree = "<group>"; };
+		FR_136210399342 /* stp_card_cvc.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_cvc.png; sourceTree = "<group>"; };
+		FR_137435447838 /* stp_card_applepay.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_applepay.png; sourceTree = "<group>"; };
+		FR_138052789861 /* UIView+Stripe_FirstResponder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+Stripe_FirstResponder.m"; sourceTree = "<group>"; };
+		FR_140209500333 /* ios-app-bin-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-app-bin-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_140640746934 /* ios-app-bin-ios-12.0-Bazel.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-app-bin-ios-12.0-Bazel.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_140931474443 /* UnitTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_144332652217 /* STPCategoryLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
+		FR_145973180178 /* STPCustomer+SourceTuple.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPCustomer+SourceTuple.m"; sourceTree = "<group>"; };
+		FR_148767108939 /* STPCoreTableViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreTableViewController+Private.h"; sourceTree = "<group>"; };
+		FR_150621172151 /* STPRedirectContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPRedirectContext.h; sourceTree = "<group>"; };
+		FR_152009236735 /* stp_card_discover.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_discover.png; sourceTree = "<group>"; };
+		FR_152702596118 /* stp_card_amex_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_amex_template.png; sourceTree = "<group>"; };
+		FR_155070680239 /* stp_card_cvc@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc@2x.png"; sourceTree = "<group>"; };
+		FR_155216169727 /* stp_card_amex_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex_template@2x.png"; sourceTree = "<group>"; };
+		FR_156154002606 /* UIImage+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Stripe.h"; sourceTree = "<group>"; };
+		FR_157144616729 /* STPDispatchFunctions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPDispatchFunctions.m; sourceTree = "<group>"; };
+		FR_157313604927 /* stp_card_unionpay_en@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_en@3x.png"; sourceTree = "<group>"; };
+		FR_157970986760 /* PINCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCaching.h; sourceTree = "<group>"; };
+		FR_158773525708 /* Stripe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "Stripe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_163191866606 /* STPPaymentCardTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextField.m; sourceTree = "<group>"; };
+		FR_165031089231 /* STPValidatedTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPValidatedTextField.h; sourceTree = "<group>"; };
+		FR_168442315296 /* stp_card_form_back@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_back@3x.png"; sourceTree = "<group>"; };
+		FR_169652316528 /* STPSourceOwner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceOwner.h; sourceTree = "<group>"; };
+		FR_169667767185 /* STPFormTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFormTextField.m; sourceTree = "<group>"; };
+		FR_171751278593 /* STPPaymentMethodsInternalViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsInternalViewController.h; sourceTree = "<group>"; };
+		FR_172053165053 /* stp_card_mastercard_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_mastercard_template.png; sourceTree = "<group>"; };
+		FR_172594157380 /* STPImageLibrary+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPImageLibrary+Private.h"; sourceTree = "<group>"; };
+		FR_173522648416 /* StripeError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = StripeError.m; sourceTree = "<group>"; };
+		FR_175105183886 /* STPSourceVerification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceVerification.h; sourceTree = "<group>"; };
+		FR_176299773792 /* PINCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCache.h; sourceTree = "<group>"; };
+		FR_176432501039 /* STPBankAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccountParams.h; sourceTree = "<group>"; };
+		FR_176498309403 /* STPAPIRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIRequest.h; sourceTree = "<group>"; };
+		FR_180176959680 /* STPPaymentCardTextFieldCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextFieldCell.m; sourceTree = "<group>"; };
+		FR_181564135531 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_184070624316 /* STPPaymentContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContext.m; sourceTree = "<group>"; };
+		FR_185441073186 /* STPSource+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSource+Private.h"; sourceTree = "<group>"; };
+		FR_187515162480 /* stp_card_unionpay_template_en@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_en@3x.png"; sourceTree = "<group>"; };
+		FR_187614841027 /* STPSourceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceProtocol.h; sourceTree = "<group>"; };
+		FR_191852455760 /* Some.hpp */ = {isa = PBXFileReference; path = Some.hpp; sourceTree = "<group>"; };
+		FR_192330679505 /* STPSourceReceiver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceReceiver.h; sourceTree = "<group>"; };
+		FR_192476533600 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "zh-Hans"; path = "zh-Hans.lproj/AppIntentVocabulary.plist"; sourceTree = "<group>"; };
+		FR_193081474965 /* STPConnectAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPConnectAccountParams.h; sourceTree = "<group>"; };
+		FR_193437629670 /* STPAddressViewModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddressViewModel.m; sourceTree = "<group>"; };
+		FR_193764108659 /* stp_card_jcb_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_jcb_template.png; sourceTree = "<group>"; };
+		FR_194454815750 /* STPSourceCardDetails+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceCardDetails+Private.h"; sourceTree = "<group>"; };
+		FR_195448006827 /* STPApplePayPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPApplePayPaymentMethod.h; sourceTree = "<group>"; };
+		FR_195771909498 /* UIViewController+Stripe_NavigationItemProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_NavigationItemProxy.m"; sourceTree = "<group>"; };
+		FR_196237328163 /* STPCustomerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomerContext.h; sourceTree = "<group>"; };
+		FR_199879867824 /* stp_card_mastercard_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard_template@2x.png"; sourceTree = "<group>"; };
+		FR_201102775891 /* STPURLCallbackHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPURLCallbackHandler.h; sourceTree = "<group>"; };
+		FR_201870136181 /* STPPostalCodeValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPostalCodeValidator.m; sourceTree = "<group>"; };
+		FR_203221802802 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.m"; sourceTree = "<group>"; };
+		FR_207408458888 /* strings-extension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = "strings-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_207425658966 /* stp_card_mastercard_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard_template@3x.png"; sourceTree = "<group>"; };
+		FR_207486663369 /* NSArray+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSArray+Stripe.h"; sourceTree = "<group>"; };
+		FR_208509687828 /* ShareExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ShareExtension-Info.plist"; sourceTree = "<group>"; };
+		FR_209653977955 /* UIViewController+Stripe_KeyboardAvoiding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_KeyboardAvoiding.h"; sourceTree = "<group>"; };
+		FR_211689055946 /* stp_card_form_back.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_form_back.png; sourceTree = "<group>"; };
+		FR_213100779117 /* STPSource+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSource+Private.h"; sourceTree = "<group>"; };
+		FR_214532835490 /* stp_card_unionpay_template_zh.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_template_zh.png; sourceTree = "<group>"; };
+		FR_215569688439 /* STPPaymentMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsViewController.h; sourceTree = "<group>"; };
+		FR_216502832656 /* STPCustomerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomerContext.h; sourceTree = "<group>"; };
+		FR_216833396960 /* NSString+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+Stripe.h"; sourceTree = "<group>"; };
+		FR_217452499355 /* STPTheme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTheme.h; sourceTree = "<group>"; };
+		FR_222145928215 /* stp_card_visa.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_visa.png; sourceTree = "<group>"; };
+		FR_222491318798 /* PINOperationTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationTypes.h; sourceTree = "<group>"; };
+		FR_223058608906 /* GoogleAuthUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleAuthUtilities.framework; path = Vendor/GoogleAuthUtilities/Frameworks/frameworks/GoogleAuthUtilities.framework; sourceTree = "<group>"; };
+		FR_223072980108 /* STPLegalEntityParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLegalEntityParams.h; sourceTree = "<group>"; };
+		FR_225702220465 /* stp_card_form_back@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_back@2x.png"; sourceTree = "<group>"; };
+		FR_227746174149 /* STPSourcePoller.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourcePoller.m; sourceTree = "<group>"; };
+		FR_230900326107 /* STPSourceVerification.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceVerification.h; sourceTree = "<group>"; };
+		FR_232158185953 /* STPSourceSEPADebitDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceSEPADebitDetails.h; sourceTree = "<group>"; };
+		FR_232273873872 /* STPSourceParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceParams.m; sourceTree = "<group>"; };
+		FR_232583874017 /* STPFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPFile+Private.h"; sourceTree = "<group>"; };
+		FR_235580276653 /* stp_card_cvc_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_cvc_amex.png; sourceTree = "<group>"; };
+		FR_239658343536 /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
+		FR_242594867211 /* STPAddCardViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddCardViewController.h; sourceTree = "<group>"; };
+		FR_242694328966 /* PINMemoryCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINMemoryCache.h; sourceTree = "<group>"; };
+		FR_243169012465 /* STPPaymentMethodsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodsViewController.m; sourceTree = "<group>"; };
+		FR_243565016729 /* STPPaymentContextAmountModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContextAmountModel.h; sourceTree = "<group>"; };
+		FR_243638250146 /* stp_icon_checkmark@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_checkmark@2x.png"; sourceTree = "<group>"; };
+		FR_244552489410 /* stp_card_diners_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_diners_template.png; sourceTree = "<group>"; };
+		FR_244673885284 /* STPSourceOwner.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceOwner.m; sourceTree = "<group>"; };
+		FR_246469422063 /* UIViewController+Stripe_NavigationItemProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_NavigationItemProxy.h"; sourceTree = "<group>"; };
+		FR_248193021936 /* STPPaymentMethodTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTuple.h; sourceTree = "<group>"; };
+		FR_248552697129 /* STPSourceRedirect.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceRedirect.m; sourceTree = "<group>"; };
+		FR_250904967226 /* STPEphemeralKeyManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyManager.h; sourceTree = "<group>"; };
+		FR_251987009335 /* STPCardParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardParams.h; sourceTree = "<group>"; };
+		FR_252085585404 /* libPINCache-Core-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Core-ios-9.0.a"; sourceTree = "<group>"; };
+		FR_253547440632 /* UIView+Stripe_SafeAreaBounds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_SafeAreaBounds.h"; sourceTree = "<group>"; };
+		FR_253971462755 /* STPEphemeralKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEphemeralKey.m; sourceTree = "<group>"; };
+		FR_255209825296 /* PINOperationTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationTypes.h; sourceTree = "<group>"; };
+		FR_256989447831 /* STPCardParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardParams.m; sourceTree = "<group>"; };
+		FR_258423055020 /* STPSourceCardDetails+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceCardDetails+Private.h"; sourceTree = "<group>"; };
+		FR_258729086301 /* STPAPIClient+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+Private.h"; sourceTree = "<group>"; };
+		FR_259116261371 /* STPPaymentConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentConfiguration.m; sourceTree = "<group>"; };
+		FR_259527767589 /* STPCoreViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreViewController.h; sourceTree = "<group>"; };
+		FR_262706035702 /* STPLegalEntityParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLegalEntityParams.h; sourceTree = "<group>"; };
+		FR_262712408620 /* STPPromise.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPromise.m; sourceTree = "<group>"; };
+		FR_264904425728 /* STPCardIOProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardIOProxy.h; sourceTree = "<group>"; };
+		FR_266084204646 /* GoogleNetworkingUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleNetworkingUtilities.framework; path = Vendor/GoogleNetworkingUtilities/Frameworks/frameworks/GoogleNetworkingUtilities.framework; sourceTree = "<group>"; };
+		FR_266277694519 /* stp_card_error_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error_amex@3x.png"; sourceTree = "<group>"; };
+		FR_267089408731 /* STPShippingMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodTableViewCell.h; sourceTree = "<group>"; };
+		FR_269159801669 /* PINOperationQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationQueue.h; sourceTree = "<group>"; };
+		FR_270702652206 /* Generated.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Generated.m; sourceTree = "<group>"; };
+		FR_273845325521 /* PINOperation-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINOperation-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_274948360570 /* UIView+Stripe_FirstResponder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_FirstResponder.h"; sourceTree = "<group>"; };
+		FR_275539566864 /* Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.plug-in"; path = "Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_276438809486 /* stp_card_diners@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners@3x.png"; sourceTree = "<group>"; };
+		FR_278953099320 /* fi */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fi; path = fi.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_279172722993 /* STPPaymentMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsViewController.h; sourceTree = "<group>"; };
+		FR_279407611271 /* GoogleAppIndexing.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleAppIndexing.framework; path = Vendor/GoogleAppIndexing/Frameworks/GoogleAppIndexing.framework; sourceTree = "<group>"; };
+		FR_279876855106 /* stp_card_diners_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners_template@3x.png"; sourceTree = "<group>"; };
+		FR_279929849787 /* STPSourceParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceParams.h; sourceTree = "<group>"; };
+		FR_288246765774 /* stp_card_unionpay_template_en.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_template_en.png; sourceTree = "<group>"; };
+		FR_292969540570 /* STPCategoryLoader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCategoryLoader.m; sourceTree = "<group>"; };
+		FR_295584209343 /* STPAPIClient+ApplePay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+ApplePay.h"; sourceTree = "<group>"; };
+		FR_296070546472 /* STPValidatedTextField.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPValidatedTextField.m; sourceTree = "<group>"; };
+		FR_298150824334 /* STPSourceReceiver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceReceiver.h; sourceTree = "<group>"; };
+		FR_298260645729 /* STPPaymentCardTextFieldCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldCell.h; sourceTree = "<group>"; };
+		FR_302162599226 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cs; path = cs.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		FR_303191177043 /* STPFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPFile+Private.h"; sourceTree = "<group>"; };
+		FR_304125809938 /* STPStringUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPStringUtils.m; sourceTree = "<group>"; };
+		FR_306021898086 /* STPPaymentConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentConfiguration+Private.h"; sourceTree = "<group>"; };
+		FR_306211367156 /* NSError+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+Stripe.h"; sourceTree = "<group>"; };
+		FR_306785741455 /* STPStringUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
+		FR_307775792133 /* STPAPIClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAPIClient.m; sourceTree = "<group>"; };
+		FR_309931703660 /* stp_card_visa_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa_template@2x.png"; sourceTree = "<group>"; };
+		FR_315250298335 /* libios-app-bin-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-app-bin-ios-12.0.a"; sourceTree = "<group>"; };
+		FR_315742577216 /* GoogleAppIndexingResources.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = GoogleAppIndexingResources.bundle; sourceTree = "<group>"; };
+		FR_319425446576 /* libsiri-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libsiri-ext-bin.a"; sourceTree = "<group>"; };
+		FR_319823595011 /* STPSwitchTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSwitchTableViewCell.m; sourceTree = "<group>"; };
+		FR_324746483455 /* NSBundle+Stripe_AppName.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+Stripe_AppName.h"; sourceTree = "<group>"; };
+		FR_325961342376 /* STPCardValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardValidator.m; sourceTree = "<group>"; };
+		FR_326732228556 /* STPCoreViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreViewController.m; sourceTree = "<group>"; };
+		FR_328297644782 /* STPSwitchTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSwitchTableViewCell.h; sourceTree = "<group>"; };
+		FR_331262609749 /* stp_card_unionpay_zh@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_zh@3x.png"; sourceTree = "<group>"; };
+		FR_332580781655 /* STPDelegateProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDelegateProxy.h; sourceTree = "<group>"; };
+		FR_333437850711 /* STPAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIResponseDecodable.h; sourceTree = "<group>"; };
+		FR_334236722090 /* NSBundle+Stripe_AppName.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSBundle+Stripe_AppName.h"; sourceTree = "<group>"; };
+		FR_334771080966 /* STPSourcePoller.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourcePoller.h; sourceTree = "<group>"; };
+		FR_334971231063 /* STPSourceSEPADebitDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceSEPADebitDetails.h; sourceTree = "<group>"; };
+		FR_335325431422 /* STPFormEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncoder.h; sourceTree = "<group>"; };
+		FR_336214935292 /* UIView+Stripe_FirstResponder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_FirstResponder.h"; sourceTree = "<group>"; };
+		FR_336502039808 /* STPSourceVerification+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceVerification+Private.h"; sourceTree = "<group>"; };
+		FR_338459165423 /* UIImage+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIImage+Stripe.h"; sourceTree = "<group>"; };
+		FR_339590863894 /* share-extension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = "share-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_340771593126 /* STPPaymentContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentContext+Private.h"; sourceTree = "<group>"; };
+		FR_345350465673 /* STPTheme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPTheme.m; sourceTree = "<group>"; };
+		FR_346017508252 /* STPFormEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncoder.h; sourceTree = "<group>"; };
+		FR_346528843102 /* UINavigationController+Stripe_Completion.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UINavigationController+Stripe_Completion.m"; sourceTree = "<group>"; };
+		FR_346809824920 /* STPBankAccountParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPBankAccountParams+Private.h"; sourceTree = "<group>"; };
+		FR_346958850421 /* STPPaymentMethodTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTuple.h; sourceTree = "<group>"; };
+		FR_346968037020 /* stp_card_cvc@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc@3x.png"; sourceTree = "<group>"; };
+		FR_348092391241 /* Fabric+FABKits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fabric+FABKits.h"; sourceTree = "<group>"; };
+		FR_349247967105 /* PINOperationQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationQueue.h; sourceTree = "<group>"; };
+		FR_350397440933 /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
+		FR_351480681724 /* FauxPasAnnotations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FauxPasAnnotations.h; sourceTree = "<group>"; };
+		FR_353786914718 /* PINCaching.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCaching.h; sourceTree = "<group>"; };
+		FR_354572980175 /* STPSource.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSource.m; sourceTree = "<group>"; };
+		FR_357805727123 /* STPEphemeralKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKey.h; sourceTree = "<group>"; };
+		FR_358371710400 /* Stub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Stub.m; sourceTree = "<group>"; };
+		FR_358868972834 /* NSCharacterSet+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSCharacterSet+Stripe.h"; sourceTree = "<group>"; };
+		FR_359007197538 /* STPSectionHeaderView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSectionHeaderView.m; sourceTree = "<group>"; };
+		FR_361180168062 /* STPSourceCardDetails.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceCardDetails.m; sourceTree = "<group>"; };
+		FR_362145144513 /* stp_card_visa@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa@3x.png"; sourceTree = "<group>"; };
+		FR_362487785619 /* libPINCache-Core-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Core-ios-12.0.a"; sourceTree = "<group>"; };
+		FR_363992742899 /* STPCoreTableViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreTableViewController.h; sourceTree = "<group>"; };
+		FR_364137728612 /* en-GB */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB"; path = "en-GB.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		FR_364844710872 /* STPToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPToken.h; sourceTree = "<group>"; };
+		FR_365735314709 /* stp_card_mastercard@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard@2x.png"; sourceTree = "<group>"; };
+		FR_368419140898 /* STPPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethod.h; sourceTree = "<group>"; };
+		FR_371726814006 /* FauxPasAnnotations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FauxPasAnnotations.h; sourceTree = "<group>"; };
+		FR_374314786944 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.h"; sourceTree = "<group>"; };
+		FR_375459743988 /* FABKitProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FABKitProtocol.h; sourceTree = "<group>"; };
+		FR_376219813331 /* STPPaymentContextAmountModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentContextAmountModel.m; sourceTree = "<group>"; };
+		FR_377768318972 /* STPShippingAddressViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingAddressViewController.h; sourceTree = "<group>"; };
+		FR_379385289566 /* STPColorUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPColorUtils.h; sourceTree = "<group>"; };
+		FR_379475835433 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		FR_380589523590 /* STPPaymentCardTextFieldViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldViewModel.h; sourceTree = "<group>"; };
+		FR_382402128781 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		FR_384868030190 /* STPPaymentResult.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentResult.m; sourceTree = "<group>"; };
+		FR_385123840418 /* STPCoreScrollViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreScrollViewController.m; sourceTree = "<group>"; };
+		FR_385170037705 /* stp_card_mastercard.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_mastercard.png; sourceTree = "<group>"; };
+		FR_386981154662 /* STPAspects.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAspects.m; sourceTree = "<group>"; };
+		FR_387881769002 /* STPAPIClient+ApplePay.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "STPAPIClient+ApplePay.m"; sourceTree = "<group>"; };
+		FR_387987486934 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		FR_388278762452 /* STPEmailAddressValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEmailAddressValidator.h; sourceTree = "<group>"; };
+		FR_389377991035 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_390587793162 /* STPCustomer+SourceTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+SourceTuple.h"; sourceTree = "<group>"; };
+		FR_391364783044 /* STPURLCallbackHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPURLCallbackHandler.h; sourceTree = "<group>"; };
+		FR_393790783742 /* ios-app.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_394762242749 /* UITableViewCell+Stripe_Borders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UITableViewCell+Stripe_Borders.h"; sourceTree = "<group>"; };
+		FR_396079641272 /* stp_card_form_front@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_front@3x.png"; sourceTree = "<group>"; };
+		FR_396363747617 /* STPEmailAddressValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEmailAddressValidator.h; sourceTree = "<group>"; };
+		FR_397991274865 /* STPBundleLocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBundleLocator.h; sourceTree = "<group>"; };
+		FR_399733994594 /* STPPaymentCardTextField+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentCardTextField+Private.h"; sourceTree = "<group>"; };
+		FR_400311668699 /* UrlGetViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UrlGetViewController.xib; sourceTree = "<group>"; };
+		FR_400952142106 /* STPShippingMethodTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingMethodTableViewCell.m; sourceTree = "<group>"; };
+		FR_401009960707 /* stp_card_cvc_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc_amex@2x.png"; sourceTree = "<group>"; };
+		FR_406016197234 /* UrlGet-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "UrlGet-Info.plist"; sourceTree = "<group>"; };
+		FR_407081031539 /* FABKitProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FABKitProtocol.h; sourceTree = "<group>"; };
+		FR_409483507308 /* STPPaymentCardTextField+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentCardTextField+Private.h"; sourceTree = "<group>"; };
+		FR_410545183530 /* PINOperationMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationMacros.h; sourceTree = "<group>"; };
+		FR_413344087887 /* STPCoreTableViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCoreTableViewController.m; sourceTree = "<group>"; };
+		FR_413571327928 /* UITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_414139705988 /* NoArc.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NoArc.m; sourceTree = "<group>"; };
+		FR_414155344076 /* PKPayment+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPayment+Stripe.h"; sourceTree = "<group>"; };
+		FR_414479750077 /* STPShippingMethodsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingMethodsViewController.m; sourceTree = "<group>"; };
+		FR_418726020237 /* PKPayment+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PKPayment+Stripe.m"; sourceTree = "<group>"; };
+		FR_419545860786 /* stp_card_discover_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover_template@2x.png"; sourceTree = "<group>"; };
+		FR_424062180158 /* PINOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperation.h; sourceTree = "<group>"; };
+		FR_426131539244 /* PINOperation-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINOperation-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_428291350140 /* UINavigationBar+Stripe_Theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+Stripe_Theme.h"; sourceTree = "<group>"; };
+		FR_428659206443 /* STPMultipartFormDataPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataPart.h; sourceTree = "<group>"; };
+		FR_429558583380 /* STPCoreTableViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreTableViewController.h; sourceTree = "<group>"; };
+		FR_430412408542 /* STPCardValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidator.h; sourceTree = "<group>"; };
+		FR_431351183220 /* SiriExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "SiriExtension-Info.plist"; sourceTree = "<group>"; };
+		FR_437241804723 /* STPSwitchTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSwitchTableViewCell.h; sourceTree = "<group>"; };
+		FR_439326957297 /* STPCustomer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomer.h; sourceTree = "<group>"; };
+		FR_439756482345 /* UIToolbar+Stripe_InputAccessory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIToolbar+Stripe_InputAccessory.h"; sourceTree = "<group>"; };
+		FR_442035849345 /* STPBankAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccountParams.h; sourceTree = "<group>"; };
+		FR_442182732790 /* stp_card_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_amex.png; sourceTree = "<group>"; };
+		FR_442378964830 /* UrlGetClasses-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "UrlGetClasses-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_443157579235 /* NSDecimalNumber+Stripe_Currency.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDecimalNumber+Stripe_Currency.h"; sourceTree = "<group>"; };
+		FR_443174613397 /* STPAddCardViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddCardViewController.h; sourceTree = "<group>"; };
+		FR_444167311156 /* UINavigationBar+Stripe_Theme.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UINavigationBar+Stripe_Theme.m"; sourceTree = "<group>"; };
+		FR_444421953328 /* libstrings-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libstrings-ext-bin.a"; sourceTree = "<group>"; };
+		FR_445616536231 /* StripeError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeError.h; sourceTree = "<group>"; };
+		FR_448226038197 /* STPBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBlocks.h; sourceTree = "<group>"; };
+		FR_448796637040 /* libios-ext-bin.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-ext-bin.a"; sourceTree = "<group>"; };
+		FR_453308441391 /* stp_card_discover_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_discover_template.png; sourceTree = "<group>"; };
+		FR_456888694968 /* STPPaymentActivityIndicatorView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentActivityIndicatorView.h; sourceTree = "<group>"; };
+		FR_457368245148 /* STPApplePayPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPApplePayPaymentMethod.h; sourceTree = "<group>"; };
+		FR_458195826767 /* NSDecimalNumber+Stripe_Currency.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDecimalNumber+Stripe_Currency.m"; sourceTree = "<group>"; };
+		FR_458705192052 /* STPPaymentContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentContext+Private.h"; sourceTree = "<group>"; };
+		FR_461151547306 /* STPDelegateProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDelegateProxy.h; sourceTree = "<group>"; };
+		FR_462669009401 /* STPPaymentContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContext.h; sourceTree = "<group>"; };
+		FR_462772464315 /* STPCoreScrollViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreScrollViewController.h; sourceTree = "<group>"; };
+		FR_463272392459 /* STPPaymentResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentResult.h; sourceTree = "<group>"; };
+		FR_463700594726 /* NSCharacterSet+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSCharacterSet+Stripe.m"; sourceTree = "<group>"; };
+		FR_465076796337 /* STPImageLibrary+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPImageLibrary+Private.h"; sourceTree = "<group>"; };
+		FR_472348897847 /* STPEphemeralKeyManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyManager.h; sourceTree = "<group>"; };
+		FR_473192119440 /* STPPhoneNumberValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPhoneNumberValidator.h; sourceTree = "<group>"; };
+		FR_473436317539 /* STPSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSource.h; sourceTree = "<group>"; };
+		FR_474344641046 /* STPAddCardViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAddCardViewController+Private.h"; sourceTree = "<group>"; };
+		FR_474849171272 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_475171097171 /* STPCoreTableViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreTableViewController+Private.h"; sourceTree = "<group>"; };
+		FR_475795149343 /* STPPaymentCardTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextField.h; sourceTree = "<group>"; };
+		FR_476535447008 /* STPApplePayPaymentMethod.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPApplePayPaymentMethod.m; sourceTree = "<group>"; };
+		FR_478769126414 /* STPShippingMethodsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodsViewController.h; sourceTree = "<group>"; };
+		FR_480264551522 /* STPDispatchFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDispatchFunctions.h; sourceTree = "<group>"; };
+		FR_480377833594 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_480570027159 /* STPColorUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPColorUtils.h; sourceTree = "<group>"; };
+		FR_483720092972 /* Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests.m; sourceTree = "<group>"; };
+		FR_484197994638 /* stp_card_error_amex.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_error_amex.png; sourceTree = "<group>"; };
+		FR_486050354264 /* STPSourcePoller.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourcePoller.h; sourceTree = "<group>"; };
+		FR_486189815482 /* UIViewController+Stripe_KeyboardAvoiding.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_KeyboardAvoiding.m"; sourceTree = "<group>"; };
+		FR_487939169679 /* STPEphemeralKeyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyProvider.h; sourceTree = "<group>"; };
+		FR_488043227274 /* STPBackendAPIAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBackendAPIAdapter.h; sourceTree = "<group>"; };
+		FR_488522868567 /* STPSourceParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceParams+Private.h"; sourceTree = "<group>"; };
+		FR_490180650504 /* HeaderLib-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "HeaderLib-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_491814232968 /* UINavigationController+Stripe_Completion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+Stripe_Completion.h"; sourceTree = "<group>"; };
+		FR_491855309750 /* NSDictionary+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+Stripe.h"; sourceTree = "<group>"; };
+		FR_492186305663 /* stp_test_upload_image.jpeg */ = {isa = PBXFileReference; path = stp_test_upload_image.jpeg; sourceTree = "<group>"; };
+		FR_493600713592 /* STPBINRange.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBINRange.m; sourceTree = "<group>"; };
+		FR_499069437964 /* NSString+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSString+Stripe.h"; sourceTree = "<group>"; };
+		FR_499112778551 /* STPImageLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPImageLibrary.h; sourceTree = "<group>"; };
+		FR_499185708877 /* PINOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperation.h; sourceTree = "<group>"; };
+		FR_500728372472 /* UrlGetClasses-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "UrlGetClasses-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_501557594644 /* PINMemoryCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINMemoryCache.h; sourceTree = "<group>"; };
+		FR_504407375548 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		FR_506673325060 /* NSBundle+Stripe_AppName.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSBundle+Stripe_AppName.m"; sourceTree = "<group>"; };
+		FR_508532188928 /* STPPaymentCardTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextField.h; sourceTree = "<group>"; };
+		FR_510153968201 /* STPSourceRedirect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceRedirect.h; sourceTree = "<group>"; };
+		FR_511504885436 /* STPStringUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPStringUtils.h; sourceTree = "<group>"; };
+		FR_511984329756 /* stp_card_error@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error@3x.png"; sourceTree = "<group>"; };
+		FR_514487626366 /* stp_card_jcb_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb_template@3x.png"; sourceTree = "<group>"; };
+		FR_516317479758 /* STPPaymentMethodsViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethodsViewController+Private.h"; sourceTree = "<group>"; };
+		FR_517473833142 /* NSMutableURLRequest+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Stripe.h"; sourceTree = "<group>"; };
+		FR_519641547204 /* NSError+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSError+Stripe.h"; sourceTree = "<group>"; };
+		FR_520761578796 /* STPEphemeralKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKey.h; sourceTree = "<group>"; };
+		FR_521258380702 /* ios-app-Bazel.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app-Bazel.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_521388462865 /* stp_card_unknown@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unknown@3x.png"; sourceTree = "<group>"; };
+		FR_521763319067 /* stp_card_error_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error_amex@2x.png"; sourceTree = "<group>"; };
+		FR_522861047398 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPaymentAuthorizationViewController+Stripe_Blocks.h"; sourceTree = "<group>"; };
+		FR_524961920525 /* libUrlGetClasses-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libUrlGetClasses-ios-9.0.a"; sourceTree = "<group>"; };
+		FR_525593892119 /* STPCoreViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreViewController+Private.h"; sourceTree = "<group>"; };
+		FR_526089843922 /* STPPaymentMethodsViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentMethodsViewController+Private.h"; sourceTree = "<group>"; };
+		FR_527807314452 /* STPSourceRedirect+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceRedirect+Private.h"; sourceTree = "<group>"; };
+		FR_529472279870 /* STPTelemetryClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTelemetryClient.h; sourceTree = "<group>"; };
+		FR_531466238338 /* NSCharacterSet+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSCharacterSet+Stripe.h"; sourceTree = "<group>"; };
+		FR_532052830250 /* STPToken.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPToken.h; sourceTree = "<group>"; };
+		FR_533629523548 /* STPToken.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPToken.m; sourceTree = "<group>"; };
+		FR_536395162937 /* Tests2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Tests2.m; sourceTree = "<group>"; };
+		FR_537691850882 /* STPSourceVerification.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceVerification.m; sourceTree = "<group>"; };
+		FR_538821595566 /* ios-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_540633154062 /* STPPaymentMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTableViewCell.h; sourceTree = "<group>"; };
+		FR_540897959944 /* UIViewController+Stripe_ParentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_ParentViewController.h"; sourceTree = "<group>"; };
+		FR_541854991234 /* STPAddress.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddress.m; sourceTree = "<group>"; };
+		FR_542871956439 /* STPPaymentMethodTuple.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTuple.m; sourceTree = "<group>"; };
+		FR_551244171870 /* Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Stripe.h; sourceTree = "<group>"; };
+		FR_552521354687 /* STPAPIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIClient.h; sourceTree = "<group>"; };
+		FR_554940461685 /* STPPromise.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPromise.h; sourceTree = "<group>"; };
+		FR_555298796716 /* STPPaymentMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodTableViewCell.h; sourceTree = "<group>"; };
+		FR_560470219857 /* PINDiskCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINDiskCache.h; sourceTree = "<group>"; };
+		FR_561293049977 /* PINCache-Core-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Core-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_571144748643 /* UIBarButtonItem+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIBarButtonItem+Stripe.m"; sourceTree = "<group>"; };
+		FR_572570595015 /* stp_icon_add@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_add@2x.png"; sourceTree = "<group>"; };
+		FR_575113983346 /* stp_card_unionpay_zh@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_zh@2x.png"; sourceTree = "<group>"; };
+		FR_575533640387 /* stp_card_applepay@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_applepay@2x.png"; sourceTree = "<group>"; };
+		FR_577170055431 /* STPMultipartFormDataEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataEncoder.h; sourceTree = "<group>"; };
+		FR_581486754320 /* STPCardValidationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidationState.h; sourceTree = "<group>"; };
+		FR_585192593384 /* GoogleSymbolUtilities.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleSymbolUtilities.framework; path = Vendor/GoogleSymbolUtilities/Frameworks/frameworks/GoogleSymbolUtilities.framework; sourceTree = "<group>"; };
+		FR_586728708045 /* STPPaymentMethodsInternalViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodsInternalViewController.m; sourceTree = "<group>"; };
+		FR_586858897267 /* STPAPIRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIRequest.h; sourceTree = "<group>"; };
+		FR_589053450594 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		FR_589269095208 /* STPCustomer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Private.h"; sourceTree = "<group>"; };
+		FR_590164391763 /* PINCacheObjectSubscripting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheObjectSubscripting.h; sourceTree = "<group>"; };
+		FR_592203597580 /* PINDiskCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINDiskCache.m; sourceTree = "<group>"; };
+		FR_594028262377 /* UITableViewCell+Stripe_Borders.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UITableViewCell+Stripe_Borders.m"; sourceTree = "<group>"; };
+		FR_597844010667 /* Some.cc */ = {isa = PBXFileReference; path = Some.cc; sourceTree = "<group>"; };
+		FR_601051940933 /* STPRedirectContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPRedirectContext.h; sourceTree = "<group>"; };
+		FR_602088298360 /* STPInternalAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPInternalAPIResponseDecodable.h; sourceTree = "<group>"; };
+		FR_603413644505 /* stp_card_visa_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa_template@3x.png"; sourceTree = "<group>"; };
+		FR_603748432416 /* StringsExtension-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "StringsExtension-Info.plist"; sourceTree = "<group>"; };
+		FR_604853984230 /* STPAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIResponseDecodable.h; sourceTree = "<group>"; };
+		FR_605275026753 /* STPLocalizationUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLocalizationUtils.h; sourceTree = "<group>"; };
+		FR_606016628554 /* PINDiskCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINDiskCache.h; sourceTree = "<group>"; };
+		FR_606702039249 /* STPPaymentResult.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentResult.h; sourceTree = "<group>"; };
+		FR_607013564544 /* STPPhoneNumberValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPhoneNumberValidator.m; sourceTree = "<group>"; };
+		FR_608836942526 /* STPTelemetryClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPTelemetryClient.m; sourceTree = "<group>"; };
+		FR_610462910989 /* STPAnalyticsClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAnalyticsClient.m; sourceTree = "<group>"; };
+		FR_611698887423 /* STPBankAccount.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBankAccount.h; sourceTree = "<group>"; };
+		FR_613129380815 /* stp_card_discover@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover@3x.png"; sourceTree = "<group>"; };
+		FR_615331454112 /* STPWeakStrongMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPWeakStrongMacros.h; sourceTree = "<group>"; };
+		FR_617004790111 /* strings-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "strings-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_617298386939 /* STPBINRange.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBINRange.h; sourceTree = "<group>"; };
+		FR_619129721469 /* NSDictionary+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+Stripe.m"; sourceTree = "<group>"; };
+		FR_619568838966 /* STPBundleLocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBundleLocator.h; sourceTree = "<group>"; };
+		FR_620106212103 /* STPFile.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFile.m; sourceTree = "<group>"; };
+		FR_620622155048 /* UIToolbar+Stripe_InputAccessory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIToolbar+Stripe_InputAccessory.h"; sourceTree = "<group>"; };
+		FR_621667375658 /* STPCustomer+SourceTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+SourceTuple.h"; sourceTree = "<group>"; };
+		FR_622346843396 /* stp_card_error@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_error@2x.png"; sourceTree = "<group>"; };
+		FR_626135400964 /* UIView+Stripe_SafeAreaBounds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIView+Stripe_SafeAreaBounds.h"; sourceTree = "<group>"; };
+		FR_627381929349 /* stp_card_diners@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_diners@2x.png"; sourceTree = "<group>"; };
+		FR_627448499289 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_628765823358 /* STPInternalAPIResponseDecodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPInternalAPIResponseDecodable.h; sourceTree = "<group>"; };
+		FR_628854353609 /* NSDictionary+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+Stripe.h"; sourceTree = "<group>"; };
+		FR_632648320726 /* empty-main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "empty-main.m"; sourceTree = "<group>"; };
+		FR_641447449553 /* STPCardIOProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCardIOProxy.m; sourceTree = "<group>"; };
+		FR_641806051736 /* STPSourceSEPADebitDetails.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceSEPADebitDetails.m; sourceTree = "<group>"; };
+		FR_643129213697 /* siri-ext-bin.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "siri-ext-bin.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_643601304366 /* STPAddCardViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddCardViewController.m; sourceTree = "<group>"; };
+		FR_644018226998 /* STPPaymentContextAmountModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContextAmountModel.h; sourceTree = "<group>"; };
+		FR_645419483261 /* NSMutableURLRequest+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSMutableURLRequest+Stripe.m"; sourceTree = "<group>"; };
+		FR_646448954976 /* STPImageLibrary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPImageLibrary.h; sourceTree = "<group>"; };
+		FR_646482828278 /* STPCoreScrollViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreScrollViewController.h; sourceTree = "<group>"; };
+		FR_648604114055 /* STPEphemeralKeyManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEphemeralKeyManager.m; sourceTree = "<group>"; };
+		FR_650327201175 /* stp_shipping_form.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_shipping_form.png; sourceTree = "<group>"; };
+		FR_653223178753 /* STPDispatchFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPDispatchFunctions.h; sourceTree = "<group>"; };
+		FR_654523445914 /* stp_card_discover_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_discover_template@3x.png"; sourceTree = "<group>"; };
+		FR_655065637744 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.plug-in"; path = "Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_655731362161 /* STPSourceCardDetails.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceCardDetails.h; sourceTree = "<group>"; };
+		FR_658088880964 /* STPSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSource.h; sourceTree = "<group>"; };
+		FR_658835132655 /* stp_card_jcb_template@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb_template@2x.png"; sourceTree = "<group>"; };
+		FR_660084857839 /* PINOperationQueue.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINOperationQueue.m; sourceTree = "<group>"; };
+		FR_665133782783 /* STPUserInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPUserInformation.h; sourceTree = "<group>"; };
+		FR_670858721125 /* stp_card_form_front@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_form_front@2x.png"; sourceTree = "<group>"; };
+		FR_671168073175 /* STPShippingAddressViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPShippingAddressViewController.m; sourceTree = "<group>"; };
+		FR_671356256024 /* STPShippingAddressViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingAddressViewController.h; sourceTree = "<group>"; };
+		FR_671973988729 /* UIToolbar+Stripe_InputAccessory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIToolbar+Stripe_InputAccessory.m"; sourceTree = "<group>"; };
+		FR_672272147268 /* STPFormEncodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncodable.h; sourceTree = "<group>"; };
+		FR_673456040385 /* PINOperationGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationGroup.h; sourceTree = "<group>"; };
+		FR_674683558842 /* STPAPIRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAPIRequest.m; sourceTree = "<group>"; };
+		FR_676936962722 /* STPMultipartFormDataPart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataPart.h; sourceTree = "<group>"; };
+		FR_677319161634 /* STPPaymentActivityIndicatorView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentActivityIndicatorView.m; sourceTree = "<group>"; };
+		FR_685465727036 /* STPAddressFieldTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPAddressFieldTableViewCell.m; sourceTree = "<group>"; };
+		FR_687756258433 /* STPPromise.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPromise.h; sourceTree = "<group>"; };
+		FR_688759072197 /* NSError+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSError+Stripe.m"; sourceTree = "<group>"; };
+		FR_690875243305 /* STPPaymentContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentContext.h; sourceTree = "<group>"; };
+		FR_692892454609 /* STPPaymentMethodTableViewCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentMethodTableViewCell.m; sourceTree = "<group>"; };
+		FR_693545976554 /* STPCustomer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCustomer+Private.h"; sourceTree = "<group>"; };
+		FR_693961626544 /* libPINCache-Arc-exception-safe-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Arc-exception-safe-ios-12.0.a"; sourceTree = "<group>"; };
+		FR_695264615504 /* PINOperationGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationGroup.h; sourceTree = "<group>"; };
+		FR_700015233991 /* STPPaymentCardTextFieldViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldViewModel.h; sourceTree = "<group>"; };
+		FR_702226405411 /* PINCacheObjectSubscripting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheObjectSubscripting.h; sourceTree = "<group>"; };
+		FR_708974059261 /* Stripe-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "Stripe-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_711215481061 /* stp_shipping_form@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_shipping_form@3x.png"; sourceTree = "<group>"; };
+		FR_711764376983 /* stp_shipping_form@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_shipping_form@2x.png"; sourceTree = "<group>"; };
+		FR_712193767199 /* stp_card_unknown@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unknown@2x.png"; sourceTree = "<group>"; };
+		FR_712558935001 /* STPCard+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCard+Private.h"; sourceTree = "<group>"; };
+		FR_714158383804 /* stp_icon_add.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_icon_add.png; sourceTree = "<group>"; };
+		FR_714439942917 /* STPConnectAccountParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPConnectAccountParams.h; sourceTree = "<group>"; };
+		FR_715092956653 /* Fabric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
+		FR_715803299424 /* STPSourceOwner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceOwner.h; sourceTree = "<group>"; };
+		FR_717035337333 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_717345258349 /* STPConnectAccountParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPConnectAccountParams.m; sourceTree = "<group>"; };
+		FR_719405050763 /* STPCoreViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCoreViewController.h; sourceTree = "<group>"; };
+		FR_721965906259 /* stp_card_unionpay_en@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_en@2x.png"; sourceTree = "<group>"; };
+		FR_722428560957 /* STPPaymentMethod.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethod.h; sourceTree = "<group>"; };
+		FR_724415273822 /* STPBundleLocator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBundleLocator.m; sourceTree = "<group>"; };
+		FR_725221541400 /* STPSourceRedirect+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceRedirect+Private.h"; sourceTree = "<group>"; };
+		FR_725419030615 /* stp_card_unionpay_zh.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_zh.png; sourceTree = "<group>"; };
+		FR_726258871684 /* STPSectionHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSectionHeaderView.h; sourceTree = "<group>"; };
+		FR_726301448942 /* UIBarButtonItem+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBarButtonItem+Stripe.h"; sourceTree = "<group>"; };
+		FR_728732702136 /* HeaderLib.hpp */ = {isa = PBXFileReference; path = HeaderLib.hpp; sourceTree = "<group>"; };
+		FR_729056130422 /* HeaderLib-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "HeaderLib-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_729823338412 /* stp_card_diners.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_diners.png; sourceTree = "<group>"; };
+		FR_730057302106 /* stp_card_unionpay_template_zh@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_zh@2x.png"; sourceTree = "<group>"; };
+		FR_733844630235 /* UIView+Stripe_SafeAreaBounds.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+Stripe_SafeAreaBounds.m"; sourceTree = "<group>"; };
+		FR_737326472839 /* STPCustomer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCustomer.m; sourceTree = "<group>"; };
+		FR_737402177737 /* STPCustomerContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCustomerContext.m; sourceTree = "<group>"; };
+		FR_738184609669 /* STPRedirectContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPRedirectContext.m; sourceTree = "<group>"; };
+		FR_738901483927 /* stp_card_applepay@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_applepay@3x.png"; sourceTree = "<group>"; };
+		FR_740665298049 /* UIViewController+Stripe_KeyboardAvoiding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_KeyboardAvoiding.h"; sourceTree = "<group>"; };
+		FR_742311769633 /* NSString+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSString+Stripe.m"; sourceTree = "<group>"; };
+		FR_742405757158 /* UIViewController+Stripe_Promises.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_Promises.h"; sourceTree = "<group>"; };
+		FR_744031881443 /* UIViewController+Stripe_ParentViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_ParentViewController.m"; sourceTree = "<group>"; };
+		FR_745814336160 /* UITableViewCell+Stripe_Borders.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UITableViewCell+Stripe_Borders.h"; sourceTree = "<group>"; };
+		FR_747618226391 /* UIViewController+Stripe_Promises.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+Stripe_Promises.m"; sourceTree = "<group>"; };
+		FR_748789438654 /* STPSourceReceiver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPSourceReceiver.m; sourceTree = "<group>"; };
+		FR_750681051983 /* STPAddressViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressViewModel.h; sourceTree = "<group>"; };
+		FR_751267158973 /* stp_card_visa@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_visa@2x.png"; sourceTree = "<group>"; };
+		FR_756148561161 /* NSArray+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSArray+Stripe.m"; sourceTree = "<group>"; };
+		FR_757308223899 /* Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Stripe.h; sourceTree = "<group>"; };
+		FR_758328319458 /* STPImageLibrary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPImageLibrary.m; sourceTree = "<group>"; };
+		FR_758823072707 /* STPPaymentCardTextFieldViewModel.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPPaymentCardTextFieldViewModel.m; sourceTree = "<group>"; };
+		FR_759500150446 /* stp_card_cvc_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_cvc_amex@3x.png"; sourceTree = "<group>"; };
+		FR_759813942983 /* stp_card_amex@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex@3x.png"; sourceTree = "<group>"; };
+		FR_761481658638 /* libUrlGetClasses-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libUrlGetClasses-ios-12.0.a"; sourceTree = "<group>"; };
+		FR_763988016072 /* STPShippingMethodTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPShippingMethodTableViewCell.h; sourceTree = "<group>"; };
+		FR_765731174060 /* PINCache-Arc-exception-safe-ios-12.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Arc-exception-safe-ios-12.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_767845194876 /* STPAspects.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAspects.h; sourceTree = "<group>"; };
+		FR_770853841763 /* STPEphemeralKeyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPEphemeralKeyProvider.h; sourceTree = "<group>"; };
+		FR_771482279297 /* STPAPIClient+ApplePay.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+ApplePay.h"; sourceTree = "<group>"; };
+		FR_772375839219 /* STPCardBrand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardBrand.h; sourceTree = "<group>"; };
+		FR_775707534446 /* libPINOperation-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINOperation-ios-12.0.a"; sourceTree = "<group>"; };
+		FR_776899178610 /* STPFormTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormTextField.h; sourceTree = "<group>"; };
+		FR_780541414116 /* STPAPIClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAPIClient.h; sourceTree = "<group>"; };
+		FR_783332722407 /* STPAPIClient+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAPIClient+Private.h"; sourceTree = "<group>"; };
+		FR_784002482892 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		FR_786390752320 /* STPPaymentConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentConfiguration.h; sourceTree = "<group>"; };
+		FR_786904937064 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Base; path = Base.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
+		FR_787080648262 /* STPCardValidationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidationState.h; sourceTree = "<group>"; };
+		FR_788344785540 /* STPAddCardViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPAddCardViewController+Private.h"; sourceTree = "<group>"; };
+		FR_788978376050 /* STPAddressFieldTableViewCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressFieldTableViewCell.h; sourceTree = "<group>"; };
+		FR_791443385444 /* PINMemoryCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINMemoryCache.m; sourceTree = "<group>"; };
+		FR_792226602984 /* STPMultipartFormDataEncoder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPMultipartFormDataEncoder.h; sourceTree = "<group>"; };
+		FR_794743392604 /* STPUserInformation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPUserInformation.h; sourceTree = "<group>"; };
+		FR_795014177049 /* STPSourceEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceEnums.h; sourceTree = "<group>"; };
+		FR_795258740755 /* PINOperationMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINOperationMacros.h; sourceTree = "<group>"; };
+		FR_795282443937 /* STPValidatedTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPValidatedTextField.h; sourceTree = "<group>"; };
+		FR_796389677736 /* STPDelegateProxy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPDelegateProxy.m; sourceTree = "<group>"; };
+		FR_798577433392 /* PINCacheMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheMacros.h; sourceTree = "<group>"; };
+		FR_799125542095 /* STPCoreViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreViewController+Private.h"; sourceTree = "<group>"; };
+		FR_800682286459 /* STPMultipartFormDataPart.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPMultipartFormDataPart.m; sourceTree = "<group>"; };
+		FR_801560513350 /* NSURLComponents+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLComponents+Stripe.h"; sourceTree = "<group>"; };
+		FR_802011361010 /* PINCacheMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCacheMacros.h; sourceTree = "<group>"; };
+		FR_802404793893 /* stp_card_jcb.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_jcb.png; sourceTree = "<group>"; };
+		FR_803217793216 /* stp_card_error.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_error.png; sourceTree = "<group>"; };
+		FR_803993631086 /* STPCategoryLoader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCategoryLoader.h; sourceTree = "<group>"; };
+		FR_804931815947 /* STPLocalizationUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPLocalizationUtils.m; sourceTree = "<group>"; };
+		FR_805282718192 /* STPPaymentConfiguration+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPPaymentConfiguration+Private.h"; sourceTree = "<group>"; };
+		FR_806162094116 /* STPFile.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFile.h; sourceTree = "<group>"; };
+		FR_806196035267 /* AppIntent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppIntent.m; sourceTree = "<group>"; };
+		FR_806941639685 /* UIViewController+Stripe_ParentViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_ParentViewController.h"; sourceTree = "<group>"; };
+		FR_807000054470 /* STPPhoneNumberValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPhoneNumberValidator.h; sourceTree = "<group>"; };
+		FR_812459734000 /* STPCardValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardValidator.h; sourceTree = "<group>"; };
+		FR_813387328933 /* PINCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINCache.h; sourceTree = "<group>"; };
+		FR_814035781224 /* STPAnalyticsClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAnalyticsClient.h; sourceTree = "<group>"; };
+		FR_816157806696 /* StripeError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeError.h; sourceTree = "<group>"; };
+		FR_817088716264 /* STPSourceProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceProtocol.h; sourceTree = "<group>"; };
+		FR_819003985091 /* stp_card_amex@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex@2x.png"; sourceTree = "<group>"; };
+		FR_822311040905 /* libStripe-ios-12.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libStripe-ios-12.0.a"; sourceTree = "<group>"; };
+		FR_822622224200 /* UrlGetViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UrlGetViewController.m; sourceTree = "<group>"; };
+		FR_823291178367 /* STPSourceRedirect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceRedirect.h; sourceTree = "<group>"; };
+		FR_826786322062 /* stp_card_visa_template.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_visa_template.png; sourceTree = "<group>"; };
+		FR_828673204570 /* STPCoreScrollViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreScrollViewController+Private.h"; sourceTree = "<group>"; };
+		FR_830275844486 /* PINCache.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINCache.m; sourceTree = "<group>"; };
+		FR_839146335427 /* PKPayment+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PKPayment+Stripe.h"; sourceTree = "<group>"; };
+		FR_842462552754 /* UINavigationController+Stripe_Completion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationController+Stripe_Completion.h"; sourceTree = "<group>"; };
+		FR_842477165671 /* STPSourceParams.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceParams.h; sourceTree = "<group>"; };
+		FR_843164853455 /* UIViewController+Stripe_NavigationItemProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_NavigationItemProxy.h"; sourceTree = "<group>"; };
+		FR_843603205312 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		FR_845546175975 /* stp_card_jcb@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb@3x.png"; sourceTree = "<group>"; };
+		FR_847516745795 /* PINOperationGroup.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINOperationGroup.m; sourceTree = "<group>"; };
+		FR_847721840679 /* STPLocalizationUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPLocalizationUtils.h; sourceTree = "<group>"; };
+		FR_849113673423 /* STPSourceVerification+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPSourceVerification+Private.h"; sourceTree = "<group>"; };
+		FR_850087254357 /* stp_card_jcb@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_jcb@2x.png"; sourceTree = "<group>"; };
+		FR_850772742307 /* AppJerry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppJerry.m; sourceTree = "<group>"; };
+		FR_850832029853 /* stp_card_unionpay_template_en@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_en@2x.png"; sourceTree = "<group>"; };
+		FR_852796935086 /* PINCache-Arc-exception-safe-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Arc-exception-safe-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_853994749600 /* stp_icon_add@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_icon_add@3x.png"; sourceTree = "<group>"; };
+		FR_854164364230 /* STPAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddress.h; sourceTree = "<group>"; };
+		FR_855525910280 /* libPINCache-Arc-exception-safe-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINCache-Arc-exception-safe-ios-9.0.a"; sourceTree = "<group>"; };
+		FR_855793908054 /* STPAspects.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAspects.h; sourceTree = "<group>"; };
+		FR_857085055871 /* stp_card_unionpay_template_zh@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_unionpay_template_zh@3x.png"; sourceTree = "<group>"; };
+		FR_859627797282 /* NSDecimalNumber+Stripe_Currency.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDecimalNumber+Stripe_Currency.h"; sourceTree = "<group>"; };
+		FR_871667522712 /* STPFormEncodable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormEncodable.h; sourceTree = "<group>"; };
+		FR_871811812819 /* stp_card_mastercard@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_mastercard@3x.png"; sourceTree = "<group>"; };
+		FR_871945793837 /* STPPaymentCardTextFieldCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentCardTextFieldCell.h; sourceTree = "<group>"; };
+		FR_872390854429 /* UINavigationBar+Stripe_Theme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UINavigationBar+Stripe_Theme.h"; sourceTree = "<group>"; };
+		FR_873994371050 /* Analyzer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Analyzer.xcconfig; sourceTree = "<group>"; };
+		FR_874071751772 /* cs */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = cs; path = cs.lproj/AppIntentVocabulary.plist; sourceTree = "<group>"; };
+		FR_875062748093 /* stp_card_form_front.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_form_front.png; sourceTree = "<group>"; };
+		FR_875775578448 /* STPPostalCodeValidator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPostalCodeValidator.h; sourceTree = "<group>"; };
+		FR_875786652607 /* STPCard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCard.h; sourceTree = "<group>"; };
+		FR_876293920603 /* NSMutableURLRequest+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+Stripe.h"; sourceTree = "<group>"; };
+		FR_877183059027 /* STPAddress.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddress.h; sourceTree = "<group>"; };
+		FR_877692020624 /* STPBankAccount.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPBankAccount.m; sourceTree = "<group>"; };
+		FR_883395499833 /* Fabric+FABKits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fabric+FABKits.h"; sourceTree = "<group>"; };
+		FR_884510017797 /* STPCard.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPCard.m; sourceTree = "<group>"; };
+		FR_888354852550 /* stp_card_amex_template@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "stp_card_amex_template@3x.png"; sourceTree = "<group>"; };
+		FR_888513362157 /* AppJerry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppJerry.h; sourceTree = "<group>"; };
+		FR_889380289586 /* STPPaymentConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentConfiguration.h; sourceTree = "<group>"; };
+		FR_891271893429 /* share-extension-Bazel.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = "share-extension-Bazel.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_891436639477 /* STPEmailAddressValidator.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPEmailAddressValidator.m; sourceTree = "<group>"; };
+		FR_891766987304 /* STPBlocks.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPBlocks.h; sourceTree = "<group>"; };
+		FR_893676537074 /* UIImage+Stripe.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIImage+Stripe.m"; sourceTree = "<group>"; };
+		FR_894319557924 /* NSURLComponents+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSURLComponents+Stripe.h"; sourceTree = "<group>"; };
+		FR_895059102994 /* STPAddressViewModel.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPAddressViewModel.h; sourceTree = "<group>"; };
+		FR_895687763669 /* UIBarButtonItem+Stripe.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIBarButtonItem+Stripe.h"; sourceTree = "<group>"; };
+		FR_896024321091 /* PINCache-Core-ios-9.0.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "PINCache-Core-ios-9.0.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_896160604721 /* UIViewController+Stripe_Promises.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+Stripe_Promises.h"; sourceTree = "<group>"; };
+		FR_897018280740 /* STPSourceEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSourceEnums.h; sourceTree = "<group>"; };
+		FR_898478279498 /* STPFormEncoder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPFormEncoder.m; sourceTree = "<group>"; };
+		FR_899762404898 /* stp_icon_checkmark.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_icon_checkmark.png; sourceTree = "<group>"; };
+		FR_901703376767 /* STPCustomer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCustomer.h; sourceTree = "<group>"; };
+		FR_903389206028 /* stp_card_unionpay_en.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = stp_card_unionpay_en.png; sourceTree = "<group>"; };
+		FR_903485295144 /* libPINOperation-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libPINOperation-ios-9.0.a"; sourceTree = "<group>"; };
+		FR_905457408802 /* STPSectionHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPSectionHeaderView.h; sourceTree = "<group>"; };
+		FR_905481250877 /* STPCardBrand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardBrand.h; sourceTree = "<group>"; };
+		FR_907005147347 /* siri-extension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = "siri-extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_907909434975 /* STPCardIOProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCardIOProxy.h; sourceTree = "<group>"; };
+		FR_911104891096 /* STPFormTextField.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPFormTextField.h; sourceTree = "<group>"; };
+		FR_912153776991 /* STPCoreScrollViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPCoreScrollViewController+Private.h"; sourceTree = "<group>"; };
+		FR_915031944710 /* STPTheme.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTheme.h; sourceTree = "<group>"; };
+		FR_916780536843 /* STPLegalEntityParams.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPLegalEntityParams.m; sourceTree = "<group>"; };
+		FR_919339625812 /* AppIntent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppIntent.h; sourceTree = "<group>"; };
+		FR_920507342830 /* STPTelemetryClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPTelemetryClient.h; sourceTree = "<group>"; };
+		FR_920585382813 /* STPURLCallbackHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPURLCallbackHandler.m; sourceTree = "<group>"; };
+		FR_920605117287 /* STPColorUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = STPColorUtils.m; sourceTree = "<group>"; };
+		FR_921685205996 /* STPCard.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPCard.h; sourceTree = "<group>"; };
+		FR_921726608824 /* STPPaymentMethodsInternalViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPPaymentMethodsInternalViewController.h; sourceTree = "<group>"; };
+		FR_930348723303 /* STPBankAccountParams+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "STPBankAccountParams+Private.h"; sourceTree = "<group>"; };
+		FR_970407844810 /* STPWeakStrongMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = STPWeakStrongMacros.h; sourceTree = "<group>"; };
+		FR_983905050479 /* libStripe-ios-9.0.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libStripe-ios-9.0.a"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		FBP_10145247170 /* Frameworks */ = {
+		FBP_13224825308 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_325955960758 /* GoogleNetworkingUtilities.framework in Frameworks */,
-				BF_352399059718 /* GoogleSymbolUtilities.framework in Frameworks */,
-				BF_359742756737 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
-				BF_364513652865 /* GoogleAuthUtilities.framework in Frameworks */,
-				BF_816549455071 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
-				BF_214935354420 /* libPINOperation-ios-9.0.a in Frameworks */,
-				BF_525907241504 /* GoogleAppIndexing.framework in Frameworks */,
-				BF_184316768586 /* libStripe-ios-9.0.a in Frameworks */,
-				BF_466785343628 /* libPINCache-Core-ios-9.0.a in Frameworks */,
+				BF_469038964441 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
+				BF_108610441744 /* GoogleAppIndexing.framework in Frameworks */,
+				BF_805966118789 /* GoogleSymbolUtilities.framework in Frameworks */,
+				BF_643520686279 /* libPINCache-Core-ios-9.0.a in Frameworks */,
+				BF_476314191379 /* libStripe-ios-9.0.a in Frameworks */,
+				BF_307155949021 /* libPINOperation-ios-9.0.a in Frameworks */,
+				BF_359469183277 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
+				BF_735490463247 /* GoogleNetworkingUtilities.framework in Frameworks */,
+				BF_436498784082 /* GoogleAuthUtilities.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_21047886488 /* Frameworks */ = {
+		FBP_14093147444 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_671920274269 /* libUrlGetClasses-ios-12.0.a in Frameworks */,
-				BF_744238514087 /* libios-app-bin-ios-12.0.a in Frameworks */,
-				BF_255304234772 /* GoogleSymbolUtilities.framework in Frameworks */,
-				BF_744545583275 /* libPINOperation-ios-12.0.a in Frameworks */,
-				BF_348067796375 /* GoogleNetworkingUtilities.framework in Frameworks */,
-				BF_444417618277 /* libStripe-ios-12.0.a in Frameworks */,
-				BF_633851398856 /* GoogleAuthUtilities.framework in Frameworks */,
-				BF_130827952654 /* libPINCache-Arc-exception-safe-ios-12.0.a in Frameworks */,
-				BF_334827842514 /* GoogleAppIndexing.framework in Frameworks */,
-				BF_245416482780 /* libPINCache-Core-ios-12.0.a in Frameworks */,
+				BF_697995507556 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
+				BF_899491127373 /* GoogleAppIndexing.framework in Frameworks */,
+				BF_440319957567 /* GoogleSymbolUtilities.framework in Frameworks */,
+				BF_642433567139 /* libPINCache-Core-ios-9.0.a in Frameworks */,
+				BF_155219890949 /* libStripe-ios-9.0.a in Frameworks */,
+				BF_916584786395 /* libPINOperation-ios-9.0.a in Frameworks */,
+				BF_792006449576 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
+				BF_865856056016 /* GoogleNetworkingUtilities.framework in Frameworks */,
+				BF_563065676105 /* GoogleAuthUtilities.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_36395135131 /* Frameworks */ = {
+		FBP_20740845888 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_215931264842 /* GoogleNetworkingUtilities.framework in Frameworks */,
-				BF_906623330959 /* GoogleSymbolUtilities.framework in Frameworks */,
-				BF_690477533380 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
-				BF_233545122777 /* GoogleAuthUtilities.framework in Frameworks */,
-				BF_130413526576 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
-				BF_320109163276 /* libPINOperation-ios-9.0.a in Frameworks */,
-				BF_230723261129 /* GoogleAppIndexing.framework in Frameworks */,
-				BF_641275083979 /* libStripe-ios-9.0.a in Frameworks */,
-				BF_210852987118 /* libPINCache-Core-ios-9.0.a in Frameworks */,
+				BF_231774139577 /* libstrings-ext-bin.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_40652102921 /* Frameworks */ = {
+		FBP_33959086389 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_567470263986 /* libios-ext-bin.a in Frameworks */,
+				BF_469844427557 /* libios-ext-bin.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_40950323780 /* Frameworks */ = {
+		FBP_39379078374 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_179566918738 /* libstrings-ext-bin.a in Frameworks */,
+				BF_285772620346 /* libPINCache-Arc-exception-safe-ios-12.0.a in Frameworks */,
+				BF_340837542068 /* GoogleAppIndexing.framework in Frameworks */,
+				BF_199117639807 /* libios-app-bin-ios-12.0.a in Frameworks */,
+				BF_634761092432 /* GoogleNetworkingUtilities.framework in Frameworks */,
+				BF_700087754499 /* libStripe-ios-12.0.a in Frameworks */,
+				BF_249067817230 /* libUrlGetClasses-ios-12.0.a in Frameworks */,
+				BF_674246997961 /* GoogleSymbolUtilities.framework in Frameworks */,
+				BF_204056941971 /* libPINCache-Core-ios-12.0.a in Frameworks */,
+				BF_710512128781 /* libPINOperation-ios-12.0.a in Frameworks */,
+				BF_860523227170 /* GoogleAuthUtilities.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_60605076682 /* Frameworks */ = {
+		FBP_41357132792 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_305480418362 /* GoogleNetworkingUtilities.framework in Frameworks */,
-				BF_671407416528 /* GoogleSymbolUtilities.framework in Frameworks */,
-				BF_504283189498 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
-				BF_375327645367 /* GoogleAuthUtilities.framework in Frameworks */,
-				BF_305993522699 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
-				BF_366983124095 /* libPINOperation-ios-9.0.a in Frameworks */,
-				BF_161039779458 /* GoogleAppIndexing.framework in Frameworks */,
-				BF_668070357035 /* libStripe-ios-9.0.a in Frameworks */,
-				BF_829125851855 /* libPINCache-Core-ios-9.0.a in Frameworks */,
+				BF_742743427862 /* libUrlGetClasses-ios-9.0.a in Frameworks */,
+				BF_187006970888 /* GoogleAppIndexing.framework in Frameworks */,
+				BF_462762841132 /* GoogleSymbolUtilities.framework in Frameworks */,
+				BF_575004115082 /* libPINCache-Core-ios-9.0.a in Frameworks */,
+				BF_449813988220 /* libStripe-ios-9.0.a in Frameworks */,
+				BF_620710219927 /* libPINOperation-ios-9.0.a in Frameworks */,
+				BF_563679749270 /* libPINCache-Arc-exception-safe-ios-9.0.a in Frameworks */,
+				BF_131339518258 /* GoogleNetworkingUtilities.framework in Frameworks */,
+				BF_200319378214 /* GoogleAuthUtilities.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		FBP_95496141142 /* Frameworks */ = {
+		FBP_90700514734 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_922087774493 /* libsiri-ext-bin.a in Frameworks */,
+				BF_220255122560 /* libsiri-ext-bin.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		G_1008629500772 /* Resources */ = {
+		G_1709659587767 /* Localization */ = {
 			isa = PBXGroup;
 			children = (
-				FR_111466561084 /* StringsExtension-Info.plist */,
-				G_6408243056626 /* Localization */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		G_1132853363307 /* HeaderLib */ = {
-			isa = PBXGroup;
-			children = (
-				FR_550956318664 /* HeaderLib.hpp */,
-			);
-			path = HeaderLib;
-			sourceTree = "<group>";
-		};
-		G_1181679691437 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				FR_576766155188 /* AppIntent.h */,
-				FR_211196868537 /* AppIntent.m */,
-			);
-			path = Sources;
-			sourceTree = "<group>";
-		};
-		G_1190614392986 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				FR_903524758896 /* HeaderLib-ios-9.0.a */,
-				FR_629548608649 /* HeaderLib-ios-12.0.a */,
-				FR_455050505758 /* ios-app-Bazel.app */,
-				FR_273923590342 /* ios-app-bin-ios-12.0-Bazel.a */,
-				FR_854342266175 /* ios-app-bin-ios-12.0.a */,
-				FR_210478864884 /* ios-app.app */,
-				FR_114615400230 /* ios-ext-bin.a */,
-				FR_645411521541 /* PINCache-Arc-exception-safe-ios-9.0.a */,
-				FR_515456468255 /* PINCache-Arc-exception-safe-ios-12.0.a */,
-				FR_826359326254 /* PINCache-Core-ios-9.0.a */,
-				FR_446505840808 /* PINCache-Core-ios-12.0.a */,
-				FR_135115533237 /* PINOperation-ios-9.0.a */,
-				FR_888995822461 /* PINOperation-ios-12.0.a */,
-				FR_856017749152 /* share-extension-Bazel.appex */,
-				FR_406521029219 /* share-extension.appex */,
-				FR_682252300927 /* siri-ext-bin.a */,
-				FR_954961411422 /* siri-extension.appex */,
-				FR_420127068589 /* strings-ext-bin.a */,
-				FR_409503237802 /* strings-extension.appex */,
-				FR_404433001070 /* Stripe-ios-9.0.a */,
-				FR_623276489142 /* Stripe-ios-12.0.a */,
-				FR_722755400736 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */,
-				FR_540659108168 /* Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle */,
-				FR_101452471709 /* UITests.xctest */,
-				FR_606050766824 /* UnitTests.xctest */,
-				FR_363951351315 /* UnitTestsWithHost.xctest */,
-				FR_542815357791 /* UrlGetClasses-ios-9.0.a */,
-				FR_848652416968 /* UrlGetClasses-ios-12.0.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		G_1317992041714 /* UnitTests */ = {
-			isa = PBXGroup;
-			children = (
-				FR_515610011898 /* Tests.m */,
-				FR_366960336468 /* Tests2.m */,
-			);
-			path = UnitTests;
-			sourceTree = "<group>";
-		};
-		G_1353143497566 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				FR_826804962981 /* GoogleAppIndexingResources.bundle */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		G_1607218128998 /* Public */ = {
-			isa = PBXGroup;
-			children = (
-				G_3509668622477 /* PINCache */,
-			);
-			path = Public;
-			sourceTree = "<group>";
-		};
-		G_1706547191179 /* PINOperation */ = {
-			isa = PBXGroup;
-			children = (
-				G_2405186093743 /* pod_support */,
-				G_5212418710483 /* Source */,
-			);
-			path = PINOperation;
-			sourceTree = "<group>";
-		};
-		G_1737247195532 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				FR_188215767539 /* SiriExtension-Info.plist */,
-				G_1977934892383 /* Localization */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		G_1977934892383 /* Localization */ = {
-			isa = PBXGroup;
-			children = (
-				VG_114608902985 /* AppIntentVocabulary.plist */,
+				VG_843603205312 /* InfoPlist.strings */,
 			);
 			path = Localization;
 			sourceTree = "<group>";
 		};
-		G_2104788648841 /* ios-app */ = {
+		G_1729959325787 /* pod_support */ = {
 			isa = PBXGroup;
 			children = (
-				FR_823746509568 /* Diags.xcconfig */,
-				FR_362912493533 /* empty-main.m */,
-				G_1132853363307 /* HeaderLib */,
-				G_7884178875015 /* ShareExtension */,
-				G_3212778500724 /* SiriExtension */,
-				G_3052382352411 /* StringsExtension */,
-				G_1317992041714 /* UnitTests */,
-				G_7758867582615 /* UrlGet */,
-			);
-			path = "ios-app";
-			sourceTree = "<group>";
-		};
-		G_2125117200830 /* Stripe */ = {
-			isa = PBXGroup;
-			children = (
-				FR_790956405061 /* FABKitProtocol.h */,
-				FR_155181785535 /* Fabric.h */,
-				FR_825630796487 /* Fabric+FABKits.h */,
-				FR_321188290181 /* NSArray+Stripe.h */,
-				FR_760953752264 /* NSArray+Stripe.m */,
-				FR_248353099271 /* NSBundle+Stripe_AppName.h */,
-				FR_268644933511 /* NSBundle+Stripe_AppName.m */,
-				FR_797237603389 /* NSCharacterSet+Stripe.h */,
-				FR_160616828485 /* NSCharacterSet+Stripe.m */,
-				FR_568706760541 /* NSDecimalNumber+Stripe_Currency.h */,
-				FR_133536345426 /* NSDecimalNumber+Stripe_Currency.m */,
-				FR_581443142118 /* NSDictionary+Stripe.h */,
-				FR_298510265968 /* NSDictionary+Stripe.m */,
-				FR_491941513565 /* NSError+Stripe.h */,
-				FR_444626220675 /* NSError+Stripe.m */,
-				FR_292374537681 /* NSMutableURLRequest+Stripe.h */,
-				FR_900155382855 /* NSMutableURLRequest+Stripe.m */,
-				FR_917066196830 /* NSString+Stripe.h */,
-				FR_129103540819 /* NSString+Stripe.m */,
-				FR_799056671175 /* NSURLComponents+Stripe.h */,
-				FR_921549316179 /* NSURLComponents+Stripe.m */,
-				FR_826920421366 /* PKPayment+Stripe.h */,
-				FR_536507582456 /* PKPayment+Stripe.m */,
-				FR_654701584642 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */,
-				FR_394251211369 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */,
-				FR_768451756079 /* STPAddCardViewController.m */,
-				FR_385908145032 /* STPAddCardViewController+Private.h */,
-				FR_714589191537 /* STPAddress.m */,
-				FR_103772008651 /* STPAddressFieldTableViewCell.h */,
-				FR_374760221277 /* STPAddressFieldTableViewCell.m */,
-				FR_611426224449 /* STPAddressViewModel.h */,
-				FR_923168362961 /* STPAddressViewModel.m */,
-				FR_594100986418 /* STPAnalyticsClient.h */,
-				FR_212125637458 /* STPAnalyticsClient.m */,
-				FR_902210249661 /* STPAPIClient.m */,
-				FR_466487462811 /* STPAPIClient+ApplePay.m */,
-				FR_762256666880 /* STPAPIClient+Private.h */,
-				FR_821927058828 /* STPAPIRequest.h */,
-				FR_580663685603 /* STPAPIRequest.m */,
-				FR_949688277225 /* STPApplePayPaymentMethod.m */,
-				FR_140034954402 /* STPAspects.h */,
-				FR_143462498570 /* STPAspects.m */,
-				FR_571217998206 /* STPBankAccount.m */,
-				FR_423034687929 /* STPBankAccountParams.m */,
-				FR_883882644277 /* STPBankAccountParams+Private.h */,
-				FR_325796315490 /* STPBINRange.h */,
-				FR_701536383989 /* STPBINRange.m */,
-				FR_137141565957 /* STPBundleLocator.h */,
-				FR_504790352271 /* STPBundleLocator.m */,
-				FR_286261044399 /* STPCard.m */,
-				FR_188574106381 /* STPCard+Private.h */,
-				FR_814450748520 /* STPCardIOProxy.h */,
-				FR_684842129661 /* STPCardIOProxy.m */,
-				FR_795132420225 /* STPCardParams.m */,
-				FR_698865802314 /* STPCardValidator.m */,
-				FR_232130472703 /* STPCategoryLoader.h */,
-				FR_535352815691 /* STPCategoryLoader.m */,
-				FR_827303504770 /* STPColorUtils.h */,
-				FR_885437122687 /* STPColorUtils.m */,
-				FR_401594702906 /* STPConnectAccountParams.m */,
-				FR_295195067470 /* STPCoreScrollViewController.m */,
-				FR_346342066788 /* STPCoreScrollViewController+Private.h */,
-				FR_149930208538 /* STPCoreTableViewController.m */,
-				FR_786752301895 /* STPCoreTableViewController+Private.h */,
-				FR_360479079920 /* STPCoreViewController.m */,
-				FR_279590091072 /* STPCoreViewController+Private.h */,
-				FR_877683079452 /* STPCustomer.m */,
-				FR_328355623393 /* STPCustomer+Private.h */,
-				FR_688517925663 /* STPCustomer+SourceTuple.h */,
-				FR_670075701234 /* STPCustomer+SourceTuple.m */,
-				FR_588629070354 /* STPCustomerContext.m */,
-				FR_414892880882 /* STPDelegateProxy.h */,
-				FR_685562832071 /* STPDelegateProxy.m */,
-				FR_209688800430 /* STPDispatchFunctions.h */,
-				FR_562402903136 /* STPDispatchFunctions.m */,
-				FR_629149074297 /* STPEmailAddressValidator.h */,
-				FR_571164217949 /* STPEmailAddressValidator.m */,
-				FR_736955945348 /* STPEphemeralKey.h */,
-				FR_472902154735 /* STPEphemeralKey.m */,
-				FR_957602751546 /* STPEphemeralKeyManager.h */,
-				FR_259766013406 /* STPEphemeralKeyManager.m */,
-				FR_140591238195 /* STPFile.m */,
-				FR_833832260348 /* STPFile+Private.h */,
-				FR_418981300576 /* STPFormEncoder.h */,
-				FR_667620021817 /* STPFormEncoder.m */,
-				FR_181527925903 /* STPFormTextField.h */,
-				FR_882491438659 /* STPFormTextField.m */,
-				FR_132874026439 /* STPImageLibrary.m */,
-				FR_528265777249 /* STPImageLibrary+Private.h */,
-				FR_428784919258 /* STPInternalAPIResponseDecodable.h */,
-				FR_160651095057 /* STPLegalEntityParams.m */,
-				FR_459280268679 /* STPLocalizationUtils.h */,
-				FR_246324868641 /* STPLocalizationUtils.m */,
-				FR_132341323032 /* STPMultipartFormDataEncoder.h */,
-				FR_268528132629 /* STPMultipartFormDataEncoder.m */,
-				FR_159505340326 /* STPMultipartFormDataPart.h */,
-				FR_442086127483 /* STPMultipartFormDataPart.m */,
-				FR_333624610927 /* STPPaymentActivityIndicatorView.m */,
-				FR_395459264864 /* STPPaymentCardTextField.m */,
-				FR_818505862395 /* STPPaymentCardTextField+Private.h */,
-				FR_748370301216 /* STPPaymentCardTextFieldCell.h */,
-				FR_646329714542 /* STPPaymentCardTextFieldCell.m */,
-				FR_482859520448 /* STPPaymentCardTextFieldViewModel.h */,
-				FR_301311350687 /* STPPaymentCardTextFieldViewModel.m */,
-				FR_665937321012 /* STPPaymentConfiguration.m */,
-				FR_123818210598 /* STPPaymentConfiguration+Private.h */,
-				FR_459740821355 /* STPPaymentContext.m */,
-				FR_318744245772 /* STPPaymentContext+Private.h */,
-				FR_322129515820 /* STPPaymentContextAmountModel.h */,
-				FR_887912048029 /* STPPaymentContextAmountModel.m */,
-				FR_561613473899 /* STPPaymentMethodsInternalViewController.h */,
-				FR_299182598435 /* STPPaymentMethodsInternalViewController.m */,
-				FR_244801847772 /* STPPaymentMethodsViewController.m */,
-				FR_849271034348 /* STPPaymentMethodsViewController+Private.h */,
-				FR_339403818705 /* STPPaymentMethodTableViewCell.h */,
-				FR_485722511970 /* STPPaymentMethodTableViewCell.m */,
-				FR_514428095081 /* STPPaymentMethodTuple.h */,
-				FR_358026470844 /* STPPaymentMethodTuple.m */,
-				FR_582914940802 /* STPPaymentResult.m */,
-				FR_802354542601 /* STPPhoneNumberValidator.h */,
-				FR_209621477518 /* STPPhoneNumberValidator.m */,
-				FR_406546668048 /* STPPostalCodeValidator.h */,
-				FR_732694155215 /* STPPostalCodeValidator.m */,
-				FR_243703993641 /* STPPromise.h */,
-				FR_331287642191 /* STPPromise.m */,
-				FR_289929860900 /* STPRedirectContext.m */,
-				FR_574090485879 /* STPSectionHeaderView.h */,
-				FR_474020775691 /* STPSectionHeaderView.m */,
-				FR_919742180124 /* STPShippingAddressViewController.m */,
-				FR_433492106586 /* STPShippingMethodsViewController.h */,
-				FR_292133108427 /* STPShippingMethodsViewController.m */,
-				FR_330612961242 /* STPShippingMethodTableViewCell.h */,
-				FR_574931413907 /* STPShippingMethodTableViewCell.m */,
-				FR_840677560290 /* STPSource.m */,
-				FR_740669461234 /* STPSource+Private.h */,
-				FR_264105247925 /* STPSourceCardDetails.m */,
-				FR_485682691696 /* STPSourceCardDetails+Private.h */,
-				FR_821560233640 /* STPSourceOwner.m */,
-				FR_635722256605 /* STPSourceParams.m */,
-				FR_288982143251 /* STPSourceParams+Private.h */,
-				FR_789614747984 /* STPSourcePoller.h */,
-				FR_288321554063 /* STPSourcePoller.m */,
-				FR_391523138388 /* STPSourceReceiver.m */,
-				FR_425904257008 /* STPSourceRedirect.m */,
-				FR_724373808324 /* STPSourceRedirect+Private.h */,
-				FR_410374790759 /* STPSourceSEPADebitDetails.m */,
-				FR_533049156564 /* STPSourceVerification.m */,
-				FR_355184773089 /* STPSourceVerification+Private.h */,
-				FR_599349326557 /* STPStringUtils.h */,
-				FR_181204666019 /* STPStringUtils.m */,
-				FR_545341058950 /* STPSwitchTableViewCell.h */,
-				FR_707702346637 /* STPSwitchTableViewCell.m */,
-				FR_657939000329 /* STPTelemetryClient.h */,
-				FR_401389674811 /* STPTelemetryClient.m */,
-				FR_792160814884 /* STPTheme.m */,
-				FR_821099591187 /* STPToken.m */,
-				FR_815939899847 /* STPURLCallbackHandler.h */,
-				FR_405349128011 /* STPURLCallbackHandler.m */,
-				FR_378986667073 /* STPUserInformation.m */,
-				FR_707855371868 /* STPValidatedTextField.h */,
-				FR_281509917340 /* STPValidatedTextField.m */,
-				FR_313941452068 /* STPWeakStrongMacros.h */,
-				FR_682270288359 /* StripeError.m */,
-				FR_151991304951 /* UIBarButtonItem+Stripe.h */,
-				FR_416373643255 /* UIBarButtonItem+Stripe.m */,
-				FR_599387940932 /* UIImage+Stripe.h */,
-				FR_525895464802 /* UIImage+Stripe.m */,
-				FR_795417469207 /* UINavigationBar+Stripe_Theme.m */,
-				FR_706287541467 /* UINavigationController+Stripe_Completion.h */,
-				FR_725982103443 /* UINavigationController+Stripe_Completion.m */,
-				FR_834529548017 /* UITableViewCell+Stripe_Borders.h */,
-				FR_108265599351 /* UITableViewCell+Stripe_Borders.m */,
-				FR_848089631548 /* UIToolbar+Stripe_InputAccessory.h */,
-				FR_652869617708 /* UIToolbar+Stripe_InputAccessory.m */,
-				FR_543689780104 /* UIView+Stripe_FirstResponder.h */,
-				FR_831704377129 /* UIView+Stripe_FirstResponder.m */,
-				FR_388049849250 /* UIView+Stripe_SafeAreaBounds.h */,
-				FR_214657321101 /* UIView+Stripe_SafeAreaBounds.m */,
-				FR_820412954877 /* UIViewController+Stripe_KeyboardAvoiding.h */,
-				FR_832155225473 /* UIViewController+Stripe_KeyboardAvoiding.m */,
-				FR_186625950046 /* UIViewController+Stripe_NavigationItemProxy.h */,
-				FR_812073861033 /* UIViewController+Stripe_NavigationItemProxy.m */,
-				FR_251322316326 /* UIViewController+Stripe_ParentViewController.h */,
-				FR_430541868205 /* UIViewController+Stripe_ParentViewController.m */,
-				FR_559018671517 /* UIViewController+Stripe_Promises.h */,
-				FR_499853310274 /* UIViewController+Stripe_Promises.m */,
-				G_5479743953642 /* PublicHeaders */,
-				G_4376436462613 /* Resources */,
-			);
-			path = Stripe;
-			sourceTree = "<group>";
-		};
-		G_2363395555826 /* UrlGet.xcodeproj */ = {
-			isa = PBXGroup;
-			children = (
-				G_6533566337535 /* XCHammerAssets */,
-			);
-			path = UrlGet.xcodeproj;
-			sourceTree = "<group>";
-		};
-		G_2405186093743 /* pod_support */ = {
-			isa = PBXGroup;
-			children = (
-				G_8622697200703 /* Headers */,
+				G_8174493743338 /* Headers */,
 			);
 			path = pod_support;
 			sourceTree = "<group>";
 		};
-		G_2939218085132 /* Headers */ = {
+		G_2160786746100 /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				G_4590881387693 /* Public */,
-			);
-			path = Headers;
-			sourceTree = "<group>";
-		};
-		G_2990742683824 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				FR_811655502329 /* GoogleAppIndexing.framework */,
-				FR_633906012597 /* GoogleAuthUtilities.framework */,
-				FR_288738750739 /* GoogleNetworkingUtilities.framework */,
-				FR_854600736464 /* GoogleSymbolUtilities.framework */,
-				FR_571118315125 /* libios-app-bin-ios-12.0.a */,
-				FR_524174742878 /* libios-ext-bin.a */,
-				FR_201794194523 /* libPINCache-Arc-exception-safe-ios-9.0.a */,
-				FR_836986626561 /* libPINCache-Arc-exception-safe-ios-12.0.a */,
-				FR_800458577779 /* libPINCache-Core-ios-9.0.a */,
-				FR_839061891305 /* libPINCache-Core-ios-12.0.a */,
-				FR_248755332667 /* libPINOperation-ios-9.0.a */,
-				FR_127927644982 /* libPINOperation-ios-12.0.a */,
-				FR_538830033660 /* libsiri-ext-bin.a */,
-				FR_534115266600 /* libstrings-ext-bin.a */,
-				FR_849310420444 /* libStripe-ios-9.0.a */,
-				FR_621770749327 /* libStripe-ios-12.0.a */,
-				FR_212516784466 /* libUrlGetClasses-ios-9.0.a */,
-				FR_193583997594 /* libUrlGetClasses-ios-12.0.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		G_3052382352411 /* StringsExtension */ = {
-			isa = PBXGroup;
-			children = (
-				G_1008629500772 /* Resources */,
-				G_8870550762206 /* Sources */,
-			);
-			path = StringsExtension;
-			sourceTree = "<group>";
-		};
-		G_3084679974460 /* Stripe */ = {
-			isa = PBXGroup;
-			children = (
-				G_4869662978608 /* pod_support */,
-				G_2125117200830 /* Stripe */,
-			);
-			path = Stripe;
-			sourceTree = "<group>";
-		};
-		G_3212778500724 /* SiriExtension */ = {
-			isa = PBXGroup;
-			children = (
-				G_1737247195532 /* Resources */,
-				G_1181679691437 /* Sources */,
-			);
-			path = SiriExtension;
-			sourceTree = "<group>";
-		};
-		G_3270894773512 /* Public */ = {
-			isa = PBXGroup;
-			children = (
-				G_7475870226326 /* PINOperation */,
-			);
-			path = Public;
-			sourceTree = "<group>";
-		};
-		G_3509668622477 /* PINCache */ = {
-			isa = PBXGroup;
-			children = (
-				FR_158610862646 /* PINCache.h */,
-				FR_470378515142 /* PINCacheMacros.h */,
-				FR_218535940030 /* PINCacheObjectSubscripting.h */,
-				FR_863592367999 /* PINCaching.h */,
-				FR_519449128250 /* PINDiskCache.h */,
-				FR_859974805442 /* PINMemoryCache.h */,
-			);
-			path = PINCache;
-			sourceTree = "<group>";
-		};
-		G_3593619295521 /* Vendor */ = {
-			isa = PBXGroup;
-			children = (
-				G_6150583057200 /* GoogleAppIndexing */,
-				G_8765011268743 /* PINCache */,
-				G_1706547191179 /* PINOperation */,
-				G_3084679974460 /* Stripe */,
-			);
-			path = Vendor;
-			sourceTree = "<group>";
-		};
-		G_4279368520912 /* pod_support */ = {
-			isa = PBXGroup;
-			children = (
-				G_4792351409257 /* Headers */,
-			);
-			path = pod_support;
-			sourceTree = "<group>";
-		};
-		G_4376436462613 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				G_5852754205192 /* Images */,
-				G_8342682597001 /* Localizations */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		G_4590881387693 /* Public */ = {
-			isa = PBXGroup;
-			children = (
-				G_8008610950905 /* Stripe */,
-			);
-			path = Public;
-			sourceTree = "<group>";
-		};
-		G_4792351409257 /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				G_1607218128998 /* Public */,
-			);
-			path = Headers;
-			sourceTree = "<group>";
-		};
-		G_4869662978608 /* pod_support */ = {
-			isa = PBXGroup;
-			children = (
-				G_2939218085132 /* Headers */,
-			);
-			path = pod_support;
-			sourceTree = "<group>";
-		};
-		G_5212418710483 /* Source */ = {
-			isa = PBXGroup;
-			children = (
-				FR_524827012853 /* PINOperation.h */,
-				FR_111953531546 /* PINOperationGroup.h */,
-				FR_763548395573 /* PINOperationGroup.m */,
-				FR_904277097215 /* PINOperationMacros.h */,
-				FR_628721409824 /* PINOperationQueue.h */,
-				FR_129106470870 /* PINOperationQueue.m */,
-				FR_127801604110 /* PINOperationTypes.h */,
+				FR_499185708877 /* PINOperation.h */,
+				FR_695264615504 /* PINOperationGroup.h */,
+				FR_847516745795 /* PINOperationGroup.m */,
+				FR_410545183530 /* PINOperationMacros.h */,
+				FR_349247967105 /* PINOperationQueue.h */,
+				FR_660084857839 /* PINOperationQueue.m */,
+				FR_222491318798 /* PINOperationTypes.h */,
 			);
 			path = Source;
 			sourceTree = "<group>";
 		};
-		G_5479743953642 /* PublicHeaders */ = {
+		G_2161021005139 /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
-				FR_747253515199 /* FauxPasAnnotations.h */,
-				FR_404856632346 /* STPAddCardViewController.h */,
-				FR_919264268692 /* STPAddress.h */,
-				FR_419705868654 /* STPAPIClient.h */,
-				FR_298053197398 /* STPAPIClient+ApplePay.h */,
-				FR_122282325744 /* STPAPIResponseDecodable.h */,
-				FR_770709987754 /* STPApplePayPaymentMethod.h */,
-				FR_107366029463 /* STPBackendAPIAdapter.h */,
-				FR_747880172874 /* STPBankAccount.h */,
-				FR_420204909531 /* STPBankAccountParams.h */,
-				FR_298239715908 /* STPBlocks.h */,
-				FR_820499346752 /* STPCard.h */,
-				FR_347091572157 /* STPCardBrand.h */,
-				FR_893575362148 /* STPCardParams.h */,
-				FR_797436073728 /* STPCardValidationState.h */,
-				FR_202613678448 /* STPCardValidator.h */,
-				FR_114522988977 /* STPConnectAccountParams.h */,
-				FR_199269573806 /* STPCoreScrollViewController.h */,
-				FR_311557376990 /* STPCoreTableViewController.h */,
-				FR_312385741133 /* STPCoreViewController.h */,
-				FR_136953339046 /* STPCustomer.h */,
-				FR_241162817988 /* STPCustomerContext.h */,
-				FR_847045712447 /* STPEphemeralKeyProvider.h */,
-				FR_562943593105 /* STPFile.h */,
-				FR_575524244686 /* STPFormEncodable.h */,
-				FR_756270580861 /* STPImageLibrary.h */,
-				FR_431935522678 /* STPLegalEntityParams.h */,
-				FR_156168063359 /* STPPaymentActivityIndicatorView.h */,
-				FR_649238455296 /* STPPaymentCardTextField.h */,
-				FR_129519285691 /* STPPaymentConfiguration.h */,
-				FR_782705593529 /* STPPaymentContext.h */,
-				FR_629270262851 /* STPPaymentMethod.h */,
-				FR_879608332693 /* STPPaymentMethodsViewController.h */,
-				FR_595096526234 /* STPPaymentResult.h */,
-				FR_849623333700 /* STPRedirectContext.h */,
-				FR_263478129584 /* STPShippingAddressViewController.h */,
-				FR_585940230866 /* STPSource.h */,
-				FR_593273223553 /* STPSourceCardDetails.h */,
-				FR_624367940457 /* STPSourceEnums.h */,
-				FR_686356710930 /* STPSourceOwner.h */,
-				FR_159828199997 /* STPSourceParams.h */,
-				FR_430371989691 /* STPSourceProtocol.h */,
-				FR_500726537716 /* STPSourceReceiver.h */,
-				FR_269106334444 /* STPSourceRedirect.h */,
-				FR_196111026094 /* STPSourceSEPADebitDetails.h */,
-				FR_423624774639 /* STPSourceVerification.h */,
-				FR_592268760850 /* STPTheme.h */,
-				FR_617051424034 /* STPToken.h */,
-				FR_587985957033 /* STPUserInformation.h */,
-				FR_480004592247 /* Stripe.h */,
-				FR_573374430468 /* StripeError.h */,
-				FR_565338640322 /* UINavigationBar+Stripe_Theme.h */,
+				FR_483720092972 /* Tests.m */,
+				FR_536395162937 /* Tests2.m */,
 			);
-			path = PublicHeaders;
+			path = UnitTests;
 			sourceTree = "<group>";
 		};
-		G_5852754205192 /* Images */ = {
+		G_2423028212279 /* PINCache */ = {
 			isa = PBXGroup;
 			children = (
-				FR_351223294806 /* stp_card_amex_template.png */,
-				FR_862109982380 /* stp_card_amex_template@2x.png */,
-				FR_225452001627 /* stp_card_amex_template@3x.png */,
-				FR_758089556382 /* stp_card_amex.png */,
-				FR_905942270940 /* stp_card_amex@2x.png */,
-				FR_431621881643 /* stp_card_amex@3x.png */,
-				FR_603505517320 /* stp_card_applepay.png */,
-				FR_224516879435 /* stp_card_applepay@2x.png */,
-				FR_277947155239 /* stp_card_applepay@3x.png */,
-				FR_384110904147 /* stp_card_cvc_amex.png */,
-				FR_222933926124 /* stp_card_cvc_amex@2x.png */,
-				FR_510961761073 /* stp_card_cvc_amex@3x.png */,
-				FR_765251530720 /* stp_card_cvc.png */,
-				FR_564512028139 /* stp_card_cvc@2x.png */,
-				FR_305781761228 /* stp_card_cvc@3x.png */,
-				FR_729563592373 /* stp_card_diners_template.png */,
-				FR_116888220100 /* stp_card_diners_template@2x.png */,
-				FR_890612956832 /* stp_card_diners_template@3x.png */,
-				FR_367189898554 /* stp_card_diners.png */,
-				FR_843574680132 /* stp_card_diners@2x.png */,
-				FR_195382795454 /* stp_card_diners@3x.png */,
-				FR_723722683585 /* stp_card_discover_template.png */,
-				FR_350139185969 /* stp_card_discover_template@2x.png */,
-				FR_600826957346 /* stp_card_discover_template@3x.png */,
-				FR_233463993954 /* stp_card_discover.png */,
-				FR_393570962306 /* stp_card_discover@2x.png */,
-				FR_647718745479 /* stp_card_discover@3x.png */,
-				FR_903119597428 /* stp_card_error_amex.png */,
-				FR_163201521832 /* stp_card_error_amex@2x.png */,
-				FR_245329396039 /* stp_card_error_amex@3x.png */,
-				FR_918544604518 /* stp_card_error.png */,
-				FR_865204967261 /* stp_card_error@2x.png */,
-				FR_900806134110 /* stp_card_error@3x.png */,
-				FR_858844900391 /* stp_card_form_back.png */,
-				FR_608546669129 /* stp_card_form_back@2x.png */,
-				FR_785291574055 /* stp_card_form_back@3x.png */,
-				FR_646401499000 /* stp_card_form_front.png */,
-				FR_913750020022 /* stp_card_form_front@2x.png */,
-				FR_188039461400 /* stp_card_form_front@3x.png */,
-				FR_651709914966 /* stp_card_jcb_template.png */,
-				FR_304102532309 /* stp_card_jcb_template@2x.png */,
-				FR_342721641775 /* stp_card_jcb_template@3x.png */,
-				FR_357987593239 /* stp_card_jcb.png */,
-				FR_250835929950 /* stp_card_jcb@2x.png */,
-				FR_152255977769 /* stp_card_jcb@3x.png */,
-				FR_262765526800 /* stp_card_mastercard_template.png */,
-				FR_764521294758 /* stp_card_mastercard_template@2x.png */,
-				FR_593438413731 /* stp_card_mastercard_template@3x.png */,
-				FR_721269067802 /* stp_card_mastercard.png */,
-				FR_134545133893 /* stp_card_mastercard@2x.png */,
-				FR_573348568627 /* stp_card_mastercard@3x.png */,
-				FR_404502426469 /* stp_card_unionpay_en.png */,
-				FR_904565042407 /* stp_card_unionpay_en@2x.png */,
-				FR_730682142522 /* stp_card_unionpay_en@3x.png */,
-				FR_700870847596 /* stp_card_unionpay_template_en.png */,
-				FR_392935778985 /* stp_card_unionpay_template_en@2x.png */,
-				FR_600685478634 /* stp_card_unionpay_template_en@3x.png */,
-				FR_869656627571 /* stp_card_unionpay_template_zh.png */,
-				FR_357471098469 /* stp_card_unionpay_template_zh@2x.png */,
-				FR_335380563722 /* stp_card_unionpay_template_zh@3x.png */,
-				FR_815379450093 /* stp_card_unionpay_zh.png */,
-				FR_109008019044 /* stp_card_unionpay_zh@2x.png */,
-				FR_805132164928 /* stp_card_unionpay_zh@3x.png */,
-				FR_896260771039 /* stp_card_unknown.png */,
-				FR_359125113541 /* stp_card_unknown@2x.png */,
-				FR_810092475433 /* stp_card_unknown@3x.png */,
-				FR_321921907264 /* stp_card_visa_template.png */,
-				FR_420913153337 /* stp_card_visa_template@2x.png */,
-				FR_682789186016 /* stp_card_visa_template@3x.png */,
-				FR_365700562027 /* stp_card_visa.png */,
-				FR_680376588314 /* stp_card_visa@2x.png */,
-				FR_947777323233 /* stp_card_visa@3x.png */,
-				FR_168201804537 /* stp_icon_add.png */,
-				FR_629820978782 /* stp_icon_add@2x.png */,
-				FR_441528659827 /* stp_icon_add@3x.png */,
-				FR_211759521425 /* stp_icon_checkmark.png */,
-				FR_515852211545 /* stp_icon_checkmark@2x.png */,
-				FR_549986619017 /* stp_icon_checkmark@3x.png */,
-				FR_693100679042 /* stp_shipping_form.png */,
-				FR_720785863149 /* stp_shipping_form@2x.png */,
-				FR_766714036471 /* stp_shipping_form@3x.png */,
-				FR_474718748706 /* stp_test_upload_image.jpeg */,
+				G_5131974638345 /* pod_support */,
+				G_5973419548828 /* Source */,
 			);
-			path = Images;
+			path = PINCache;
 			sourceTree = "<group>";
 		};
-		G_6150583057200 /* GoogleAppIndexing */ = {
+		G_2524840969052 /* Stripe */ = {
 			isa = PBXGroup;
 			children = (
-				G_1353143497566 /* Resources */,
+				G_1729959325787 /* pod_support */,
+				G_8104672363126 /* Stripe */,
 			);
-			path = GoogleAppIndexing;
+			path = Stripe;
 			sourceTree = "<group>";
 		};
-		G_6408243056626 /* Localization */ = {
+		G_2744151723622 = {
 			isa = PBXGroup;
 			children = (
-				VG_678627904183 /* InfoPlist.strings */,
-			);
-			path = Localization;
-			sourceTree = "<group>";
-		};
-		G_6533566337535 /* XCHammerAssets */ = {
-			isa = PBXGroup;
-			children = (
-				FR_411849423046 /* Stub.m */,
-			);
-			path = XCHammerAssets;
-			sourceTree = "<group>";
-		};
-		G_6855430150171 = {
-			isa = PBXGroup;
-			children = (
-				G_7866255286210 /* bazel-genfiles */,
-				G_2104788648841 /* ios-app */,
-				G_2363395555826 /* UrlGet.xcodeproj */,
-				G_3593619295521 /* Vendor */,
-				G_2990742683824 /* Frameworks */,
-				G_1190614392986 /* Products */,
+				G_4402556533416 /* bazel-genfiles */,
+				G_3937907837427 /* ios-app */,
+				G_6368496378397 /* UrlGet.xcodeproj */,
+				G_4595084264354 /* Vendor */,
+				G_6012606165216 /* Frameworks */,
+				G_8046148863901 /* Products */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
 			tabWidth = 4;
 			usesTabs = 0;
 		};
-		G_7410372946843 /* Source */ = {
+		G_2918801855098 /* Localization */ = {
 			isa = PBXGroup;
 			children = (
-				FR_748516206887 /* PINCache.h */,
-				FR_121139739215 /* PINCache.m */,
-				FR_595384544521 /* PINCacheMacros.h */,
-				FR_484445793271 /* PINCacheObjectSubscripting.h */,
-				FR_877522748700 /* PINCaching.h */,
-				FR_510268330865 /* PINDiskCache.h */,
-				FR_145914995522 /* PINDiskCache.m */,
-				FR_155107299127 /* PINMemoryCache.h */,
-				FR_398590689728 /* PINMemoryCache.m */,
+				VG_786904937064 /* AppIntentVocabulary.plist */,
 			);
-			path = Source;
+			path = Localization;
 			sourceTree = "<group>";
 		};
-		G_7475870226326 /* PINOperation */ = {
+		G_2938798845120 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				FR_910623067955 /* PINOperation.h */,
-				FR_315911173146 /* PINOperationGroup.h */,
-				FR_647919086969 /* PINOperationMacros.h */,
-				FR_236610832137 /* PINOperationQueue.h */,
-				FR_139695597457 /* PINOperationTypes.h */,
-			);
-			path = PINOperation;
-			sourceTree = "<group>";
-		};
-		G_7758867582615 /* UrlGet */ = {
-			isa = PBXGroup;
-			children = (
-				FR_560728635814 /* AppDelegate.h */,
-				FR_653012245890 /* AppDelegate.m */,
-				FR_750021784507 /* main.m */,
-				FR_914926894106 /* NoArc.m */,
-				FR_262245891890 /* Some.cc */,
-				FR_294706493915 /* Some.hpp */,
-				FR_278392824234 /* UrlGet-Info.plist */,
-				FR_346022409790 /* UrlGetViewController.h */,
-				FR_893633932801 /* UrlGetViewController.m */,
-				FR_898308164695 /* UrlGetViewController.xib */,
-			);
-			path = UrlGet;
-			sourceTree = "<group>";
-		};
-		G_7866255286210 /* bazel-genfiles */ = {
-			isa = PBXGroup;
-			children = (
-				G_7891426731740 /* ios-app */,
-			);
-			path = "bazel-genfiles";
-			sourceTree = "<group>";
-		};
-		G_7884178875015 /* ShareExtension */ = {
-			isa = PBXGroup;
-			children = (
-				FR_172654872023 /* ShareExtension-Info.plist */,
-			);
-			path = ShareExtension;
-			sourceTree = "<group>";
-		};
-		G_7891426731740 /* ios-app */ = {
-			isa = PBXGroup;
-			children = (
-				FR_536833584482 /* Generated.m */,
-			);
-			path = "ios-app";
-			sourceTree = "<group>";
-		};
-		G_8008610950905 /* Stripe */ = {
-			isa = PBXGroup;
-			children = (
-				FR_758860821355 /* FABKitProtocol.h */,
-				FR_423248315424 /* Fabric.h */,
-				FR_508273787935 /* Fabric+FABKits.h */,
-				FR_155440772017 /* FauxPasAnnotations.h */,
-				FR_503781061646 /* NSArray+Stripe.h */,
-				FR_634495254009 /* NSBundle+Stripe_AppName.h */,
-				FR_576915136294 /* NSCharacterSet+Stripe.h */,
-				FR_504151002142 /* NSDecimalNumber+Stripe_Currency.h */,
-				FR_417555773173 /* NSDictionary+Stripe.h */,
-				FR_560042372130 /* NSError+Stripe.h */,
-				FR_404486997170 /* NSMutableURLRequest+Stripe.h */,
-				FR_401970492002 /* NSString+Stripe.h */,
-				FR_462191760454 /* NSURLComponents+Stripe.h */,
-				FR_785617435345 /* PKPayment+Stripe.h */,
-				FR_807240866189 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */,
-				FR_728026518839 /* STPAddCardViewController.h */,
-				FR_543005669959 /* STPAddCardViewController+Private.h */,
-				FR_514135117544 /* STPAddress.h */,
-				FR_694773287744 /* STPAddressFieldTableViewCell.h */,
-				FR_586986624055 /* STPAddressViewModel.h */,
-				FR_418773092332 /* STPAnalyticsClient.h */,
-				FR_332422960777 /* STPAPIClient.h */,
-				FR_789854558921 /* STPAPIClient+ApplePay.h */,
-				FR_256159406193 /* STPAPIClient+Private.h */,
-				FR_238051608612 /* STPAPIRequest.h */,
-				FR_818774264549 /* STPAPIResponseDecodable.h */,
-				FR_861672862353 /* STPApplePayPaymentMethod.h */,
-				FR_274521215767 /* STPAspects.h */,
-				FR_876379193786 /* STPBackendAPIAdapter.h */,
-				FR_748822618665 /* STPBankAccount.h */,
-				FR_670152390772 /* STPBankAccountParams.h */,
-				FR_782498420325 /* STPBankAccountParams+Private.h */,
-				FR_323887596110 /* STPBINRange.h */,
-				FR_921508757598 /* STPBlocks.h */,
-				FR_591087034932 /* STPBundleLocator.h */,
-				FR_489574871852 /* STPCard.h */,
-				FR_350835833985 /* STPCard+Private.h */,
-				FR_987445166148 /* STPCardBrand.h */,
-				FR_541504829408 /* STPCardIOProxy.h */,
-				FR_544549138247 /* STPCardParams.h */,
-				FR_386610645429 /* STPCardValidationState.h */,
-				FR_850949429257 /* STPCardValidator.h */,
-				FR_914246773896 /* STPCategoryLoader.h */,
-				FR_561627957161 /* STPColorUtils.h */,
-				FR_871001035230 /* STPConnectAccountParams.h */,
-				FR_669453909057 /* STPCoreScrollViewController.h */,
-				FR_221599280939 /* STPCoreScrollViewController+Private.h */,
-				FR_100286439270 /* STPCoreTableViewController.h */,
-				FR_157547947389 /* STPCoreTableViewController+Private.h */,
-				FR_423454223633 /* STPCoreViewController.h */,
-				FR_298308069312 /* STPCoreViewController+Private.h */,
-				FR_382488979221 /* STPCustomer.h */,
-				FR_374682488696 /* STPCustomer+Private.h */,
-				FR_148025955428 /* STPCustomer+SourceTuple.h */,
-				FR_790732552626 /* STPCustomerContext.h */,
-				FR_825197242686 /* STPDelegateProxy.h */,
-				FR_877552865893 /* STPDispatchFunctions.h */,
-				FR_420351753711 /* STPEmailAddressValidator.h */,
-				FR_647044893441 /* STPEphemeralKey.h */,
-				FR_180854351342 /* STPEphemeralKeyManager.h */,
-				FR_731891552567 /* STPEphemeralKeyProvider.h */,
-				FR_141640256136 /* STPFile.h */,
-				FR_533405582252 /* STPFile+Private.h */,
-				FR_546761756616 /* STPFormEncodable.h */,
-				FR_143096604872 /* STPFormEncoder.h */,
-				FR_149015947095 /* STPFormTextField.h */,
-				FR_191080603083 /* STPImageLibrary.h */,
-				FR_220146349829 /* STPImageLibrary+Private.h */,
-				FR_477653190877 /* STPInternalAPIResponseDecodable.h */,
-				FR_564214461619 /* STPLegalEntityParams.h */,
-				FR_309738637754 /* STPLocalizationUtils.h */,
-				FR_914874316924 /* STPMultipartFormDataEncoder.h */,
-				FR_392811231591 /* STPMultipartFormDataPart.h */,
-				FR_731776241747 /* STPPaymentActivityIndicatorView.h */,
-				FR_819880206632 /* STPPaymentCardTextField.h */,
-				FR_750971871591 /* STPPaymentCardTextField+Private.h */,
-				FR_525920755561 /* STPPaymentCardTextFieldCell.h */,
-				FR_322504740038 /* STPPaymentCardTextFieldViewModel.h */,
-				FR_691495142809 /* STPPaymentConfiguration.h */,
-				FR_325996419707 /* STPPaymentConfiguration+Private.h */,
-				FR_195674470488 /* STPPaymentContext.h */,
-				FR_283351945692 /* STPPaymentContext+Private.h */,
-				FR_783911409348 /* STPPaymentContextAmountModel.h */,
-				FR_411623523903 /* STPPaymentMethod.h */,
-				FR_432522117665 /* STPPaymentMethodsInternalViewController.h */,
-				FR_445478471295 /* STPPaymentMethodsViewController.h */,
-				FR_683967887143 /* STPPaymentMethodsViewController+Private.h */,
-				FR_295701939216 /* STPPaymentMethodTableViewCell.h */,
-				FR_780002710116 /* STPPaymentMethodTuple.h */,
-				FR_562520138872 /* STPPaymentResult.h */,
-				FR_334874974082 /* STPPhoneNumberValidator.h */,
-				FR_121877701792 /* STPPostalCodeValidator.h */,
-				FR_694424347491 /* STPPromise.h */,
-				FR_523252164916 /* STPRedirectContext.h */,
-				FR_399167766251 /* STPSectionHeaderView.h */,
-				FR_720237274209 /* STPShippingAddressViewController.h */,
-				FR_424126959875 /* STPShippingMethodsViewController.h */,
-				FR_441077981283 /* STPShippingMethodTableViewCell.h */,
-				FR_627507193231 /* STPSource.h */,
-				FR_380964705581 /* STPSource+Private.h */,
-				FR_217007679238 /* STPSourceCardDetails.h */,
-				FR_374847588504 /* STPSourceCardDetails+Private.h */,
-				FR_593400371332 /* STPSourceEnums.h */,
-				FR_614599844040 /* STPSourceOwner.h */,
-				FR_878614281729 /* STPSourceParams.h */,
-				FR_686700913758 /* STPSourceParams+Private.h */,
-				FR_348836605145 /* STPSourcePoller.h */,
-				FR_385496779698 /* STPSourceProtocol.h */,
-				FR_381020398572 /* STPSourceReceiver.h */,
-				FR_250884507592 /* STPSourceRedirect.h */,
-				FR_599090964629 /* STPSourceRedirect+Private.h */,
-				FR_516941852563 /* STPSourceSEPADebitDetails.h */,
-				FR_629869520108 /* STPSourceVerification.h */,
-				FR_244508054852 /* STPSourceVerification+Private.h */,
-				FR_350076690277 /* STPStringUtils.h */,
-				FR_404853706608 /* STPSwitchTableViewCell.h */,
-				FR_726706439679 /* STPTelemetryClient.h */,
-				FR_682061921855 /* STPTheme.h */,
-				FR_683331153862 /* STPToken.h */,
-				FR_207445636632 /* STPURLCallbackHandler.h */,
-				FR_228524083929 /* STPUserInformation.h */,
-				FR_784242390380 /* STPValidatedTextField.h */,
-				FR_279745772659 /* STPWeakStrongMacros.h */,
-				FR_551790036270 /* Stripe.h */,
-				FR_785336258264 /* StripeError.h */,
-				FR_591149101213 /* UIBarButtonItem+Stripe.h */,
-				FR_927073100198 /* UIImage+Stripe.h */,
-				FR_388506942031 /* UINavigationBar+Stripe_Theme.h */,
-				FR_104592274494 /* UINavigationController+Stripe_Completion.h */,
-				FR_859647957539 /* UITableViewCell+Stripe_Borders.h */,
-				FR_643271429008 /* UIToolbar+Stripe_InputAccessory.h */,
-				FR_453940417190 /* UIView+Stripe_FirstResponder.h */,
-				FR_532738764551 /* UIView+Stripe_SafeAreaBounds.h */,
-				FR_131477545399 /* UIViewController+Stripe_KeyboardAvoiding.h */,
-				FR_694106962702 /* UIViewController+Stripe_NavigationItemProxy.h */,
-				FR_792622417316 /* UIViewController+Stripe_ParentViewController.h */,
-				FR_496612823329 /* UIViewController+Stripe_Promises.h */,
-			);
-			path = Stripe;
-			sourceTree = "<group>";
-		};
-		G_8342682597001 /* Localizations */ = {
-			isa = PBXGroup;
-			children = (
-				VG_155022079262 /* Localizable.strings */,
-			);
-			path = Localizations;
-			sourceTree = "<group>";
-		};
-		G_8622697200703 /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				G_3270894773512 /* Public */,
+				G_4589909105501 /* Public */,
 			);
 			path = Headers;
 			sourceTree = "<group>";
 		};
-		G_8765011268743 /* PINCache */ = {
+		G_2979863340644 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				G_4279368520912 /* pod_support */,
-				G_7410372946843 /* Source */,
+				FR_431351183220 /* SiriExtension-Info.plist */,
+				G_2918801855098 /* Localization */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		G_3127926615514 /* SiriExtension */ = {
+			isa = PBXGroup;
+			children = (
+				G_2979863340644 /* Resources */,
+				G_3907811474651 /* Sources */,
+			);
+			path = SiriExtension;
+			sourceTree = "<group>";
+		};
+		G_3399481481583 /* GoogleAppIndexing */ = {
+			isa = PBXGroup;
+			children = (
+				G_4893298315066 /* Resources */,
+			);
+			path = GoogleAppIndexing;
+			sourceTree = "<group>";
+		};
+		G_3441691416939 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				FR_603748432416 /* StringsExtension-Info.plist */,
+				G_1709659587767 /* Localization */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		G_3564954705966 /* Localizations */ = {
+			isa = PBXGroup;
+			children = (
+				VG_389377991035 /* Localizable.strings */,
+			);
+			path = Localizations;
+			sourceTree = "<group>";
+		};
+		G_3731273667697 /* ios-app */ = {
+			isa = PBXGroup;
+			children = (
+				FR_270702652206 /* Generated.m */,
+			);
+			path = "ios-app";
+			sourceTree = "<group>";
+		};
+		G_3907811474651 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				FR_919339625812 /* AppIntent.h */,
+				FR_806196035267 /* AppIntent.m */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		G_3937907837427 /* ios-app */ = {
+			isa = PBXGroup;
+			children = (
+				FR_115188359612 /* Diags.xcconfig */,
+				FR_632648320726 /* empty-main.m */,
+				G_8805533164259 /* HeaderLib */,
+				G_5424707929366 /* ShareExtension */,
+				G_3127926615514 /* SiriExtension */,
+				G_8165188630291 /* StringsExtension */,
+				G_2161021005139 /* UnitTests */,
+				G_5500100543045 /* UrlGet */,
+			);
+			path = "ios-app";
+			sourceTree = "<group>";
+		};
+		G_4007723624883 /* Stripe */ = {
+			isa = PBXGroup;
+			children = (
+				FR_375459743988 /* FABKitProtocol.h */,
+				FR_715092956653 /* Fabric.h */,
+				FR_348092391241 /* Fabric+FABKits.h */,
+				FR_371726814006 /* FauxPasAnnotations.h */,
+				FR_207486663369 /* NSArray+Stripe.h */,
+				FR_324746483455 /* NSBundle+Stripe_AppName.h */,
+				FR_531466238338 /* NSCharacterSet+Stripe.h */,
+				FR_859627797282 /* NSDecimalNumber+Stripe_Currency.h */,
+				FR_491855309750 /* NSDictionary+Stripe.h */,
+				FR_306211367156 /* NSError+Stripe.h */,
+				FR_876293920603 /* NSMutableURLRequest+Stripe.h */,
+				FR_216833396960 /* NSString+Stripe.h */,
+				FR_894319557924 /* NSURLComponents+Stripe.h */,
+				FR_839146335427 /* PKPayment+Stripe.h */,
+				FR_522861047398 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */,
+				FR_242594867211 /* STPAddCardViewController.h */,
+				FR_788344785540 /* STPAddCardViewController+Private.h */,
+				FR_877183059027 /* STPAddress.h */,
+				FR_788978376050 /* STPAddressFieldTableViewCell.h */,
+				FR_895059102994 /* STPAddressViewModel.h */,
+				FR_110902364758 /* STPAnalyticsClient.h */,
+				FR_552521354687 /* STPAPIClient.h */,
+				FR_295584209343 /* STPAPIClient+ApplePay.h */,
+				FR_783332722407 /* STPAPIClient+Private.h */,
+				FR_586858897267 /* STPAPIRequest.h */,
+				FR_604853984230 /* STPAPIResponseDecodable.h */,
+				FR_457368245148 /* STPApplePayPaymentMethod.h */,
+				FR_855793908054 /* STPAspects.h */,
+				FR_129458307009 /* STPBackendAPIAdapter.h */,
+				FR_611698887423 /* STPBankAccount.h */,
+				FR_442035849345 /* STPBankAccountParams.h */,
+				FR_930348723303 /* STPBankAccountParams+Private.h */,
+				FR_617298386939 /* STPBINRange.h */,
+				FR_891766987304 /* STPBlocks.h */,
+				FR_397991274865 /* STPBundleLocator.h */,
+				FR_921685205996 /* STPCard.h */,
+				FR_712558935001 /* STPCard+Private.h */,
+				FR_772375839219 /* STPCardBrand.h */,
+				FR_907909434975 /* STPCardIOProxy.h */,
+				FR_110679394668 /* STPCardParams.h */,
+				FR_787080648262 /* STPCardValidationState.h */,
+				FR_430412408542 /* STPCardValidator.h */,
+				FR_803993631086 /* STPCategoryLoader.h */,
+				FR_480570027159 /* STPColorUtils.h */,
+				FR_193081474965 /* STPConnectAccountParams.h */,
+				FR_462772464315 /* STPCoreScrollViewController.h */,
+				FR_828673204570 /* STPCoreScrollViewController+Private.h */,
+				FR_363992742899 /* STPCoreTableViewController.h */,
+				FR_148767108939 /* STPCoreTableViewController+Private.h */,
+				FR_259527767589 /* STPCoreViewController.h */,
+				FR_799125542095 /* STPCoreViewController+Private.h */,
+				FR_439326957297 /* STPCustomer.h */,
+				FR_589269095208 /* STPCustomer+Private.h */,
+				FR_390587793162 /* STPCustomer+SourceTuple.h */,
+				FR_216502832656 /* STPCustomerContext.h */,
+				FR_332580781655 /* STPDelegateProxy.h */,
+				FR_480264551522 /* STPDispatchFunctions.h */,
+				FR_388278762452 /* STPEmailAddressValidator.h */,
+				FR_520761578796 /* STPEphemeralKey.h */,
+				FR_250904967226 /* STPEphemeralKeyManager.h */,
+				FR_770853841763 /* STPEphemeralKeyProvider.h */,
+				FR_132931449288 /* STPFile.h */,
+				FR_303191177043 /* STPFile+Private.h */,
+				FR_672272147268 /* STPFormEncodable.h */,
+				FR_335325431422 /* STPFormEncoder.h */,
+				FR_911104891096 /* STPFormTextField.h */,
+				FR_499112778551 /* STPImageLibrary.h */,
+				FR_465076796337 /* STPImageLibrary+Private.h */,
+				FR_602088298360 /* STPInternalAPIResponseDecodable.h */,
+				FR_223072980108 /* STPLegalEntityParams.h */,
+				FR_847721840679 /* STPLocalizationUtils.h */,
+				FR_577170055431 /* STPMultipartFormDataEncoder.h */,
+				FR_676936962722 /* STPMultipartFormDataPart.h */,
+				FR_115630106739 /* STPPaymentActivityIndicatorView.h */,
+				FR_475795149343 /* STPPaymentCardTextField.h */,
+				FR_399733994594 /* STPPaymentCardTextField+Private.h */,
+				FR_871945793837 /* STPPaymentCardTextFieldCell.h */,
+				FR_380589523590 /* STPPaymentCardTextFieldViewModel.h */,
+				FR_889380289586 /* STPPaymentConfiguration.h */,
+				FR_805282718192 /* STPPaymentConfiguration+Private.h */,
+				FR_690875243305 /* STPPaymentContext.h */,
+				FR_340771593126 /* STPPaymentContext+Private.h */,
+				FR_644018226998 /* STPPaymentContextAmountModel.h */,
+				FR_722428560957 /* STPPaymentMethod.h */,
+				FR_921726608824 /* STPPaymentMethodsInternalViewController.h */,
+				FR_215569688439 /* STPPaymentMethodsViewController.h */,
+				FR_516317479758 /* STPPaymentMethodsViewController+Private.h */,
+				FR_540633154062 /* STPPaymentMethodTableViewCell.h */,
+				FR_346958850421 /* STPPaymentMethodTuple.h */,
+				FR_463272392459 /* STPPaymentResult.h */,
+				FR_807000054470 /* STPPhoneNumberValidator.h */,
+				FR_350397440933 /* STPPostalCodeValidator.h */,
+				FR_554940461685 /* STPPromise.h */,
+				FR_150621172151 /* STPRedirectContext.h */,
+				FR_905457408802 /* STPSectionHeaderView.h */,
+				FR_671356256024 /* STPShippingAddressViewController.h */,
+				FR_101130172000 /* STPShippingMethodsViewController.h */,
+				FR_267089408731 /* STPShippingMethodTableViewCell.h */,
+				FR_473436317539 /* STPSource.h */,
+				FR_213100779117 /* STPSource+Private.h */,
+				FR_655731362161 /* STPSourceCardDetails.h */,
+				FR_194454815750 /* STPSourceCardDetails+Private.h */,
+				FR_795014177049 /* STPSourceEnums.h */,
+				FR_169652316528 /* STPSourceOwner.h */,
+				FR_279929849787 /* STPSourceParams.h */,
+				FR_126465798583 /* STPSourceParams+Private.h */,
+				FR_334771080966 /* STPSourcePoller.h */,
+				FR_817088716264 /* STPSourceProtocol.h */,
+				FR_192330679505 /* STPSourceReceiver.h */,
+				FR_510153968201 /* STPSourceRedirect.h */,
+				FR_527807314452 /* STPSourceRedirect+Private.h */,
+				FR_334971231063 /* STPSourceSEPADebitDetails.h */,
+				FR_230900326107 /* STPSourceVerification.h */,
+				FR_336502039808 /* STPSourceVerification+Private.h */,
+				FR_511504885436 /* STPStringUtils.h */,
+				FR_328297644782 /* STPSwitchTableViewCell.h */,
+				FR_920507342830 /* STPTelemetryClient.h */,
+				FR_217452499355 /* STPTheme.h */,
+				FR_364844710872 /* STPToken.h */,
+				FR_201102775891 /* STPURLCallbackHandler.h */,
+				FR_665133782783 /* STPUserInformation.h */,
+				FR_795282443937 /* STPValidatedTextField.h */,
+				FR_615331454112 /* STPWeakStrongMacros.h */,
+				FR_551244171870 /* Stripe.h */,
+				FR_816157806696 /* StripeError.h */,
+				FR_895687763669 /* UIBarButtonItem+Stripe.h */,
+				FR_156154002606 /* UIImage+Stripe.h */,
+				FR_428291350140 /* UINavigationBar+Stripe_Theme.h */,
+				FR_491814232968 /* UINavigationController+Stripe_Completion.h */,
+				FR_745814336160 /* UITableViewCell+Stripe_Borders.h */,
+				FR_620622155048 /* UIToolbar+Stripe_InputAccessory.h */,
+				FR_336214935292 /* UIView+Stripe_FirstResponder.h */,
+				FR_626135400964 /* UIView+Stripe_SafeAreaBounds.h */,
+				FR_740665298049 /* UIViewController+Stripe_KeyboardAvoiding.h */,
+				FR_843164853455 /* UIViewController+Stripe_NavigationItemProxy.h */,
+				FR_540897959944 /* UIViewController+Stripe_ParentViewController.h */,
+				FR_896160604721 /* UIViewController+Stripe_Promises.h */,
+			);
+			path = Stripe;
+			sourceTree = "<group>";
+		};
+		G_4035827323998 /* PINOperation */ = {
+			isa = PBXGroup;
+			children = (
+				G_7594989889152 /* pod_support */,
+				G_2160786746100 /* Source */,
+			);
+			path = PINOperation;
+			sourceTree = "<group>";
+		};
+		G_4124218370955 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				G_8064663886147 /* Public */,
+			);
+			path = Headers;
+			sourceTree = "<group>";
+		};
+		G_4402556533416 /* bazel-genfiles */ = {
+			isa = PBXGroup;
+			children = (
+				G_3731273667697 /* ios-app */,
+			);
+			path = "bazel-genfiles";
+			sourceTree = "<group>";
+		};
+		G_4589909105501 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				G_5190846817675 /* PINOperation */,
+			);
+			path = Public;
+			sourceTree = "<group>";
+		};
+		G_4595084264354 /* Vendor */ = {
+			isa = PBXGroup;
+			children = (
+				FR_873994371050 /* Analyzer.xcconfig */,
+				G_3399481481583 /* GoogleAppIndexing */,
+				G_2423028212279 /* PINCache */,
+				G_4035827323998 /* PINOperation */,
+				G_2524840969052 /* Stripe */,
+			);
+			path = Vendor;
+			sourceTree = "<group>";
+		};
+		G_4665374629057 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				G_9112094555453 /* Images */,
+				G_3564954705966 /* Localizations */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		G_4893298315066 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				FR_315742577216 /* GoogleAppIndexingResources.bundle */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		G_5131974638345 /* pod_support */ = {
+			isa = PBXGroup;
+			children = (
+				G_4124218370955 /* Headers */,
+			);
+			path = pod_support;
+			sourceTree = "<group>";
+		};
+		G_5190846817675 /* PINOperation */ = {
+			isa = PBXGroup;
+			children = (
+				FR_424062180158 /* PINOperation.h */,
+				FR_673456040385 /* PINOperationGroup.h */,
+				FR_795258740755 /* PINOperationMacros.h */,
+				FR_269159801669 /* PINOperationQueue.h */,
+				FR_255209825296 /* PINOperationTypes.h */,
+			);
+			path = PINOperation;
+			sourceTree = "<group>";
+		};
+		G_5424707929366 /* ShareExtension */ = {
+			isa = PBXGroup;
+			children = (
+				FR_208509687828 /* ShareExtension-Info.plist */,
+			);
+			path = ShareExtension;
+			sourceTree = "<group>";
+		};
+		G_5500100543045 /* UrlGet */ = {
+			isa = PBXGroup;
+			children = (
+				FR_382402128781 /* AppDelegate.h */,
+				FR_387987486934 /* AppDelegate.m */,
+				FR_504407375548 /* main.m */,
+				FR_414139705988 /* NoArc.m */,
+				FR_597844010667 /* Some.cc */,
+				FR_191852455760 /* Some.hpp */,
+				FR_406016197234 /* UrlGet-Info.plist */,
+				FR_107828258449 /* UrlGetViewController.h */,
+				FR_822622224200 /* UrlGetViewController.m */,
+				FR_400311668699 /* UrlGetViewController.xib */,
+			);
+			path = UrlGet;
+			sourceTree = "<group>";
+		};
+		G_5692944991033 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				FR_888513362157 /* AppJerry.h */,
+				FR_850772742307 /* AppJerry.m */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		G_5973419548828 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				FR_813387328933 /* PINCache.h */,
+				FR_830275844486 /* PINCache.m */,
+				FR_802011361010 /* PINCacheMacros.h */,
+				FR_702226405411 /* PINCacheObjectSubscripting.h */,
+				FR_353786914718 /* PINCaching.h */,
+				FR_606016628554 /* PINDiskCache.h */,
+				FR_592203597580 /* PINDiskCache.m */,
+				FR_242694328966 /* PINMemoryCache.h */,
+				FR_791443385444 /* PINMemoryCache.m */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
+		G_6012606165216 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				FR_279407611271 /* GoogleAppIndexing.framework */,
+				FR_223058608906 /* GoogleAuthUtilities.framework */,
+				FR_266084204646 /* GoogleNetworkingUtilities.framework */,
+				FR_585192593384 /* GoogleSymbolUtilities.framework */,
+				FR_315250298335 /* libios-app-bin-ios-12.0.a */,
+				FR_448796637040 /* libios-ext-bin.a */,
+				FR_855525910280 /* libPINCache-Arc-exception-safe-ios-9.0.a */,
+				FR_693961626544 /* libPINCache-Arc-exception-safe-ios-12.0.a */,
+				FR_252085585404 /* libPINCache-Core-ios-9.0.a */,
+				FR_362487785619 /* libPINCache-Core-ios-12.0.a */,
+				FR_903485295144 /* libPINOperation-ios-9.0.a */,
+				FR_775707534446 /* libPINOperation-ios-12.0.a */,
+				FR_319425446576 /* libsiri-ext-bin.a */,
+				FR_444421953328 /* libstrings-ext-bin.a */,
+				FR_983905050479 /* libStripe-ios-9.0.a */,
+				FR_822311040905 /* libStripe-ios-12.0.a */,
+				FR_524961920525 /* libUrlGetClasses-ios-9.0.a */,
+				FR_761481658638 /* libUrlGetClasses-ios-12.0.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		G_6341381036575 /* XCHammerAssets */ = {
+			isa = PBXGroup;
+			children = (
+				FR_358371710400 /* Stub.m */,
+			);
+			path = XCHammerAssets;
+			sourceTree = "<group>";
+		};
+		G_6368496378397 /* UrlGet.xcodeproj */ = {
+			isa = PBXGroup;
+			children = (
+				G_6341381036575 /* XCHammerAssets */,
+			);
+			path = UrlGet.xcodeproj;
+			sourceTree = "<group>";
+		};
+		G_7009350195638 /* PINCache */ = {
+			isa = PBXGroup;
+			children = (
+				FR_176299773792 /* PINCache.h */,
+				FR_798577433392 /* PINCacheMacros.h */,
+				FR_590164391763 /* PINCacheObjectSubscripting.h */,
+				FR_157970986760 /* PINCaching.h */,
+				FR_560470219857 /* PINDiskCache.h */,
+				FR_501557594644 /* PINMemoryCache.h */,
 			);
 			path = PINCache;
 			sourceTree = "<group>";
 		};
-		G_8870550762206 /* Sources */ = {
+		G_7425218360814 /* Public */ = {
 			isa = PBXGroup;
 			children = (
-				FR_575837856911 /* AppJerry.h */,
-				FR_813232904291 /* AppJerry.m */,
+				G_4007723624883 /* Stripe */,
 			);
-			path = Sources;
+			path = Public;
+			sourceTree = "<group>";
+		};
+		G_7594989889152 /* pod_support */ = {
+			isa = PBXGroup;
+			children = (
+				G_2938798845120 /* Headers */,
+			);
+			path = pod_support;
+			sourceTree = "<group>";
+		};
+		G_8046148863901 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FR_490180650504 /* HeaderLib-ios-9.0.a */,
+				FR_729056130422 /* HeaderLib-ios-12.0.a */,
+				FR_521258380702 /* ios-app-Bazel.app */,
+				FR_140640746934 /* ios-app-bin-ios-12.0-Bazel.a */,
+				FR_140209500333 /* ios-app-bin-ios-12.0.a */,
+				FR_393790783742 /* ios-app.app */,
+				FR_538821595566 /* ios-ext-bin.a */,
+				FR_852796935086 /* PINCache-Arc-exception-safe-ios-9.0.a */,
+				FR_765731174060 /* PINCache-Arc-exception-safe-ios-12.0.a */,
+				FR_896024321091 /* PINCache-Core-ios-9.0.a */,
+				FR_561293049977 /* PINCache-Core-ios-12.0.a */,
+				FR_426131539244 /* PINOperation-ios-9.0.a */,
+				FR_273845325521 /* PINOperation-ios-12.0.a */,
+				FR_891271893429 /* share-extension-Bazel.appex */,
+				FR_339590863894 /* share-extension.appex */,
+				FR_643129213697 /* siri-ext-bin.a */,
+				FR_907005147347 /* siri-extension.appex */,
+				FR_617004790111 /* strings-ext-bin.a */,
+				FR_207408458888 /* strings-extension.appex */,
+				FR_158773525708 /* Stripe-ios-9.0.a */,
+				FR_708974059261 /* Stripe-ios-12.0.a */,
+				FR_655065637744 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */,
+				FR_275539566864 /* Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle */,
+				FR_413571327928 /* UITests.xctest */,
+				FR_140931474443 /* UnitTests.xctest */,
+				FR_132248253085 /* UnitTestsWithHost.xctest */,
+				FR_442378964830 /* UrlGetClasses-ios-9.0.a */,
+				FR_500728372472 /* UrlGetClasses-ios-12.0.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		G_8064663886147 /* Public */ = {
+			isa = PBXGroup;
+			children = (
+				G_7009350195638 /* PINCache */,
+			);
+			path = Public;
+			sourceTree = "<group>";
+		};
+		G_8104672363126 /* Stripe */ = {
+			isa = PBXGroup;
+			children = (
+				FR_407081031539 /* FABKitProtocol.h */,
+				FR_103939101377 /* Fabric.h */,
+				FR_883395499833 /* Fabric+FABKits.h */,
+				FR_119002602353 /* NSArray+Stripe.h */,
+				FR_756148561161 /* NSArray+Stripe.m */,
+				FR_334236722090 /* NSBundle+Stripe_AppName.h */,
+				FR_506673325060 /* NSBundle+Stripe_AppName.m */,
+				FR_358868972834 /* NSCharacterSet+Stripe.h */,
+				FR_463700594726 /* NSCharacterSet+Stripe.m */,
+				FR_443157579235 /* NSDecimalNumber+Stripe_Currency.h */,
+				FR_458195826767 /* NSDecimalNumber+Stripe_Currency.m */,
+				FR_628854353609 /* NSDictionary+Stripe.h */,
+				FR_619129721469 /* NSDictionary+Stripe.m */,
+				FR_519641547204 /* NSError+Stripe.h */,
+				FR_688759072197 /* NSError+Stripe.m */,
+				FR_517473833142 /* NSMutableURLRequest+Stripe.h */,
+				FR_645419483261 /* NSMutableURLRequest+Stripe.m */,
+				FR_499069437964 /* NSString+Stripe.h */,
+				FR_742311769633 /* NSString+Stripe.m */,
+				FR_801560513350 /* NSURLComponents+Stripe.h */,
+				FR_121714099050 /* NSURLComponents+Stripe.m */,
+				FR_414155344076 /* PKPayment+Stripe.h */,
+				FR_418726020237 /* PKPayment+Stripe.m */,
+				FR_374314786944 /* PKPaymentAuthorizationViewController+Stripe_Blocks.h */,
+				FR_203221802802 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m */,
+				FR_643601304366 /* STPAddCardViewController.m */,
+				FR_474344641046 /* STPAddCardViewController+Private.h */,
+				FR_541854991234 /* STPAddress.m */,
+				FR_239658343536 /* STPAddressFieldTableViewCell.h */,
+				FR_685465727036 /* STPAddressFieldTableViewCell.m */,
+				FR_750681051983 /* STPAddressViewModel.h */,
+				FR_193437629670 /* STPAddressViewModel.m */,
+				FR_814035781224 /* STPAnalyticsClient.h */,
+				FR_610462910989 /* STPAnalyticsClient.m */,
+				FR_307775792133 /* STPAPIClient.m */,
+				FR_387881769002 /* STPAPIClient+ApplePay.m */,
+				FR_258729086301 /* STPAPIClient+Private.h */,
+				FR_176498309403 /* STPAPIRequest.h */,
+				FR_674683558842 /* STPAPIRequest.m */,
+				FR_476535447008 /* STPApplePayPaymentMethod.m */,
+				FR_767845194876 /* STPAspects.h */,
+				FR_386981154662 /* STPAspects.m */,
+				FR_877692020624 /* STPBankAccount.m */,
+				FR_103239545125 /* STPBankAccountParams.m */,
+				FR_346809824920 /* STPBankAccountParams+Private.h */,
+				FR_129519764473 /* STPBINRange.h */,
+				FR_493600713592 /* STPBINRange.m */,
+				FR_619568838966 /* STPBundleLocator.h */,
+				FR_724415273822 /* STPBundleLocator.m */,
+				FR_884510017797 /* STPCard.m */,
+				FR_108718220097 /* STPCard+Private.h */,
+				FR_264904425728 /* STPCardIOProxy.h */,
+				FR_641447449553 /* STPCardIOProxy.m */,
+				FR_256989447831 /* STPCardParams.m */,
+				FR_325961342376 /* STPCardValidator.m */,
+				FR_144332652217 /* STPCategoryLoader.h */,
+				FR_292969540570 /* STPCategoryLoader.m */,
+				FR_379385289566 /* STPColorUtils.h */,
+				FR_920605117287 /* STPColorUtils.m */,
+				FR_717345258349 /* STPConnectAccountParams.m */,
+				FR_385123840418 /* STPCoreScrollViewController.m */,
+				FR_912153776991 /* STPCoreScrollViewController+Private.h */,
+				FR_413344087887 /* STPCoreTableViewController.m */,
+				FR_475171097171 /* STPCoreTableViewController+Private.h */,
+				FR_326732228556 /* STPCoreViewController.m */,
+				FR_525593892119 /* STPCoreViewController+Private.h */,
+				FR_737326472839 /* STPCustomer.m */,
+				FR_693545976554 /* STPCustomer+Private.h */,
+				FR_621667375658 /* STPCustomer+SourceTuple.h */,
+				FR_145973180178 /* STPCustomer+SourceTuple.m */,
+				FR_737402177737 /* STPCustomerContext.m */,
+				FR_461151547306 /* STPDelegateProxy.h */,
+				FR_796389677736 /* STPDelegateProxy.m */,
+				FR_653223178753 /* STPDispatchFunctions.h */,
+				FR_157144616729 /* STPDispatchFunctions.m */,
+				FR_396363747617 /* STPEmailAddressValidator.h */,
+				FR_891436639477 /* STPEmailAddressValidator.m */,
+				FR_357805727123 /* STPEphemeralKey.h */,
+				FR_253971462755 /* STPEphemeralKey.m */,
+				FR_472348897847 /* STPEphemeralKeyManager.h */,
+				FR_648604114055 /* STPEphemeralKeyManager.m */,
+				FR_620106212103 /* STPFile.m */,
+				FR_232583874017 /* STPFile+Private.h */,
+				FR_346017508252 /* STPFormEncoder.h */,
+				FR_898478279498 /* STPFormEncoder.m */,
+				FR_776899178610 /* STPFormTextField.h */,
+				FR_169667767185 /* STPFormTextField.m */,
+				FR_758328319458 /* STPImageLibrary.m */,
+				FR_172594157380 /* STPImageLibrary+Private.h */,
+				FR_628765823358 /* STPInternalAPIResponseDecodable.h */,
+				FR_916780536843 /* STPLegalEntityParams.m */,
+				FR_605275026753 /* STPLocalizationUtils.h */,
+				FR_804931815947 /* STPLocalizationUtils.m */,
+				FR_792226602984 /* STPMultipartFormDataEncoder.h */,
+				FR_125415528864 /* STPMultipartFormDataEncoder.m */,
+				FR_428659206443 /* STPMultipartFormDataPart.h */,
+				FR_800682286459 /* STPMultipartFormDataPart.m */,
+				FR_677319161634 /* STPPaymentActivityIndicatorView.m */,
+				FR_163191866606 /* STPPaymentCardTextField.m */,
+				FR_409483507308 /* STPPaymentCardTextField+Private.h */,
+				FR_298260645729 /* STPPaymentCardTextFieldCell.h */,
+				FR_180176959680 /* STPPaymentCardTextFieldCell.m */,
+				FR_700015233991 /* STPPaymentCardTextFieldViewModel.h */,
+				FR_758823072707 /* STPPaymentCardTextFieldViewModel.m */,
+				FR_259116261371 /* STPPaymentConfiguration.m */,
+				FR_306021898086 /* STPPaymentConfiguration+Private.h */,
+				FR_184070624316 /* STPPaymentContext.m */,
+				FR_458705192052 /* STPPaymentContext+Private.h */,
+				FR_243565016729 /* STPPaymentContextAmountModel.h */,
+				FR_376219813331 /* STPPaymentContextAmountModel.m */,
+				FR_171751278593 /* STPPaymentMethodsInternalViewController.h */,
+				FR_586728708045 /* STPPaymentMethodsInternalViewController.m */,
+				FR_243169012465 /* STPPaymentMethodsViewController.m */,
+				FR_526089843922 /* STPPaymentMethodsViewController+Private.h */,
+				FR_555298796716 /* STPPaymentMethodTableViewCell.h */,
+				FR_692892454609 /* STPPaymentMethodTableViewCell.m */,
+				FR_248193021936 /* STPPaymentMethodTuple.h */,
+				FR_542871956439 /* STPPaymentMethodTuple.m */,
+				FR_384868030190 /* STPPaymentResult.m */,
+				FR_473192119440 /* STPPhoneNumberValidator.h */,
+				FR_607013564544 /* STPPhoneNumberValidator.m */,
+				FR_875775578448 /* STPPostalCodeValidator.h */,
+				FR_201870136181 /* STPPostalCodeValidator.m */,
+				FR_687756258433 /* STPPromise.h */,
+				FR_262712408620 /* STPPromise.m */,
+				FR_738184609669 /* STPRedirectContext.m */,
+				FR_726258871684 /* STPSectionHeaderView.h */,
+				FR_359007197538 /* STPSectionHeaderView.m */,
+				FR_671168073175 /* STPShippingAddressViewController.m */,
+				FR_478769126414 /* STPShippingMethodsViewController.h */,
+				FR_414479750077 /* STPShippingMethodsViewController.m */,
+				FR_763988016072 /* STPShippingMethodTableViewCell.h */,
+				FR_400952142106 /* STPShippingMethodTableViewCell.m */,
+				FR_354572980175 /* STPSource.m */,
+				FR_185441073186 /* STPSource+Private.h */,
+				FR_361180168062 /* STPSourceCardDetails.m */,
+				FR_258423055020 /* STPSourceCardDetails+Private.h */,
+				FR_244673885284 /* STPSourceOwner.m */,
+				FR_232273873872 /* STPSourceParams.m */,
+				FR_488522868567 /* STPSourceParams+Private.h */,
+				FR_486050354264 /* STPSourcePoller.h */,
+				FR_227746174149 /* STPSourcePoller.m */,
+				FR_748789438654 /* STPSourceReceiver.m */,
+				FR_248552697129 /* STPSourceRedirect.m */,
+				FR_725221541400 /* STPSourceRedirect+Private.h */,
+				FR_641806051736 /* STPSourceSEPADebitDetails.m */,
+				FR_537691850882 /* STPSourceVerification.m */,
+				FR_849113673423 /* STPSourceVerification+Private.h */,
+				FR_306785741455 /* STPStringUtils.h */,
+				FR_304125809938 /* STPStringUtils.m */,
+				FR_437241804723 /* STPSwitchTableViewCell.h */,
+				FR_319823595011 /* STPSwitchTableViewCell.m */,
+				FR_529472279870 /* STPTelemetryClient.h */,
+				FR_608836942526 /* STPTelemetryClient.m */,
+				FR_345350465673 /* STPTheme.m */,
+				FR_533629523548 /* STPToken.m */,
+				FR_391364783044 /* STPURLCallbackHandler.h */,
+				FR_920585382813 /* STPURLCallbackHandler.m */,
+				FR_121783217597 /* STPUserInformation.m */,
+				FR_165031089231 /* STPValidatedTextField.h */,
+				FR_296070546472 /* STPValidatedTextField.m */,
+				FR_970407844810 /* STPWeakStrongMacros.h */,
+				FR_173522648416 /* StripeError.m */,
+				FR_726301448942 /* UIBarButtonItem+Stripe.h */,
+				FR_571144748643 /* UIBarButtonItem+Stripe.m */,
+				FR_338459165423 /* UIImage+Stripe.h */,
+				FR_893676537074 /* UIImage+Stripe.m */,
+				FR_444167311156 /* UINavigationBar+Stripe_Theme.m */,
+				FR_842462552754 /* UINavigationController+Stripe_Completion.h */,
+				FR_346528843102 /* UINavigationController+Stripe_Completion.m */,
+				FR_394762242749 /* UITableViewCell+Stripe_Borders.h */,
+				FR_594028262377 /* UITableViewCell+Stripe_Borders.m */,
+				FR_439756482345 /* UIToolbar+Stripe_InputAccessory.h */,
+				FR_671973988729 /* UIToolbar+Stripe_InputAccessory.m */,
+				FR_274948360570 /* UIView+Stripe_FirstResponder.h */,
+				FR_138052789861 /* UIView+Stripe_FirstResponder.m */,
+				FR_253547440632 /* UIView+Stripe_SafeAreaBounds.h */,
+				FR_733844630235 /* UIView+Stripe_SafeAreaBounds.m */,
+				FR_209653977955 /* UIViewController+Stripe_KeyboardAvoiding.h */,
+				FR_486189815482 /* UIViewController+Stripe_KeyboardAvoiding.m */,
+				FR_246469422063 /* UIViewController+Stripe_NavigationItemProxy.h */,
+				FR_195771909498 /* UIViewController+Stripe_NavigationItemProxy.m */,
+				FR_806941639685 /* UIViewController+Stripe_ParentViewController.h */,
+				FR_744031881443 /* UIViewController+Stripe_ParentViewController.m */,
+				FR_742405757158 /* UIViewController+Stripe_Promises.h */,
+				FR_747618226391 /* UIViewController+Stripe_Promises.m */,
+				G_8266918551917 /* PublicHeaders */,
+				G_4665374629057 /* Resources */,
+			);
+			path = Stripe;
+			sourceTree = "<group>";
+		};
+		G_8165188630291 /* StringsExtension */ = {
+			isa = PBXGroup;
+			children = (
+				G_3441691416939 /* Resources */,
+				G_5692944991033 /* Sources */,
+			);
+			path = StringsExtension;
+			sourceTree = "<group>";
+		};
+		G_8174493743338 /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				G_7425218360814 /* Public */,
+			);
+			path = Headers;
+			sourceTree = "<group>";
+		};
+		G_8266918551917 /* PublicHeaders */ = {
+			isa = PBXGroup;
+			children = (
+				FR_351480681724 /* FauxPasAnnotations.h */,
+				FR_443174613397 /* STPAddCardViewController.h */,
+				FR_854164364230 /* STPAddress.h */,
+				FR_780541414116 /* STPAPIClient.h */,
+				FR_771482279297 /* STPAPIClient+ApplePay.h */,
+				FR_333437850711 /* STPAPIResponseDecodable.h */,
+				FR_195448006827 /* STPApplePayPaymentMethod.h */,
+				FR_488043227274 /* STPBackendAPIAdapter.h */,
+				FR_130722653257 /* STPBankAccount.h */,
+				FR_176432501039 /* STPBankAccountParams.h */,
+				FR_448226038197 /* STPBlocks.h */,
+				FR_875786652607 /* STPCard.h */,
+				FR_905481250877 /* STPCardBrand.h */,
+				FR_251987009335 /* STPCardParams.h */,
+				FR_581486754320 /* STPCardValidationState.h */,
+				FR_812459734000 /* STPCardValidator.h */,
+				FR_714439942917 /* STPConnectAccountParams.h */,
+				FR_646482828278 /* STPCoreScrollViewController.h */,
+				FR_429558583380 /* STPCoreTableViewController.h */,
+				FR_719405050763 /* STPCoreViewController.h */,
+				FR_901703376767 /* STPCustomer.h */,
+				FR_196237328163 /* STPCustomerContext.h */,
+				FR_487939169679 /* STPEphemeralKeyProvider.h */,
+				FR_806162094116 /* STPFile.h */,
+				FR_871667522712 /* STPFormEncodable.h */,
+				FR_646448954976 /* STPImageLibrary.h */,
+				FR_262706035702 /* STPLegalEntityParams.h */,
+				FR_456888694968 /* STPPaymentActivityIndicatorView.h */,
+				FR_508532188928 /* STPPaymentCardTextField.h */,
+				FR_786390752320 /* STPPaymentConfiguration.h */,
+				FR_462669009401 /* STPPaymentContext.h */,
+				FR_368419140898 /* STPPaymentMethod.h */,
+				FR_279172722993 /* STPPaymentMethodsViewController.h */,
+				FR_606702039249 /* STPPaymentResult.h */,
+				FR_601051940933 /* STPRedirectContext.h */,
+				FR_377768318972 /* STPShippingAddressViewController.h */,
+				FR_658088880964 /* STPSource.h */,
+				FR_131673468586 /* STPSourceCardDetails.h */,
+				FR_897018280740 /* STPSourceEnums.h */,
+				FR_715803299424 /* STPSourceOwner.h */,
+				FR_842477165671 /* STPSourceParams.h */,
+				FR_187614841027 /* STPSourceProtocol.h */,
+				FR_298150824334 /* STPSourceReceiver.h */,
+				FR_823291178367 /* STPSourceRedirect.h */,
+				FR_232158185953 /* STPSourceSEPADebitDetails.h */,
+				FR_175105183886 /* STPSourceVerification.h */,
+				FR_915031944710 /* STPTheme.h */,
+				FR_532052830250 /* STPToken.h */,
+				FR_794743392604 /* STPUserInformation.h */,
+				FR_757308223899 /* Stripe.h */,
+				FR_445616536231 /* StripeError.h */,
+				FR_872390854429 /* UINavigationBar+Stripe_Theme.h */,
+			);
+			path = PublicHeaders;
+			sourceTree = "<group>";
+		};
+		G_8805533164259 /* HeaderLib */ = {
+			isa = PBXGroup;
+			children = (
+				FR_728732702136 /* HeaderLib.hpp */,
+			);
+			path = HeaderLib;
+			sourceTree = "<group>";
+		};
+		G_9112094555453 /* Images */ = {
+			isa = PBXGroup;
+			children = (
+				FR_152702596118 /* stp_card_amex_template.png */,
+				FR_155216169727 /* stp_card_amex_template@2x.png */,
+				FR_888354852550 /* stp_card_amex_template@3x.png */,
+				FR_442182732790 /* stp_card_amex.png */,
+				FR_819003985091 /* stp_card_amex@2x.png */,
+				FR_759813942983 /* stp_card_amex@3x.png */,
+				FR_137435447838 /* stp_card_applepay.png */,
+				FR_575533640387 /* stp_card_applepay@2x.png */,
+				FR_738901483927 /* stp_card_applepay@3x.png */,
+				FR_235580276653 /* stp_card_cvc_amex.png */,
+				FR_401009960707 /* stp_card_cvc_amex@2x.png */,
+				FR_759500150446 /* stp_card_cvc_amex@3x.png */,
+				FR_136210399342 /* stp_card_cvc.png */,
+				FR_155070680239 /* stp_card_cvc@2x.png */,
+				FR_346968037020 /* stp_card_cvc@3x.png */,
+				FR_244552489410 /* stp_card_diners_template.png */,
+				FR_129901347196 /* stp_card_diners_template@2x.png */,
+				FR_279876855106 /* stp_card_diners_template@3x.png */,
+				FR_729823338412 /* stp_card_diners.png */,
+				FR_627381929349 /* stp_card_diners@2x.png */,
+				FR_276438809486 /* stp_card_diners@3x.png */,
+				FR_453308441391 /* stp_card_discover_template.png */,
+				FR_419545860786 /* stp_card_discover_template@2x.png */,
+				FR_654523445914 /* stp_card_discover_template@3x.png */,
+				FR_152009236735 /* stp_card_discover.png */,
+				FR_114970438289 /* stp_card_discover@2x.png */,
+				FR_613129380815 /* stp_card_discover@3x.png */,
+				FR_484197994638 /* stp_card_error_amex.png */,
+				FR_521763319067 /* stp_card_error_amex@2x.png */,
+				FR_266277694519 /* stp_card_error_amex@3x.png */,
+				FR_803217793216 /* stp_card_error.png */,
+				FR_622346843396 /* stp_card_error@2x.png */,
+				FR_511984329756 /* stp_card_error@3x.png */,
+				FR_211689055946 /* stp_card_form_back.png */,
+				FR_225702220465 /* stp_card_form_back@2x.png */,
+				FR_168442315296 /* stp_card_form_back@3x.png */,
+				FR_875062748093 /* stp_card_form_front.png */,
+				FR_670858721125 /* stp_card_form_front@2x.png */,
+				FR_396079641272 /* stp_card_form_front@3x.png */,
+				FR_193764108659 /* stp_card_jcb_template.png */,
+				FR_658835132655 /* stp_card_jcb_template@2x.png */,
+				FR_514487626366 /* stp_card_jcb_template@3x.png */,
+				FR_802404793893 /* stp_card_jcb.png */,
+				FR_850087254357 /* stp_card_jcb@2x.png */,
+				FR_845546175975 /* stp_card_jcb@3x.png */,
+				FR_172053165053 /* stp_card_mastercard_template.png */,
+				FR_199879867824 /* stp_card_mastercard_template@2x.png */,
+				FR_207425658966 /* stp_card_mastercard_template@3x.png */,
+				FR_385170037705 /* stp_card_mastercard.png */,
+				FR_365735314709 /* stp_card_mastercard@2x.png */,
+				FR_871811812819 /* stp_card_mastercard@3x.png */,
+				FR_903389206028 /* stp_card_unionpay_en.png */,
+				FR_721965906259 /* stp_card_unionpay_en@2x.png */,
+				FR_157313604927 /* stp_card_unionpay_en@3x.png */,
+				FR_288246765774 /* stp_card_unionpay_template_en.png */,
+				FR_850832029853 /* stp_card_unionpay_template_en@2x.png */,
+				FR_187515162480 /* stp_card_unionpay_template_en@3x.png */,
+				FR_214532835490 /* stp_card_unionpay_template_zh.png */,
+				FR_730057302106 /* stp_card_unionpay_template_zh@2x.png */,
+				FR_857085055871 /* stp_card_unionpay_template_zh@3x.png */,
+				FR_725419030615 /* stp_card_unionpay_zh.png */,
+				FR_575113983346 /* stp_card_unionpay_zh@2x.png */,
+				FR_331262609749 /* stp_card_unionpay_zh@3x.png */,
+				FR_105312376394 /* stp_card_unknown.png */,
+				FR_712193767199 /* stp_card_unknown@2x.png */,
+				FR_521388462865 /* stp_card_unknown@3x.png */,
+				FR_826786322062 /* stp_card_visa_template.png */,
+				FR_309931703660 /* stp_card_visa_template@2x.png */,
+				FR_603413644505 /* stp_card_visa_template@3x.png */,
+				FR_222145928215 /* stp_card_visa.png */,
+				FR_751267158973 /* stp_card_visa@2x.png */,
+				FR_362145144513 /* stp_card_visa@3x.png */,
+				FR_714158383804 /* stp_icon_add.png */,
+				FR_572570595015 /* stp_icon_add@2x.png */,
+				FR_853994749600 /* stp_icon_add@3x.png */,
+				FR_899762404898 /* stp_icon_checkmark.png */,
+				FR_243638250146 /* stp_icon_checkmark@2x.png */,
+				FR_108219390614 /* stp_icon_checkmark@3x.png */,
+				FR_650327201175 /* stp_shipping_form.png */,
+				FR_711764376983 /* stp_shipping_form@2x.png */,
+				FR_711215481061 /* stp_shipping_form@3x.png */,
+				FR_492186305663 /* stp_test_upload_image.jpeg */,
+			);
+			path = Images;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXLegacyTarget section */
-		LT_279102286816 /* GeneratedFiles */ = {
-			isa = PBXLegacyTarget;
-			buildArgumentsString = "-c '[[ \"$(ACTION)\" == \"clean\" ]] && (__PWD__/sample/UrlGet/tools/bazelwrapper clean) || (__PWD__/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/retry.sh __PWD__/sample/UrlGet/tools/bazelwrapper build --experimental_show_artifacts //ios-app:GeneratedSource //UrlGet.xcodeproj/XCHammerAssets:ios-app-strings-extension_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-ios-app_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-share-extension_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-siri-extension_entitlements)'";
-			buildConfigurationList = CL_279102286816 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */;
-			buildPhases = (
-				SBP_27910228681 /* Sources */,
-			);
-			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/UrlGet;
-			dependencies = (
-			);
-			name = GeneratedFiles;
-			passBuildSettingsInEnvironment = 1;
-			productName = GeneratedFiles;
-		};
-		LT_375541906091 /* ResetLLDBInit */ = {
+		LT_308849640290 /* ResetLLDBInit */ = {
 			isa = PBXLegacyTarget;
 			buildArgumentsString = "-c 'echo \"settings clear target.source-map\" > ~/.lldbinit-tulsiproj'";
-			buildConfigurationList = CL_375541906091 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */;
+			buildConfigurationList = CL_308849640290 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */;
 			buildPhases = (
-				SBP_37554190609 /* Sources */,
+				SBP_30884964029 /* Sources */,
 			);
 			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/UrlGet;
+			buildWorkingDirectory = "__PWD__/sample/UrlGet";
 			dependencies = (
 			);
 			name = ResetLLDBInit;
 			passBuildSettingsInEnvironment = 1;
 			productName = ResetLLDBInit;
 		};
-		LT_766195758934 /* UpdateXcodeProject */ = {
+		LT_503688096250 /* GeneratedFiles */ = {
 			isa = PBXLegacyTarget;
-			buildArgumentsString = "-c __PWD__/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/updateXcodeProj.sh";
-			buildConfigurationList = CL_766195758934 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */;
+			buildArgumentsString = "-c '[[ \"$(ACTION)\" == \"clean\" ]] && (__PWD__/sample/UrlGet/tools/bazelwrapper clean) || (__PWD__/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/retry.sh __PWD__/sample/UrlGet/tools/bazelwrapper build --experimental_show_artifacts //ios-app:GeneratedSource //UrlGet.xcodeproj/XCHammerAssets:ios-app-strings-extension_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-siri-extension_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-share-extension_entitlements //UrlGet.xcodeproj/XCHammerAssets:ios-app-ios-app_entitlements)'";
+			buildConfigurationList = CL_503688096250 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */;
 			buildPhases = (
-				SBP_76619575893 /* Sources */,
+				SBP_50368809625 /* Sources */,
 			);
 			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/UrlGet;
+			buildWorkingDirectory = "__PWD__/sample/UrlGet";
+			dependencies = (
+			);
+			name = GeneratedFiles;
+			passBuildSettingsInEnvironment = 1;
+			productName = GeneratedFiles;
+		};
+		LT_637681236190 /* UpdateXcodeProject */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "-c __PWD__/sample/UrlGet/UrlGet.xcodeproj/XCHammerAssets/updateXcodeProj.sh";
+			buildConfigurationList = CL_637681236190 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */;
+			buildPhases = (
+				SBP_63768123619 /* Sources */,
+			);
+			buildToolPath = /bin/bash;
+			buildWorkingDirectory = "__PWD__/sample/UrlGet";
 			dependencies = (
 			);
 			name = UpdateXcodeProject;
@@ -2197,384 +2199,30 @@
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
-		NT_101452471709 /* UITests */ = {
+		NT_132248253085 /* UnitTestsWithHost */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_101452471709 /* Build configuration list for PBXNativeTarget "UITests" */;
+			buildConfigurationList = CL_132248253085 /* Build configuration list for PBXNativeTarget "UnitTestsWithHost" */;
 			buildPhases = (
-				SBP_10145247170 /* Sources */,
-				RBP_10145247170 /* Resources */,
-				FBP_10145247170 /* Frameworks */,
+				SBP_13224825308 /* Sources */,
+				RBP_13224825308 /* Resources */,
+				FBP_13224825308 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				TD_354942992784 /* PBXTargetDependency */,
-			);
-			name = UITests;
-			productName = UITests;
-			productReference = FR_101452471709 /* UITests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		NT_114615400230 /* ios-ext-bin */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_114615400230 /* Build configuration list for PBXNativeTarget "ios-ext-bin" */;
-			buildPhases = (
-				SBP_11461540023 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ios-ext-bin";
-			productName = "ios-ext-bin";
-			productReference = FR_114615400230 /* ios-ext-bin.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_135115533237 /* PINOperation-ios-9.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_135115533237 /* Build configuration list for PBXNativeTarget "PINOperation-ios-9.0" */;
-			buildPhases = (
-				SBP_13511553323 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "PINOperation-ios-9.0";
-			productName = "PINOperation-ios-9.0";
-			productReference = FR_135115533237 /* PINOperation-ios-9.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_210478864884 /* ios-app */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_210478864884 /* Build configuration list for PBXNativeTarget "ios-app" */;
-			buildPhases = (
-				SBP_21047886488 /* Sources */,
-				RBP_21047886488 /* Resources */,
-				FBP_21047886488 /* Frameworks */,
-				CFBP_1086377483 /* Embed App Extensions */,
-				SSBP_6816104382 /* Process IPA */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_263965622171 /* PBXTargetDependency */,
-				TD_121281603735 /* PBXTargetDependency */,
-				TD_770656248467 /* PBXTargetDependency */,
-			);
-			name = "ios-app";
-			productName = "ios-app";
-			productReference = FR_210478864884 /* ios-app.app */;
-			productType = "com.apple.product-type.application";
-		};
-		NT_273923590342 /* ios-app-bin-ios-12.0-Bazel */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_273923590342 /* Build configuration list for PBXNativeTarget "ios-app-bin-ios-12.0-Bazel" */;
-			buildPhases = (
-				SSBP_4161717325 /* Bazel build */,
-				SBP_27392359034 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ios-app-bin-ios-12.0-Bazel";
-			productName = "ios-app-bin-ios-12.0-Bazel";
-			productReference = FR_273923590342 /* ios-app-bin-ios-12.0-Bazel.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_363951351315 /* UnitTestsWithHost */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_363951351315 /* Build configuration list for PBXNativeTarget "UnitTestsWithHost" */;
-			buildPhases = (
-				SBP_36395135131 /* Sources */,
-				RBP_36395135131 /* Resources */,
-				FBP_36395135131 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				TD_406283096221 /* PBXTargetDependency */,
+				TD_774091882821 /* PBXTargetDependency */,
 			);
 			name = UnitTestsWithHost;
 			productName = UnitTestsWithHost;
-			productReference = FR_363951351315 /* UnitTestsWithHost.xctest */;
+			productReference = FR_132248253085 /* UnitTestsWithHost.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		NT_404433001070 /* Stripe-ios-9.0 */ = {
+		NT_140209500333 /* ios-app-bin-ios-12.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_404433001070 /* Build configuration list for PBXNativeTarget "Stripe-ios-9.0" */;
+			buildConfigurationList = CL_140209500333 /* Build configuration list for PBXNativeTarget "ios-app-bin-ios-12.0" */;
 			buildPhases = (
-				SBP_40443300107 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Stripe-ios-9.0";
-			productName = "Stripe-ios-9.0";
-			productReference = FR_404433001070 /* Stripe-ios-9.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_406521029219 /* share-extension */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_406521029219 /* Build configuration list for PBXNativeTarget "share-extension" */;
-			buildPhases = (
-				SBP_40652102921 /* Sources */,
-				RBP_40652102921 /* Resources */,
-				FBP_40652102921 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "share-extension";
-			productName = "share-extension";
-			productReference = FR_406521029219 /* share-extension.appex */;
-			productType = "com.apple.product-type.app-extension";
-		};
-		NT_409503237802 /* strings-extension */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_409503237802 /* Build configuration list for PBXNativeTarget "strings-extension" */;
-			buildPhases = (
-				SBP_40950323780 /* Sources */,
-				RBP_40950323780 /* Resources */,
-				FBP_40950323780 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "strings-extension";
-			productName = "strings-extension";
-			productReference = FR_409503237802 /* strings-extension.appex */;
-			productType = "com.apple.product-type.app-extension";
-		};
-		NT_420127068589 /* strings-ext-bin */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_420127068589 /* Build configuration list for PBXNativeTarget "strings-ext-bin" */;
-			buildPhases = (
-				SBP_42012706858 /* Sources */,
-				RBP_42012706858 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "strings-ext-bin";
-			productName = "strings-ext-bin";
-			productReference = FR_420127068589 /* strings-ext-bin.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_446505840808 /* PINCache-Core-ios-12.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_446505840808 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-12.0" */;
-			buildPhases = (
-				SBP_44650584080 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "PINCache-Core-ios-12.0";
-			productName = "PINCache-Core-ios-12.0";
-			productReference = FR_446505840808 /* PINCache-Core-ios-12.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_455050505758 /* ios-app-Bazel */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_455050505758 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */;
-			buildPhases = (
-				SSBP_4096027941 /* Bazel build */,
-				SBP_45505050575 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ios-app-Bazel";
-			productName = "ios-app-Bazel";
-			productReference = FR_455050505758 /* ios-app-Bazel.app */;
-			productType = "com.apple.product-type.application";
-		};
-		NT_515456468255 /* PINCache-Arc-exception-safe-ios-12.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_515456468255 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-12.0" */;
-			buildPhases = (
-				SBP_51545646825 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "PINCache-Arc-exception-safe-ios-12.0";
-			productName = "PINCache-Arc-exception-safe-ios-12.0";
-			productReference = FR_515456468255 /* PINCache-Arc-exception-safe-ios-12.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_540659108168 /* Stripe-Stripe_Bundle_Stripe-ios-12.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_540659108168 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-12.0" */;
-			buildPhases = (
-				SBP_54065910816 /* Sources */,
-				RBP_54065910816 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Stripe-Stripe_Bundle_Stripe-ios-12.0";
-			productName = "Stripe-Stripe_Bundle_Stripe-ios-12.0";
-			productReference = FR_540659108168 /* Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle */;
-			productType = "com.apple.product-type.bundle";
-		};
-		NT_542815357791 /* UrlGetClasses-ios-9.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_542815357791 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-9.0" */;
-			buildPhases = (
-				SBP_54281535779 /* Sources */,
-				RBP_54281535779 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "UrlGetClasses-ios-9.0";
-			productName = "UrlGetClasses-ios-9.0";
-			productReference = FR_542815357791 /* UrlGetClasses-ios-9.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_606050766824 /* UnitTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_606050766824 /* Build configuration list for PBXNativeTarget "UnitTests" */;
-			buildPhases = (
-				SBP_60605076682 /* Sources */,
-				RBP_60605076682 /* Resources */,
-				FBP_60605076682 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = UnitTests;
-			productName = UnitTests;
-			productReference = FR_606050766824 /* UnitTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		NT_623276489142 /* Stripe-ios-12.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_623276489142 /* Build configuration list for PBXNativeTarget "Stripe-ios-12.0" */;
-			buildPhases = (
-				SBP_62327648914 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Stripe-ios-12.0";
-			productName = "Stripe-ios-12.0";
-			productReference = FR_623276489142 /* Stripe-ios-12.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_629548608649 /* HeaderLib-ios-12.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_629548608649 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-12.0" */;
-			buildPhases = (
-				SBP_62954860864 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "HeaderLib-ios-12.0";
-			productName = "HeaderLib-ios-12.0";
-			productReference = FR_629548608649 /* HeaderLib-ios-12.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_645411521541 /* PINCache-Arc-exception-safe-ios-9.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_645411521541 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-9.0" */;
-			buildPhases = (
-				SBP_64541152154 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "PINCache-Arc-exception-safe-ios-9.0";
-			productName = "PINCache-Arc-exception-safe-ios-9.0";
-			productReference = FR_645411521541 /* PINCache-Arc-exception-safe-ios-9.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_682252300927 /* siri-ext-bin */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_682252300927 /* Build configuration list for PBXNativeTarget "siri-ext-bin" */;
-			buildPhases = (
-				SBP_68225230092 /* Sources */,
-				RBP_68225230092 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "siri-ext-bin";
-			productName = "siri-ext-bin";
-			productReference = FR_682252300927 /* siri-ext-bin.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_722755400736 /* Stripe-Stripe_Bundle_Stripe-ios-9.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_722755400736 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-9.0" */;
-			buildPhases = (
-				SBP_72275540073 /* Sources */,
-				RBP_72275540073 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Stripe-Stripe_Bundle_Stripe-ios-9.0";
-			productName = "Stripe-Stripe_Bundle_Stripe-ios-9.0";
-			productReference = FR_722755400736 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */;
-			productType = "com.apple.product-type.bundle";
-		};
-		NT_826359326254 /* PINCache-Core-ios-9.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_826359326254 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-9.0" */;
-			buildPhases = (
-				SBP_82635932625 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "PINCache-Core-ios-9.0";
-			productName = "PINCache-Core-ios-9.0";
-			productReference = FR_826359326254 /* PINCache-Core-ios-9.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_848652416968 /* UrlGetClasses-ios-12.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_848652416968 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-12.0" */;
-			buildPhases = (
-				SBP_84865241696 /* Sources */,
-				RBP_84865241696 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "UrlGetClasses-ios-12.0";
-			productName = "UrlGetClasses-ios-12.0";
-			productReference = FR_848652416968 /* UrlGetClasses-ios-12.0.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		NT_854342266175 /* ios-app-bin-ios-12.0 */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_854342266175 /* Build configuration list for PBXNativeTarget "ios-app-bin-ios-12.0" */;
-			buildPhases = (
-				SBP_85434226617 /* Sources */,
-				RBP_85434226617 /* Resources */,
+				SBP_14020950033 /* Sources */,
+				RBP_14020950033 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -2582,30 +2230,79 @@
 			);
 			name = "ios-app-bin-ios-12.0";
 			productName = "ios-app-bin-ios-12.0";
-			productReference = FR_854342266175 /* ios-app-bin-ios-12.0.a */;
+			productReference = FR_140209500333 /* ios-app-bin-ios-12.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		NT_856017749152 /* share-extension-Bazel */ = {
+		NT_140640746934 /* ios-app-bin-ios-12.0-Bazel */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_856017749152 /* Build configuration list for PBXNativeTarget "share-extension-Bazel" */;
+			buildConfigurationList = CL_140640746934 /* Build configuration list for PBXNativeTarget "ios-app-bin-ios-12.0-Bazel" */;
 			buildPhases = (
-				SSBP_7770823466 /* Bazel build */,
-				SBP_85601774915 /* Sources */,
+				SSBP_3638444467 /* Bazel build */,
+				SBP_14064074693 /* Sources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = "share-extension-Bazel";
-			productName = "share-extension-Bazel";
-			productReference = FR_856017749152 /* share-extension-Bazel.appex */;
+			name = "ios-app-bin-ios-12.0-Bazel";
+			productName = "ios-app-bin-ios-12.0-Bazel";
+			productReference = FR_140640746934 /* ios-app-bin-ios-12.0-Bazel.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_140931474443 /* UnitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_140931474443 /* Build configuration list for PBXNativeTarget "UnitTests" */;
+			buildPhases = (
+				SBP_14093147444 /* Sources */,
+				RBP_14093147444 /* Resources */,
+				FBP_14093147444 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = UnitTests;
+			productName = UnitTests;
+			productReference = FR_140931474443 /* UnitTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		NT_158773525708 /* Stripe-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_158773525708 /* Build configuration list for PBXNativeTarget "Stripe-ios-9.0" */;
+			buildPhases = (
+				SBP_15877352570 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Stripe-ios-9.0";
+			productName = "Stripe-ios-9.0";
+			productReference = FR_158773525708 /* Stripe-ios-9.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_207408458888 /* strings-extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_207408458888 /* Build configuration list for PBXNativeTarget "strings-extension" */;
+			buildPhases = (
+				SBP_20740845888 /* Sources */,
+				RBP_20740845888 /* Resources */,
+				FBP_20740845888 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "strings-extension";
+			productName = "strings-extension";
+			productReference = FR_207408458888 /* strings-extension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
-		NT_888995822461 /* PINOperation-ios-12.0 */ = {
+		NT_273845325521 /* PINOperation-ios-12.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_888995822461 /* Build configuration list for PBXNativeTarget "PINOperation-ios-12.0" */;
+			buildConfigurationList = CL_273845325521 /* Build configuration list for PBXNativeTarget "PINOperation-ios-12.0" */;
 			buildPhases = (
-				SBP_88899582246 /* Sources */,
+				SBP_27384532552 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -2613,14 +2310,118 @@
 			);
 			name = "PINOperation-ios-12.0";
 			productName = "PINOperation-ios-12.0";
-			productReference = FR_888995822461 /* PINOperation-ios-12.0.a */;
+			productReference = FR_273845325521 /* PINOperation-ios-12.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		NT_903524758896 /* HeaderLib-ios-9.0 */ = {
+		NT_275539566864 /* Stripe-Stripe_Bundle_Stripe-ios-12.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_903524758896 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-9.0" */;
+			buildConfigurationList = CL_275539566864 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-12.0" */;
 			buildPhases = (
-				SBP_90352475889 /* Sources */,
+				SBP_27553956686 /* Sources */,
+				RBP_27553956686 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Stripe-Stripe_Bundle_Stripe-ios-12.0";
+			productName = "Stripe-Stripe_Bundle_Stripe-ios-12.0";
+			productReference = FR_275539566864 /* Stripe-Stripe_Bundle_Stripe-ios-12.0.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		NT_339590863894 /* share-extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_339590863894 /* Build configuration list for PBXNativeTarget "share-extension" */;
+			buildPhases = (
+				SBP_33959086389 /* Sources */,
+				RBP_33959086389 /* Resources */,
+				FBP_33959086389 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "share-extension";
+			productName = "share-extension";
+			productReference = FR_339590863894 /* share-extension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		NT_393790783742 /* ios-app */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_393790783742 /* Build configuration list for PBXNativeTarget "ios-app" */;
+			buildPhases = (
+				SBP_39379078374 /* Sources */,
+				RBP_39379078374 /* Resources */,
+				FBP_39379078374 /* Frameworks */,
+				CFBP_4729140647 /* Embed App Extensions */,
+				SSBP_4217667215 /* Process IPA */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TD_233991864906 /* PBXTargetDependency */,
+				TD_696565615504 /* PBXTargetDependency */,
+				TD_436368260124 /* PBXTargetDependency */,
+			);
+			name = "ios-app";
+			productName = "ios-app";
+			productReference = FR_393790783742 /* ios-app.app */;
+			productType = "com.apple.product-type.application";
+		};
+		NT_413571327928 /* UITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_413571327928 /* Build configuration list for PBXNativeTarget "UITests" */;
+			buildPhases = (
+				SBP_41357132792 /* Sources */,
+				RBP_41357132792 /* Resources */,
+				FBP_41357132792 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TD_207516869133 /* PBXTargetDependency */,
+			);
+			name = UITests;
+			productName = UITests;
+			productReference = FR_413571327928 /* UITests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		NT_426131539244 /* PINOperation-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_426131539244 /* Build configuration list for PBXNativeTarget "PINOperation-ios-9.0" */;
+			buildPhases = (
+				SBP_42613153924 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINOperation-ios-9.0";
+			productName = "PINOperation-ios-9.0";
+			productReference = FR_426131539244 /* PINOperation-ios-9.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_442378964830 /* UrlGetClasses-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_442378964830 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-9.0" */;
+			buildPhases = (
+				SBP_44237896483 /* Sources */,
+				RBP_44237896483 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "UrlGetClasses-ios-9.0";
+			productName = "UrlGetClasses-ios-9.0";
+			productReference = FR_442378964830 /* UrlGetClasses-ios-9.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_490180650504 /* HeaderLib-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_490180650504 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-9.0" */;
+			buildPhases = (
+				SBP_49018065050 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -2628,16 +2429,217 @@
 			);
 			name = "HeaderLib-ios-9.0";
 			productName = "HeaderLib-ios-9.0";
-			productReference = FR_903524758896 /* HeaderLib-ios-9.0.a */;
+			productReference = FR_490180650504 /* HeaderLib-ios-9.0.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		NT_954961411422 /* siri-extension */ = {
+		NT_500728372472 /* UrlGetClasses-ios-12.0 */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_954961411422 /* Build configuration list for PBXNativeTarget "siri-extension" */;
+			buildConfigurationList = CL_500728372472 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-12.0" */;
 			buildPhases = (
-				SBP_95496141142 /* Sources */,
-				RBP_95496141142 /* Resources */,
-				FBP_95496141142 /* Frameworks */,
+				SBP_50072837247 /* Sources */,
+				RBP_50072837247 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "UrlGetClasses-ios-12.0";
+			productName = "UrlGetClasses-ios-12.0";
+			productReference = FR_500728372472 /* UrlGetClasses-ios-12.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_521258380702 /* ios-app-Bazel */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_521258380702 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */;
+			buildPhases = (
+				SSBP_6155116519 /* Bazel build */,
+				SBP_52125838070 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ios-app-Bazel";
+			productName = "ios-app-Bazel";
+			productReference = FR_521258380702 /* ios-app-Bazel.app */;
+			productType = "com.apple.product-type.application";
+		};
+		NT_538821595566 /* ios-ext-bin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_538821595566 /* Build configuration list for PBXNativeTarget "ios-ext-bin" */;
+			buildPhases = (
+				SBP_53882159556 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ios-ext-bin";
+			productName = "ios-ext-bin";
+			productReference = FR_538821595566 /* ios-ext-bin.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_561293049977 /* PINCache-Core-ios-12.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_561293049977 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-12.0" */;
+			buildPhases = (
+				SBP_56129304997 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINCache-Core-ios-12.0";
+			productName = "PINCache-Core-ios-12.0";
+			productReference = FR_561293049977 /* PINCache-Core-ios-12.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_617004790111 /* strings-ext-bin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_617004790111 /* Build configuration list for PBXNativeTarget "strings-ext-bin" */;
+			buildPhases = (
+				SBP_61700479011 /* Sources */,
+				RBP_61700479011 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "strings-ext-bin";
+			productName = "strings-ext-bin";
+			productReference = FR_617004790111 /* strings-ext-bin.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_643129213697 /* siri-ext-bin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_643129213697 /* Build configuration list for PBXNativeTarget "siri-ext-bin" */;
+			buildPhases = (
+				SBP_64312921369 /* Sources */,
+				RBP_64312921369 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "siri-ext-bin";
+			productName = "siri-ext-bin";
+			productReference = FR_643129213697 /* siri-ext-bin.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_655065637744 /* Stripe-Stripe_Bundle_Stripe-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_655065637744 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-9.0" */;
+			buildPhases = (
+				SBP_65506563774 /* Sources */,
+				RBP_65506563774 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Stripe-Stripe_Bundle_Stripe-ios-9.0";
+			productName = "Stripe-Stripe_Bundle_Stripe-ios-9.0";
+			productReference = FR_655065637744 /* Stripe-Stripe_Bundle_Stripe-ios-9.0.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		NT_708974059261 /* Stripe-ios-12.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_708974059261 /* Build configuration list for PBXNativeTarget "Stripe-ios-12.0" */;
+			buildPhases = (
+				SBP_70897405926 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Stripe-ios-12.0";
+			productName = "Stripe-ios-12.0";
+			productReference = FR_708974059261 /* Stripe-ios-12.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_729056130422 /* HeaderLib-ios-12.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_729056130422 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-12.0" */;
+			buildPhases = (
+				SBP_72905613042 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "HeaderLib-ios-12.0";
+			productName = "HeaderLib-ios-12.0";
+			productReference = FR_729056130422 /* HeaderLib-ios-12.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_765731174060 /* PINCache-Arc-exception-safe-ios-12.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_765731174060 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-12.0" */;
+			buildPhases = (
+				SBP_76573117406 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINCache-Arc-exception-safe-ios-12.0";
+			productName = "PINCache-Arc-exception-safe-ios-12.0";
+			productReference = FR_765731174060 /* PINCache-Arc-exception-safe-ios-12.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_852796935086 /* PINCache-Arc-exception-safe-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_852796935086 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-9.0" */;
+			buildPhases = (
+				SBP_85279693508 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINCache-Arc-exception-safe-ios-9.0";
+			productName = "PINCache-Arc-exception-safe-ios-9.0";
+			productReference = FR_852796935086 /* PINCache-Arc-exception-safe-ios-9.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_891271893429 /* share-extension-Bazel */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_891271893429 /* Build configuration list for PBXNativeTarget "share-extension-Bazel" */;
+			buildPhases = (
+				SSBP_4596240311 /* Bazel build */,
+				SBP_89127189342 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "share-extension-Bazel";
+			productName = "share-extension-Bazel";
+			productReference = FR_891271893429 /* share-extension-Bazel.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		NT_896024321091 /* PINCache-Core-ios-9.0 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_896024321091 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-9.0" */;
+			buildPhases = (
+				SBP_89602432109 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "PINCache-Core-ios-9.0";
+			productName = "PINCache-Core-ios-9.0";
+			productReference = FR_896024321091 /* PINCache-Core-ios-9.0.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		NT_907005147347 /* siri-extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_907005147347 /* Build configuration list for PBXNativeTarget "siri-extension" */;
+			buildPhases = (
+				SBP_90700514734 /* Sources */,
+				RBP_90700514734 /* Resources */,
+				FBP_90700514734 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2645,104 +2647,104 @@
 			);
 			name = "siri-extension";
 			productName = "siri-extension";
-			productReference = FR_954961411422 /* siri-extension.appex */;
+			productReference = FR_907005147347 /* siri-extension.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		P_5006007611764 /* Project object */ = {
+		P_3308596046809 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0930;
 				TargetAttributes = {
-					NT_101452471709 = {
+					NT_132248253085 = {
 						ProvisioningStyle = manual;
 					};
-					NT_114615400230 = {
+					NT_140209500333 = {
 						ProvisioningStyle = manual;
 					};
-					NT_135115533237 = {
+					NT_140640746934 = {
 						ProvisioningStyle = manual;
 					};
-					NT_210478864884 = {
+					NT_140931474443 = {
 						ProvisioningStyle = manual;
 					};
-					NT_273923590342 = {
+					NT_158773525708 = {
 						ProvisioningStyle = manual;
 					};
-					NT_363951351315 = {
+					NT_207408458888 = {
 						ProvisioningStyle = manual;
 					};
-					NT_404433001070 = {
+					NT_273845325521 = {
 						ProvisioningStyle = manual;
 					};
-					NT_406521029219 = {
+					NT_275539566864 = {
 						ProvisioningStyle = manual;
 					};
-					NT_409503237802 = {
+					NT_339590863894 = {
 						ProvisioningStyle = manual;
 					};
-					NT_420127068589 = {
+					NT_393790783742 = {
 						ProvisioningStyle = manual;
 					};
-					NT_446505840808 = {
+					NT_413571327928 = {
 						ProvisioningStyle = manual;
 					};
-					NT_455050505758 = {
+					NT_426131539244 = {
 						ProvisioningStyle = manual;
 					};
-					NT_515456468255 = {
+					NT_442378964830 = {
 						ProvisioningStyle = manual;
 					};
-					NT_540659108168 = {
+					NT_490180650504 = {
 						ProvisioningStyle = manual;
 					};
-					NT_542815357791 = {
+					NT_500728372472 = {
 						ProvisioningStyle = manual;
 					};
-					NT_606050766824 = {
+					NT_521258380702 = {
 						ProvisioningStyle = manual;
 					};
-					NT_623276489142 = {
+					NT_538821595566 = {
 						ProvisioningStyle = manual;
 					};
-					NT_629548608649 = {
+					NT_561293049977 = {
 						ProvisioningStyle = manual;
 					};
-					NT_645411521541 = {
+					NT_617004790111 = {
 						ProvisioningStyle = manual;
 					};
-					NT_682252300927 = {
+					NT_643129213697 = {
 						ProvisioningStyle = manual;
 					};
-					NT_722755400736 = {
+					NT_655065637744 = {
 						ProvisioningStyle = manual;
 					};
-					NT_826359326254 = {
+					NT_708974059261 = {
 						ProvisioningStyle = manual;
 					};
-					NT_848652416968 = {
+					NT_729056130422 = {
 						ProvisioningStyle = manual;
 					};
-					NT_854342266175 = {
+					NT_765731174060 = {
 						ProvisioningStyle = manual;
 					};
-					NT_856017749152 = {
+					NT_852796935086 = {
 						ProvisioningStyle = manual;
 					};
-					NT_888995822461 = {
+					NT_891271893429 = {
 						ProvisioningStyle = manual;
 					};
-					NT_903524758896 = {
+					NT_896024321091 = {
 						ProvisioningStyle = manual;
 					};
-					NT_954961411422 = {
+					NT_907005147347 = {
 						ProvisioningStyle = manual;
 					};
 				};
 			};
-			buildConfigurationList = CL_500600761176 /* Build configuration list for PBXProject "UrlGet" */;
+			buildConfigurationList = CL_330859604680 /* Build configuration list for PBXProject "UrlGet" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
@@ -2761,349 +2763,335 @@
 				"zh-Hans",
 				"zh-Hant",
 			);
-			mainGroup = G_6855430150171;
+			mainGroup = G_2744151723622;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				LT_279102286816 /* GeneratedFiles */,
-				NT_629548608649 /* HeaderLib-ios-12.0 */,
-				NT_903524758896 /* HeaderLib-ios-9.0 */,
-				NT_515456468255 /* PINCache-Arc-exception-safe-ios-12.0 */,
-				NT_645411521541 /* PINCache-Arc-exception-safe-ios-9.0 */,
-				NT_446505840808 /* PINCache-Core-ios-12.0 */,
-				NT_826359326254 /* PINCache-Core-ios-9.0 */,
-				NT_888995822461 /* PINOperation-ios-12.0 */,
-				NT_135115533237 /* PINOperation-ios-9.0 */,
-				LT_375541906091 /* ResetLLDBInit */,
-				NT_540659108168 /* Stripe-Stripe_Bundle_Stripe-ios-12.0 */,
-				NT_722755400736 /* Stripe-Stripe_Bundle_Stripe-ios-9.0 */,
-				NT_623276489142 /* Stripe-ios-12.0 */,
-				NT_404433001070 /* Stripe-ios-9.0 */,
-				NT_101452471709 /* UITests */,
-				NT_606050766824 /* UnitTests */,
-				NT_363951351315 /* UnitTestsWithHost */,
-				LT_766195758934 /* UpdateXcodeProject */,
-				NT_848652416968 /* UrlGetClasses-ios-12.0 */,
-				NT_542815357791 /* UrlGetClasses-ios-9.0 */,
-				NT_210478864884 /* ios-app */,
-				NT_455050505758 /* ios-app-Bazel */,
-				NT_854342266175 /* ios-app-bin-ios-12.0 */,
-				NT_273923590342 /* ios-app-bin-ios-12.0-Bazel */,
-				NT_114615400230 /* ios-ext-bin */,
-				NT_406521029219 /* share-extension */,
-				NT_856017749152 /* share-extension-Bazel */,
-				NT_682252300927 /* siri-ext-bin */,
-				NT_954961411422 /* siri-extension */,
-				NT_420127068589 /* strings-ext-bin */,
-				NT_409503237802 /* strings-extension */,
+				LT_503688096250 /* GeneratedFiles */,
+				NT_729056130422 /* HeaderLib-ios-12.0 */,
+				NT_490180650504 /* HeaderLib-ios-9.0 */,
+				NT_765731174060 /* PINCache-Arc-exception-safe-ios-12.0 */,
+				NT_852796935086 /* PINCache-Arc-exception-safe-ios-9.0 */,
+				NT_561293049977 /* PINCache-Core-ios-12.0 */,
+				NT_896024321091 /* PINCache-Core-ios-9.0 */,
+				NT_273845325521 /* PINOperation-ios-12.0 */,
+				NT_426131539244 /* PINOperation-ios-9.0 */,
+				LT_308849640290 /* ResetLLDBInit */,
+				NT_275539566864 /* Stripe-Stripe_Bundle_Stripe-ios-12.0 */,
+				NT_655065637744 /* Stripe-Stripe_Bundle_Stripe-ios-9.0 */,
+				NT_708974059261 /* Stripe-ios-12.0 */,
+				NT_158773525708 /* Stripe-ios-9.0 */,
+				NT_413571327928 /* UITests */,
+				NT_140931474443 /* UnitTests */,
+				NT_132248253085 /* UnitTestsWithHost */,
+				LT_637681236190 /* UpdateXcodeProject */,
+				NT_500728372472 /* UrlGetClasses-ios-12.0 */,
+				NT_442378964830 /* UrlGetClasses-ios-9.0 */,
+				NT_393790783742 /* ios-app */,
+				NT_521258380702 /* ios-app-Bazel */,
+				NT_140209500333 /* ios-app-bin-ios-12.0 */,
+				NT_140640746934 /* ios-app-bin-ios-12.0-Bazel */,
+				NT_538821595566 /* ios-ext-bin */,
+				NT_339590863894 /* share-extension */,
+				NT_891271893429 /* share-extension-Bazel */,
+				NT_643129213697 /* siri-ext-bin */,
+				NT_907005147347 /* siri-extension */,
+				NT_617004790111 /* strings-ext-bin */,
+				NT_207408458888 /* strings-extension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		RBP_10145247170 /* Resources */ = {
+		RBP_13224825308 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_601267756545 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_296620143340 /* GoogleAppIndexingResources.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_21047886488 /* Resources */ = {
+		RBP_14020950033 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_443726715225 /* GoogleAppIndexingResources.bundle in Resources */,
-				BF_330025768680 /* ShareExtension-Info.plist in Resources */,
-				BF_323276920420 /* SiriExtension-Info.plist in Resources */,
-				BF_362744602801 /* StringsExtension-Info.plist in Resources */,
-				BF_473156637785 /* UrlGet-Info.plist in Resources */,
-				BF_307183633418 /* UrlGetViewController.xib in Resources */,
+				BF_178534895222 /* GoogleAppIndexingResources.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_36395135131 /* Resources */ = {
+		RBP_14093147444 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_663064820065 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_806054835119 /* GoogleAppIndexingResources.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_40652102921 /* Resources */ = {
+		RBP_20740845888 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_567572496505 /* ShareExtension-Info.plist in Resources */,
+				BF_818659851625 /* InfoPlist.strings in Resources */,
+				BF_611121166475 /* StringsExtension-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_40950323780 /* Resources */ = {
+		RBP_27553956686 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_559739092584 /* InfoPlist.strings in Resources */,
-				BF_557360414089 /* StringsExtension-Info.plist in Resources */,
+				BF_502034129964 /* Localizable.strings in Resources */,
+				BF_130673719455 /* stp_card_amex.png in Resources */,
+				BF_495704164110 /* stp_card_amex@2x.png in Resources */,
+				BF_630893698289 /* stp_card_amex@3x.png in Resources */,
+				BF_457006557174 /* stp_card_amex_template.png in Resources */,
+				BF_441260908951 /* stp_card_amex_template@2x.png in Resources */,
+				BF_969844257432 /* stp_card_amex_template@3x.png in Resources */,
+				BF_164430738197 /* stp_card_applepay.png in Resources */,
+				BF_222668415136 /* stp_card_applepay@2x.png in Resources */,
+				BF_766680876200 /* stp_card_applepay@3x.png in Resources */,
+				BF_418648864791 /* stp_card_cvc.png in Resources */,
+				BF_597481577995 /* stp_card_cvc@2x.png in Resources */,
+				BF_734779984104 /* stp_card_cvc@3x.png in Resources */,
+				BF_228195677607 /* stp_card_cvc_amex.png in Resources */,
+				BF_270065822659 /* stp_card_cvc_amex@2x.png in Resources */,
+				BF_468441695289 /* stp_card_cvc_amex@3x.png in Resources */,
+				BF_271526159025 /* stp_card_diners.png in Resources */,
+				BF_591415951505 /* stp_card_diners@2x.png in Resources */,
+				BF_778313442450 /* stp_card_diners@3x.png in Resources */,
+				BF_425605995076 /* stp_card_diners_template.png in Resources */,
+				BF_825167454850 /* stp_card_diners_template@2x.png in Resources */,
+				BF_898558479131 /* stp_card_diners_template@3x.png in Resources */,
+				BF_764164773486 /* stp_card_discover.png in Resources */,
+				BF_555078373532 /* stp_card_discover@2x.png in Resources */,
+				BF_543099485300 /* stp_card_discover@3x.png in Resources */,
+				BF_235695427968 /* stp_card_discover_template.png in Resources */,
+				BF_864375956715 /* stp_card_discover_template@2x.png in Resources */,
+				BF_658995553344 /* stp_card_discover_template@3x.png in Resources */,
+				BF_582033751612 /* stp_card_error.png in Resources */,
+				BF_294887808906 /* stp_card_error@2x.png in Resources */,
+				BF_763269786008 /* stp_card_error@3x.png in Resources */,
+				BF_808308483783 /* stp_card_error_amex.png in Resources */,
+				BF_673837164753 /* stp_card_error_amex@2x.png in Resources */,
+				BF_230644991492 /* stp_card_error_amex@3x.png in Resources */,
+				BF_408463999523 /* stp_card_form_back.png in Resources */,
+				BF_505787559960 /* stp_card_form_back@2x.png in Resources */,
+				BF_910973356391 /* stp_card_form_back@3x.png in Resources */,
+				BF_369008538290 /* stp_card_form_front.png in Resources */,
+				BF_423791838134 /* stp_card_form_front@2x.png in Resources */,
+				BF_321919324151 /* stp_card_form_front@3x.png in Resources */,
+				BF_258022929512 /* stp_card_jcb.png in Resources */,
+				BF_107108550206 /* stp_card_jcb@2x.png in Resources */,
+				BF_103245487545 /* stp_card_jcb@3x.png in Resources */,
+				BF_599854589984 /* stp_card_jcb_template.png in Resources */,
+				BF_903940243031 /* stp_card_jcb_template@2x.png in Resources */,
+				BF_793117178537 /* stp_card_jcb_template@3x.png in Resources */,
+				BF_888076940425 /* stp_card_mastercard.png in Resources */,
+				BF_474704292690 /* stp_card_mastercard@2x.png in Resources */,
+				BF_312927315865 /* stp_card_mastercard@3x.png in Resources */,
+				BF_196950904168 /* stp_card_mastercard_template.png in Resources */,
+				BF_812076692716 /* stp_card_mastercard_template@2x.png in Resources */,
+				BF_301552859288 /* stp_card_mastercard_template@3x.png in Resources */,
+				BF_101124874614 /* stp_card_unionpay_en.png in Resources */,
+				BF_913716101615 /* stp_card_unionpay_en@2x.png in Resources */,
+				BF_669487613180 /* stp_card_unionpay_en@3x.png in Resources */,
+				BF_531955342698 /* stp_card_unionpay_template_en.png in Resources */,
+				BF_307219991943 /* stp_card_unionpay_template_en@2x.png in Resources */,
+				BF_558520883968 /* stp_card_unionpay_template_en@3x.png in Resources */,
+				BF_539727742658 /* stp_card_unionpay_template_zh.png in Resources */,
+				BF_768788420193 /* stp_card_unionpay_template_zh@2x.png in Resources */,
+				BF_248414016722 /* stp_card_unionpay_template_zh@3x.png in Resources */,
+				BF_421289082512 /* stp_card_unionpay_zh.png in Resources */,
+				BF_977546105382 /* stp_card_unionpay_zh@2x.png in Resources */,
+				BF_407054767379 /* stp_card_unionpay_zh@3x.png in Resources */,
+				BF_114850185058 /* stp_card_unknown.png in Resources */,
+				BF_113413991490 /* stp_card_unknown@2x.png in Resources */,
+				BF_727849743157 /* stp_card_unknown@3x.png in Resources */,
+				BF_638767995750 /* stp_card_visa.png in Resources */,
+				BF_843924727945 /* stp_card_visa@2x.png in Resources */,
+				BF_260924159513 /* stp_card_visa@3x.png in Resources */,
+				BF_565996804856 /* stp_card_visa_template.png in Resources */,
+				BF_393006822716 /* stp_card_visa_template@2x.png in Resources */,
+				BF_160063044439 /* stp_card_visa_template@3x.png in Resources */,
+				BF_643667811122 /* stp_icon_add.png in Resources */,
+				BF_354403598900 /* stp_icon_add@2x.png in Resources */,
+				BF_565261435797 /* stp_icon_add@3x.png in Resources */,
+				BF_133598338587 /* stp_icon_checkmark.png in Resources */,
+				BF_511180956135 /* stp_icon_checkmark@2x.png in Resources */,
+				BF_298563852136 /* stp_icon_checkmark@3x.png in Resources */,
+				BF_687037225350 /* stp_shipping_form.png in Resources */,
+				BF_309887196265 /* stp_shipping_form@2x.png in Resources */,
+				BF_679272434237 /* stp_shipping_form@3x.png in Resources */,
+				BF_890212572892 /* stp_test_upload_image.jpeg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_42012706858 /* Resources */ = {
+		RBP_33959086389 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_110522976147 /* InfoPlist.strings in Resources */,
+				BF_825771963343 /* ShareExtension-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_54065910816 /* Resources */ = {
+		RBP_39379078374 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_435735027381 /* Localizable.strings in Resources */,
-				BF_859645923890 /* stp_card_amex.png in Resources */,
-				BF_602716324569 /* stp_card_amex@2x.png in Resources */,
-				BF_203723500807 /* stp_card_amex@3x.png in Resources */,
-				BF_103972021129 /* stp_card_amex_template.png in Resources */,
-				BF_360273540863 /* stp_card_amex_template@2x.png in Resources */,
-				BF_161782666040 /* stp_card_amex_template@3x.png in Resources */,
-				BF_658466512126 /* stp_card_applepay.png in Resources */,
-				BF_741374908450 /* stp_card_applepay@2x.png in Resources */,
-				BF_733219284589 /* stp_card_applepay@3x.png in Resources */,
-				BF_453691812649 /* stp_card_cvc.png in Resources */,
-				BF_106423611096 /* stp_card_cvc@2x.png in Resources */,
-				BF_706447119810 /* stp_card_cvc@3x.png in Resources */,
-				BF_639277334305 /* stp_card_cvc_amex.png in Resources */,
-				BF_391451429517 /* stp_card_cvc_amex@2x.png in Resources */,
-				BF_399033254679 /* stp_card_cvc_amex@3x.png in Resources */,
-				BF_359338767983 /* stp_card_diners.png in Resources */,
-				BF_535598920126 /* stp_card_diners@2x.png in Resources */,
-				BF_185170820537 /* stp_card_diners@3x.png in Resources */,
-				BF_185409518232 /* stp_card_diners_template.png in Resources */,
-				BF_345683328243 /* stp_card_diners_template@2x.png in Resources */,
-				BF_712386002629 /* stp_card_diners_template@3x.png in Resources */,
-				BF_710773766335 /* stp_card_discover.png in Resources */,
-				BF_920145620820 /* stp_card_discover@2x.png in Resources */,
-				BF_310079826345 /* stp_card_discover@3x.png in Resources */,
-				BF_573302397311 /* stp_card_discover_template.png in Resources */,
-				BF_254757182188 /* stp_card_discover_template@2x.png in Resources */,
-				BF_722312549299 /* stp_card_discover_template@3x.png in Resources */,
-				BF_947884094924 /* stp_card_error.png in Resources */,
-				BF_610936690460 /* stp_card_error@2x.png in Resources */,
-				BF_700314907952 /* stp_card_error@3x.png in Resources */,
-				BF_829899373145 /* stp_card_error_amex.png in Resources */,
-				BF_859496121002 /* stp_card_error_amex@2x.png in Resources */,
-				BF_200583839276 /* stp_card_error_amex@3x.png in Resources */,
-				BF_286804362837 /* stp_card_form_back.png in Resources */,
-				BF_266049611515 /* stp_card_form_back@2x.png in Resources */,
-				BF_133980896421 /* stp_card_form_back@3x.png in Resources */,
-				BF_328297349591 /* stp_card_form_front.png in Resources */,
-				BF_552016353612 /* stp_card_form_front@2x.png in Resources */,
-				BF_846266256497 /* stp_card_form_front@3x.png in Resources */,
-				BF_273021152810 /* stp_card_jcb.png in Resources */,
-				BF_873260921632 /* stp_card_jcb@2x.png in Resources */,
-				BF_671995804046 /* stp_card_jcb@3x.png in Resources */,
-				BF_254507463991 /* stp_card_jcb_template.png in Resources */,
-				BF_851459631362 /* stp_card_jcb_template@2x.png in Resources */,
-				BF_371622710360 /* stp_card_jcb_template@3x.png in Resources */,
-				BF_761106931406 /* stp_card_mastercard.png in Resources */,
-				BF_652621184570 /* stp_card_mastercard@2x.png in Resources */,
-				BF_558017800984 /* stp_card_mastercard@3x.png in Resources */,
-				BF_317966105622 /* stp_card_mastercard_template.png in Resources */,
-				BF_699699725999 /* stp_card_mastercard_template@2x.png in Resources */,
-				BF_145626146117 /* stp_card_mastercard_template@3x.png in Resources */,
-				BF_378472485206 /* stp_card_unionpay_en.png in Resources */,
-				BF_377899036621 /* stp_card_unionpay_en@2x.png in Resources */,
-				BF_383201409239 /* stp_card_unionpay_en@3x.png in Resources */,
-				BF_288003895250 /* stp_card_unionpay_template_en.png in Resources */,
-				BF_445621345674 /* stp_card_unionpay_template_en@2x.png in Resources */,
-				BF_393274709300 /* stp_card_unionpay_template_en@3x.png in Resources */,
-				BF_218250556539 /* stp_card_unionpay_template_zh.png in Resources */,
-				BF_900665729924 /* stp_card_unionpay_template_zh@2x.png in Resources */,
-				BF_130493963595 /* stp_card_unionpay_template_zh@3x.png in Resources */,
-				BF_214492597692 /* stp_card_unionpay_zh.png in Resources */,
-				BF_114078348659 /* stp_card_unionpay_zh@2x.png in Resources */,
-				BF_996964839134 /* stp_card_unionpay_zh@3x.png in Resources */,
-				BF_821198094022 /* stp_card_unknown.png in Resources */,
-				BF_346425895454 /* stp_card_unknown@2x.png in Resources */,
-				BF_312154897338 /* stp_card_unknown@3x.png in Resources */,
-				BF_272088808996 /* stp_card_visa.png in Resources */,
-				BF_596363109123 /* stp_card_visa@2x.png in Resources */,
-				BF_448298787531 /* stp_card_visa@3x.png in Resources */,
-				BF_810836455395 /* stp_card_visa_template.png in Resources */,
-				BF_420886463516 /* stp_card_visa_template@2x.png in Resources */,
-				BF_382236950093 /* stp_card_visa_template@3x.png in Resources */,
-				BF_457839071858 /* stp_icon_add.png in Resources */,
-				BF_498738515507 /* stp_icon_add@2x.png in Resources */,
-				BF_585200305923 /* stp_icon_add@3x.png in Resources */,
-				BF_182898266867 /* stp_icon_checkmark.png in Resources */,
-				BF_668172114664 /* stp_icon_checkmark@2x.png in Resources */,
-				BF_588281487333 /* stp_icon_checkmark@3x.png in Resources */,
-				BF_335222063543 /* stp_shipping_form.png in Resources */,
-				BF_630468293679 /* stp_shipping_form@2x.png in Resources */,
-				BF_365040729130 /* stp_shipping_form@3x.png in Resources */,
-				BF_802286475739 /* stp_test_upload_image.jpeg in Resources */,
+				BF_216038054570 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_579500660081 /* ShareExtension-Info.plist in Resources */,
+				BF_790199077922 /* SiriExtension-Info.plist in Resources */,
+				BF_332204318117 /* StringsExtension-Info.plist in Resources */,
+				BF_656749250306 /* UrlGet-Info.plist in Resources */,
+				BF_550865330733 /* UrlGetViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_54281535779 /* Resources */ = {
+		RBP_41357132792 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_514959088266 /* GoogleAppIndexingResources.bundle in Resources */,
-				BF_448009883519 /* UrlGetViewController.xib in Resources */,
+				BF_172927922956 /* GoogleAppIndexingResources.bundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_60605076682 /* Resources */ = {
+		RBP_44237896483 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_868707412367 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_185178162233 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_386112719566 /* UrlGetViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_68225230092 /* Resources */ = {
+		RBP_50072837247 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_484582902622 /* AppIntentVocabulary.plist in Resources */,
+				BF_898936898595 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_159799755155 /* UrlGetViewController.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_72275540073 /* Resources */ = {
+		RBP_61700479011 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_565278633141 /* Localizable.strings in Resources */,
-				BF_899887368282 /* stp_card_amex.png in Resources */,
-				BF_709718469977 /* stp_card_amex@2x.png in Resources */,
-				BF_645395559337 /* stp_card_amex@3x.png in Resources */,
-				BF_638459995462 /* stp_card_amex_template.png in Resources */,
-				BF_375051384038 /* stp_card_amex_template@2x.png in Resources */,
-				BF_336574979229 /* stp_card_amex_template@3x.png in Resources */,
-				BF_905434179310 /* stp_card_applepay.png in Resources */,
-				BF_500001159868 /* stp_card_applepay@2x.png in Resources */,
-				BF_784420904480 /* stp_card_applepay@3x.png in Resources */,
-				BF_394185826569 /* stp_card_cvc.png in Resources */,
-				BF_579009408428 /* stp_card_cvc@2x.png in Resources */,
-				BF_786763717602 /* stp_card_cvc@3x.png in Resources */,
-				BF_291677581212 /* stp_card_cvc_amex.png in Resources */,
-				BF_644467675530 /* stp_card_cvc_amex@2x.png in Resources */,
-				BF_866343933368 /* stp_card_cvc_amex@3x.png in Resources */,
-				BF_706868895649 /* stp_card_diners.png in Resources */,
-				BF_137349614193 /* stp_card_diners@2x.png in Resources */,
-				BF_124968280406 /* stp_card_diners@3x.png in Resources */,
-				BF_304014796876 /* stp_card_diners_template.png in Resources */,
-				BF_761751358527 /* stp_card_diners_template@2x.png in Resources */,
-				BF_568575296680 /* stp_card_diners_template@3x.png in Resources */,
-				BF_525457625255 /* stp_card_discover.png in Resources */,
-				BF_868002786765 /* stp_card_discover@2x.png in Resources */,
-				BF_529013860125 /* stp_card_discover@3x.png in Resources */,
-				BF_693488309939 /* stp_card_discover_template.png in Resources */,
-				BF_523252872546 /* stp_card_discover_template@2x.png in Resources */,
-				BF_853830505770 /* stp_card_discover_template@3x.png in Resources */,
-				BF_461676883901 /* stp_card_error.png in Resources */,
-				BF_660383706439 /* stp_card_error@2x.png in Resources */,
-				BF_220363596336 /* stp_card_error@3x.png in Resources */,
-				BF_801891862929 /* stp_card_error_amex.png in Resources */,
-				BF_448636768591 /* stp_card_error_amex@2x.png in Resources */,
-				BF_447035085506 /* stp_card_error_amex@3x.png in Resources */,
-				BF_332791913550 /* stp_card_form_back.png in Resources */,
-				BF_824131982577 /* stp_card_form_back@2x.png in Resources */,
-				BF_191596099026 /* stp_card_form_back@3x.png in Resources */,
-				BF_577973896423 /* stp_card_form_front.png in Resources */,
-				BF_460201414699 /* stp_card_form_front@2x.png in Resources */,
-				BF_910956119925 /* stp_card_form_front@3x.png in Resources */,
-				BF_514064561024 /* stp_card_jcb.png in Resources */,
-				BF_821662620929 /* stp_card_jcb@2x.png in Resources */,
-				BF_658517670157 /* stp_card_jcb@3x.png in Resources */,
-				BF_918717765723 /* stp_card_jcb_template.png in Resources */,
-				BF_658661428653 /* stp_card_jcb_template@2x.png in Resources */,
-				BF_252439999853 /* stp_card_jcb_template@3x.png in Resources */,
-				BF_501540564246 /* stp_card_mastercard.png in Resources */,
-				BF_583859739891 /* stp_card_mastercard@2x.png in Resources */,
-				BF_831428181811 /* stp_card_mastercard@3x.png in Resources */,
-				BF_145004478833 /* stp_card_mastercard_template.png in Resources */,
-				BF_128649453491 /* stp_card_mastercard_template@2x.png in Resources */,
-				BF_482566846048 /* stp_card_mastercard_template@3x.png in Resources */,
-				BF_576354606459 /* stp_card_unionpay_en.png in Resources */,
-				BF_411983063613 /* stp_card_unionpay_en@2x.png in Resources */,
-				BF_564172932390 /* stp_card_unionpay_en@3x.png in Resources */,
-				BF_717229444807 /* stp_card_unionpay_template_en.png in Resources */,
-				BF_532466961533 /* stp_card_unionpay_template_en@2x.png in Resources */,
-				BF_266069324995 /* stp_card_unionpay_template_en@3x.png in Resources */,
-				BF_610234742080 /* stp_card_unionpay_template_zh.png in Resources */,
-				BF_582818177540 /* stp_card_unionpay_template_zh@2x.png in Resources */,
-				BF_608431584620 /* stp_card_unionpay_template_zh@3x.png in Resources */,
-				BF_516667793180 /* stp_card_unionpay_zh.png in Resources */,
-				BF_488584558619 /* stp_card_unionpay_zh@2x.png in Resources */,
-				BF_249679172768 /* stp_card_unionpay_zh@3x.png in Resources */,
-				BF_832762337643 /* stp_card_unknown.png in Resources */,
-				BF_298647117939 /* stp_card_unknown@2x.png in Resources */,
-				BF_124041089401 /* stp_card_unknown@3x.png in Resources */,
-				BF_636965392308 /* stp_card_visa.png in Resources */,
-				BF_895462989558 /* stp_card_visa@2x.png in Resources */,
-				BF_259990952773 /* stp_card_visa@3x.png in Resources */,
-				BF_644094008036 /* stp_card_visa_template.png in Resources */,
-				BF_341888113091 /* stp_card_visa_template@2x.png in Resources */,
-				BF_750587250854 /* stp_card_visa_template@3x.png in Resources */,
-				BF_645910526538 /* stp_icon_add.png in Resources */,
-				BF_426862576843 /* stp_icon_add@2x.png in Resources */,
-				BF_701520676613 /* stp_icon_add@3x.png in Resources */,
-				BF_541010920711 /* stp_icon_checkmark.png in Resources */,
-				BF_644208232226 /* stp_icon_checkmark@2x.png in Resources */,
-				BF_151715570365 /* stp_icon_checkmark@3x.png in Resources */,
-				BF_905923166361 /* stp_shipping_form.png in Resources */,
-				BF_735729279605 /* stp_shipping_form@2x.png in Resources */,
-				BF_390871768126 /* stp_shipping_form@3x.png in Resources */,
-				BF_811858844530 /* stp_test_upload_image.jpeg in Resources */,
+				BF_348558215255 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_84865241696 /* Resources */ = {
+		RBP_64312921369 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_165953454949 /* GoogleAppIndexingResources.bundle in Resources */,
-				BF_543588675087 /* UrlGetViewController.xib in Resources */,
+				BF_772265866226 /* AppIntentVocabulary.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_85434226617 /* Resources */ = {
+		RBP_65506563774 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_452964777174 /* GoogleAppIndexingResources.bundle in Resources */,
+				BF_785895832047 /* Localizable.strings in Resources */,
+				BF_303588280111 /* stp_card_amex.png in Resources */,
+				BF_212568242204 /* stp_card_amex@2x.png in Resources */,
+				BF_305502748954 /* stp_card_amex@3x.png in Resources */,
+				BF_647643282752 /* stp_card_amex_template.png in Resources */,
+				BF_576960597097 /* stp_card_amex_template@2x.png in Resources */,
+				BF_165600087343 /* stp_card_amex_template@3x.png in Resources */,
+				BF_750828403759 /* stp_card_applepay.png in Resources */,
+				BF_871366012321 /* stp_card_applepay@2x.png in Resources */,
+				BF_199660305922 /* stp_card_applepay@3x.png in Resources */,
+				BF_305414781984 /* stp_card_cvc.png in Resources */,
+				BF_845850210483 /* stp_card_cvc@2x.png in Resources */,
+				BF_831330403855 /* stp_card_cvc@3x.png in Resources */,
+				BF_688576102639 /* stp_card_cvc_amex.png in Resources */,
+				BF_426168367035 /* stp_card_cvc_amex@2x.png in Resources */,
+				BF_503713314754 /* stp_card_cvc_amex@3x.png in Resources */,
+				BF_168857660714 /* stp_card_diners.png in Resources */,
+				BF_108316715201 /* stp_card_diners@2x.png in Resources */,
+				BF_618672817923 /* stp_card_diners@3x.png in Resources */,
+				BF_477334483946 /* stp_card_diners_template.png in Resources */,
+				BF_647071152864 /* stp_card_diners_template@2x.png in Resources */,
+				BF_915774520596 /* stp_card_diners_template@3x.png in Resources */,
+				BF_405532512588 /* stp_card_discover.png in Resources */,
+				BF_336658452108 /* stp_card_discover@2x.png in Resources */,
+				BF_409555442064 /* stp_card_discover@3x.png in Resources */,
+				BF_177307157856 /* stp_card_discover_template.png in Resources */,
+				BF_590679607604 /* stp_card_discover_template@2x.png in Resources */,
+				BF_341917218902 /* stp_card_discover_template@3x.png in Resources */,
+				BF_320028920961 /* stp_card_error.png in Resources */,
+				BF_697350601610 /* stp_card_error@2x.png in Resources */,
+				BF_239510425645 /* stp_card_error@3x.png in Resources */,
+				BF_119645591539 /* stp_card_error_amex.png in Resources */,
+				BF_226661331092 /* stp_card_error_amex@2x.png in Resources */,
+				BF_791049119688 /* stp_card_error_amex@3x.png in Resources */,
+				BF_510438721460 /* stp_card_form_back.png in Resources */,
+				BF_619488116763 /* stp_card_form_back@2x.png in Resources */,
+				BF_714368613035 /* stp_card_form_back@3x.png in Resources */,
+				BF_324500998307 /* stp_card_form_front.png in Resources */,
+				BF_766291129155 /* stp_card_form_front@2x.png in Resources */,
+				BF_678944982147 /* stp_card_form_front@3x.png in Resources */,
+				BF_650318570904 /* stp_card_jcb.png in Resources */,
+				BF_704710779821 /* stp_card_jcb@2x.png in Resources */,
+				BF_797659011793 /* stp_card_jcb@3x.png in Resources */,
+				BF_313912264532 /* stp_card_jcb_template.png in Resources */,
+				BF_173202650643 /* stp_card_jcb_template@2x.png in Resources */,
+				BF_222528507364 /* stp_card_jcb_template@3x.png in Resources */,
+				BF_469523812575 /* stp_card_mastercard.png in Resources */,
+				BF_494156707061 /* stp_card_mastercard@2x.png in Resources */,
+				BF_896763847980 /* stp_card_mastercard@3x.png in Resources */,
+				BF_667256003443 /* stp_card_mastercard_template.png in Resources */,
+				BF_401587573828 /* stp_card_mastercard_template@2x.png in Resources */,
+				BF_410258682644 /* stp_card_mastercard_template@3x.png in Resources */,
+				BF_649315534907 /* stp_card_unionpay_en.png in Resources */,
+				BF_615973472428 /* stp_card_unionpay_en@2x.png in Resources */,
+				BF_261997361195 /* stp_card_unionpay_en@3x.png in Resources */,
+				BF_429600621564 /* stp_card_unionpay_template_en.png in Resources */,
+				BF_109258723947 /* stp_card_unionpay_template_en@2x.png in Resources */,
+				BF_451864181836 /* stp_card_unionpay_template_en@3x.png in Resources */,
+				BF_807235759265 /* stp_card_unionpay_template_zh.png in Resources */,
+				BF_539166562665 /* stp_card_unionpay_template_zh@2x.png in Resources */,
+				BF_685436250069 /* stp_card_unionpay_template_zh@3x.png in Resources */,
+				BF_879222550178 /* stp_card_unionpay_zh.png in Resources */,
+				BF_270167025452 /* stp_card_unionpay_zh@2x.png in Resources */,
+				BF_802248202837 /* stp_card_unionpay_zh@3x.png in Resources */,
+				BF_679357323097 /* stp_card_unknown.png in Resources */,
+				BF_914693708244 /* stp_card_unknown@2x.png in Resources */,
+				BF_463603276620 /* stp_card_unknown@3x.png in Resources */,
+				BF_816944651747 /* stp_card_visa.png in Resources */,
+				BF_764562302069 /* stp_card_visa@2x.png in Resources */,
+				BF_712915253604 /* stp_card_visa@3x.png in Resources */,
+				BF_330945938768 /* stp_card_visa_template.png in Resources */,
+				BF_254374484218 /* stp_card_visa_template@2x.png in Resources */,
+				BF_330933072418 /* stp_card_visa_template@3x.png in Resources */,
+				BF_843890752677 /* stp_icon_add.png in Resources */,
+				BF_192535636513 /* stp_icon_add@2x.png in Resources */,
+				BF_451757939373 /* stp_icon_add@3x.png in Resources */,
+				BF_759782369722 /* stp_icon_checkmark.png in Resources */,
+				BF_504787206920 /* stp_icon_checkmark@2x.png in Resources */,
+				BF_377593636507 /* stp_icon_checkmark@3x.png in Resources */,
+				BF_690965970870 /* stp_shipping_form.png in Resources */,
+				BF_762034813425 /* stp_shipping_form@2x.png in Resources */,
+				BF_289830003162 /* stp_shipping_form@3x.png in Resources */,
+				BF_663849778103 /* stp_test_upload_image.jpeg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		RBP_95496141142 /* Resources */ = {
+		RBP_90700514734 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_220513902077 /* AppIntentVocabulary.plist in Resources */,
-				BF_782481236915 /* SiriExtension-Info.plist in Resources */,
+				BF_208174339023 /* AppIntentVocabulary.plist in Resources */,
+				BF_238657646724 /* SiriExtension-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		SSBP_4096027941 /* Bazel build */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Bazel build";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# We want to use this for remote caching..\nexport TULSI_USE_HAMMER_DEBUG_CONFIG=\"YES\"\necho \"Customizing Bazel invocation...\"\n__PWD__/.build/debug/bazel_build.py //ios-app:ios-app --bazel __PWD__/sample/UrlGet/tools/bazelwrapper\n\n";
-		};
-		SSBP_4161717325 /* Bazel build */ = {
+		SSBP_3638444467 /* Bazel build */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3117,7 +3105,7 @@
 			shellPath = /bin/sh;
 			shellScript = "export TULSI_USE_HAMMER_DEBUG_CONFIG=YES\n__PWD__/.build/debug/bazel_build.py //ios-app:ios-app-bin --bazel __PWD__/sample/UrlGet/tools/bazelwrapper";
 		};
-		SSBP_6816104382 /* Process IPA */ = {
+		SSBP_4217667215 /* Process IPA */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3131,7 +3119,7 @@
 			shellPath = /bin/sh;
 			shellScript = "__PWD__/.build/debug/XCHammer process-ipa";
 		};
-		SSBP_7770823466 /* Bazel build */ = {
+		SSBP_4596240311 /* Bazel build */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3145,529 +3133,543 @@
 			shellPath = /bin/sh;
 			shellScript = "export TULSI_USE_HAMMER_DEBUG_CONFIG=YES\n__PWD__/.build/debug/bazel_build.py //ios-app:share-extension --bazel __PWD__/sample/UrlGet/tools/bazelwrapper";
 		};
+		SSBP_6155116519 /* Bazel build */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bazel build";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# We want to use this for remote caching..\nexport TULSI_USE_HAMMER_DEBUG_CONFIG=\"YES\"\necho \"Customizing Bazel invocation...\"\n__PWD__/.build/debug/bazel_build.py //ios-app:ios-app --bazel __PWD__/sample/UrlGet/tools/bazelwrapper\n\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		SBP_10145247170 /* Sources */ = {
+		SBP_13224825308 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_595945633108 /* Tests.m in Sources */,
-				BF_340805802640 /* Tests2.m in Sources */,
+				BF_232927852310 /* Tests.m in Sources */,
+				BF_226981093908 /* Tests2.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_11461540023 /* Sources */ = {
+		SBP_14020950033 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_634690038552 /* empty-main.m in Sources */,
+				BF_862184642948 /* Generated.m in Sources */,
+				BF_186089854896 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_13511553323 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_600862798226 /* PINOperationGroup.m in Sources */,
-				BF_326848529959 /* PINOperationQueue.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_21047886488 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_336742621962 /* Stub.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_27392359034 /* Sources */ = {
+		SBP_14064074693 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_27910228681 /* Sources */ = {
+		SBP_14093147444 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_609056729243 /* Tests.m in Sources */,
+				BF_121480881992 /* Tests2.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_15877352570 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_128971879565 /* NSArray+Stripe.m in Sources */,
+				BF_720181823145 /* NSBundle+Stripe_AppName.m in Sources */,
+				BF_575330527930 /* NSCharacterSet+Stripe.m in Sources */,
+				BF_559184343028 /* NSDecimalNumber+Stripe_Currency.m in Sources */,
+				BF_418811959052 /* NSDictionary+Stripe.m in Sources */,
+				BF_588105762560 /* NSError+Stripe.m in Sources */,
+				BF_914082541498 /* NSMutableURLRequest+Stripe.m in Sources */,
+				BF_710215877948 /* NSString+Stripe.m in Sources */,
+				BF_164915460778 /* NSURLComponents+Stripe.m in Sources */,
+				BF_219941413000 /* PKPayment+Stripe.m in Sources */,
+				BF_258237757952 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */,
+				BF_500228453026 /* STPAPIClient+ApplePay.m in Sources */,
+				BF_134442304375 /* STPAPIClient.m in Sources */,
+				BF_886743791456 /* STPAPIRequest.m in Sources */,
+				BF_672644340006 /* STPAddCardViewController.m in Sources */,
+				BF_781461712867 /* STPAddress.m in Sources */,
+				BF_305167951630 /* STPAddressFieldTableViewCell.m in Sources */,
+				BF_881482045340 /* STPAddressViewModel.m in Sources */,
+				BF_587542324291 /* STPAnalyticsClient.m in Sources */,
+				BF_610173930762 /* STPApplePayPaymentMethod.m in Sources */,
+				BF_502725164754 /* STPAspects.m in Sources */,
+				BF_543394716926 /* STPBINRange.m in Sources */,
+				BF_516695223179 /* STPBankAccount.m in Sources */,
+				BF_311988154246 /* STPBankAccountParams.m in Sources */,
+				BF_625116946688 /* STPBundleLocator.m in Sources */,
+				BF_183600234372 /* STPCard.m in Sources */,
+				BF_506585654635 /* STPCardIOProxy.m in Sources */,
+				BF_358882162875 /* STPCardParams.m in Sources */,
+				BF_791149661131 /* STPCardValidator.m in Sources */,
+				BF_142425411680 /* STPCategoryLoader.m in Sources */,
+				BF_196128104624 /* STPColorUtils.m in Sources */,
+				BF_624321049043 /* STPConnectAccountParams.m in Sources */,
+				BF_801535514152 /* STPCoreScrollViewController.m in Sources */,
+				BF_407383359390 /* STPCoreTableViewController.m in Sources */,
+				BF_673627856323 /* STPCoreViewController.m in Sources */,
+				BF_298654210237 /* STPCustomer+SourceTuple.m in Sources */,
+				BF_521717838213 /* STPCustomer.m in Sources */,
+				BF_117502561685 /* STPCustomerContext.m in Sources */,
+				BF_796065761753 /* STPDelegateProxy.m in Sources */,
+				BF_289141294143 /* STPDispatchFunctions.m in Sources */,
+				BF_412832480211 /* STPEmailAddressValidator.m in Sources */,
+				BF_319029929518 /* STPEphemeralKey.m in Sources */,
+				BF_478661797903 /* STPEphemeralKeyManager.m in Sources */,
+				BF_794697457499 /* STPFile.m in Sources */,
+				BF_627085115907 /* STPFormEncoder.m in Sources */,
+				BF_586263945370 /* STPFormTextField.m in Sources */,
+				BF_914859729409 /* STPImageLibrary.m in Sources */,
+				BF_360519124898 /* STPLegalEntityParams.m in Sources */,
+				BF_525794329434 /* STPLocalizationUtils.m in Sources */,
+				BF_740567332917 /* STPMultipartFormDataEncoder.m in Sources */,
+				BF_281523435484 /* STPMultipartFormDataPart.m in Sources */,
+				BF_857839835142 /* STPPaymentActivityIndicatorView.m in Sources */,
+				BF_201607326392 /* STPPaymentCardTextField.m in Sources */,
+				BF_207307727233 /* STPPaymentCardTextFieldCell.m in Sources */,
+				BF_147606888253 /* STPPaymentCardTextFieldViewModel.m in Sources */,
+				BF_881947175560 /* STPPaymentConfiguration.m in Sources */,
+				BF_313963402708 /* STPPaymentContext.m in Sources */,
+				BF_710837560816 /* STPPaymentContextAmountModel.m in Sources */,
+				BF_384834315673 /* STPPaymentMethodTableViewCell.m in Sources */,
+				BF_430283935178 /* STPPaymentMethodTuple.m in Sources */,
+				BF_187422130445 /* STPPaymentMethodsInternalViewController.m in Sources */,
+				BF_870862087635 /* STPPaymentMethodsViewController.m in Sources */,
+				BF_292726349028 /* STPPaymentResult.m in Sources */,
+				BF_575138512021 /* STPPhoneNumberValidator.m in Sources */,
+				BF_393120345753 /* STPPostalCodeValidator.m in Sources */,
+				BF_172899996745 /* STPPromise.m in Sources */,
+				BF_267173406940 /* STPRedirectContext.m in Sources */,
+				BF_721358360726 /* STPSectionHeaderView.m in Sources */,
+				BF_188335189101 /* STPShippingAddressViewController.m in Sources */,
+				BF_771515235132 /* STPShippingMethodTableViewCell.m in Sources */,
+				BF_679277052808 /* STPShippingMethodsViewController.m in Sources */,
+				BF_241548171115 /* STPSource.m in Sources */,
+				BF_700868733775 /* STPSourceCardDetails.m in Sources */,
+				BF_173813426925 /* STPSourceOwner.m in Sources */,
+				BF_428775638150 /* STPSourceParams.m in Sources */,
+				BF_997162057735 /* STPSourcePoller.m in Sources */,
+				BF_887334060094 /* STPSourceReceiver.m in Sources */,
+				BF_309012133583 /* STPSourceRedirect.m in Sources */,
+				BF_342817674102 /* STPSourceSEPADebitDetails.m in Sources */,
+				BF_230551849999 /* STPSourceVerification.m in Sources */,
+				BF_334033244059 /* STPStringUtils.m in Sources */,
+				BF_770734317014 /* STPSwitchTableViewCell.m in Sources */,
+				BF_486856572102 /* STPTelemetryClient.m in Sources */,
+				BF_657939179964 /* STPTheme.m in Sources */,
+				BF_628665229218 /* STPToken.m in Sources */,
+				BF_140074296679 /* STPURLCallbackHandler.m in Sources */,
+				BF_185332479298 /* STPUserInformation.m in Sources */,
+				BF_219546294511 /* STPValidatedTextField.m in Sources */,
+				BF_272113176119 /* StripeError.m in Sources */,
+				BF_920262823507 /* UIBarButtonItem+Stripe.m in Sources */,
+				BF_103694247729 /* UIImage+Stripe.m in Sources */,
+				BF_105517386350 /* UINavigationBar+Stripe_Theme.m in Sources */,
+				BF_109966380663 /* UINavigationController+Stripe_Completion.m in Sources */,
+				BF_250759401629 /* UITableViewCell+Stripe_Borders.m in Sources */,
+				BF_101696638053 /* UIToolbar+Stripe_InputAccessory.m in Sources */,
+				BF_259477981462 /* UIView+Stripe_FirstResponder.m in Sources */,
+				BF_907297624925 /* UIView+Stripe_SafeAreaBounds.m in Sources */,
+				BF_290918553966 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */,
+				BF_255476020818 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */,
+				BF_417206245222 /* UIViewController+Stripe_ParentViewController.m in Sources */,
+				BF_848140824504 /* UIViewController+Stripe_Promises.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_20740845888 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_166442928755 /* Stub.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_27384532552 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_663888141921 /* PINOperationGroup.m in Sources */,
+				BF_547904238334 /* PINOperationQueue.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_27553956686 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_229308595261 /* Stub.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_30884964029 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_36395135131 /* Sources */ = {
+		SBP_33959086389 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_193776636624 /* Tests.m in Sources */,
-				BF_356777741414 /* Tests2.m in Sources */,
+				BF_292698780858 /* Stub.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_37554190609 /* Sources */ = {
+		SBP_39379078374 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BF_916188019560 /* Stub.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_40443300107 /* Sources */ = {
+		SBP_41357132792 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_685020284145 /* NSArray+Stripe.m in Sources */,
-				BF_588052029111 /* NSBundle+Stripe_AppName.m in Sources */,
-				BF_138955362658 /* NSCharacterSet+Stripe.m in Sources */,
-				BF_895946163682 /* NSDecimalNumber+Stripe_Currency.m in Sources */,
-				BF_530018599708 /* NSDictionary+Stripe.m in Sources */,
-				BF_792141876040 /* NSError+Stripe.m in Sources */,
-				BF_771058537523 /* NSMutableURLRequest+Stripe.m in Sources */,
-				BF_239435400714 /* NSString+Stripe.m in Sources */,
-				BF_357119474570 /* NSURLComponents+Stripe.m in Sources */,
-				BF_348252718764 /* PKPayment+Stripe.m in Sources */,
-				BF_515310723788 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */,
-				BF_106426006254 /* STPAPIClient+ApplePay.m in Sources */,
-				BF_367918553830 /* STPAPIClient.m in Sources */,
-				BF_139454296157 /* STPAPIRequest.m in Sources */,
-				BF_918810591389 /* STPAddCardViewController.m in Sources */,
-				BF_886805532652 /* STPAddress.m in Sources */,
-				BF_674771939222 /* STPAddressFieldTableViewCell.m in Sources */,
-				BF_298131539887 /* STPAddressViewModel.m in Sources */,
-				BF_151809760085 /* STPAnalyticsClient.m in Sources */,
-				BF_792780296590 /* STPApplePayPaymentMethod.m in Sources */,
-				BF_876436210306 /* STPAspects.m in Sources */,
-				BF_116377765548 /* STPBINRange.m in Sources */,
-				BF_200763756394 /* STPBankAccount.m in Sources */,
-				BF_477001413936 /* STPBankAccountParams.m in Sources */,
-				BF_502186160447 /* STPBundleLocator.m in Sources */,
-				BF_428922525784 /* STPCard.m in Sources */,
-				BF_391274054556 /* STPCardIOProxy.m in Sources */,
-				BF_109277108982 /* STPCardParams.m in Sources */,
-				BF_546663098919 /* STPCardValidator.m in Sources */,
-				BF_476855115754 /* STPCategoryLoader.m in Sources */,
-				BF_806612012743 /* STPColorUtils.m in Sources */,
-				BF_548611216731 /* STPConnectAccountParams.m in Sources */,
-				BF_210482066403 /* STPCoreScrollViewController.m in Sources */,
-				BF_776288618153 /* STPCoreTableViewController.m in Sources */,
-				BF_178404571906 /* STPCoreViewController.m in Sources */,
-				BF_412998867029 /* STPCustomer+SourceTuple.m in Sources */,
-				BF_795635276960 /* STPCustomer.m in Sources */,
-				BF_358938081806 /* STPCustomerContext.m in Sources */,
-				BF_455146692948 /* STPDelegateProxy.m in Sources */,
-				BF_526124682716 /* STPDispatchFunctions.m in Sources */,
-				BF_303453009225 /* STPEmailAddressValidator.m in Sources */,
-				BF_562998659658 /* STPEphemeralKey.m in Sources */,
-				BF_392554858625 /* STPEphemeralKeyManager.m in Sources */,
-				BF_877574233419 /* STPFile.m in Sources */,
-				BF_684105594855 /* STPFormEncoder.m in Sources */,
-				BF_918611492613 /* STPFormTextField.m in Sources */,
-				BF_403737463455 /* STPImageLibrary.m in Sources */,
-				BF_914420886758 /* STPLegalEntityParams.m in Sources */,
-				BF_633630823704 /* STPLocalizationUtils.m in Sources */,
-				BF_278104745467 /* STPMultipartFormDataEncoder.m in Sources */,
-				BF_778116345176 /* STPMultipartFormDataPart.m in Sources */,
-				BF_774518809346 /* STPPaymentActivityIndicatorView.m in Sources */,
-				BF_176630419312 /* STPPaymentCardTextField.m in Sources */,
-				BF_590916326727 /* STPPaymentCardTextFieldCell.m in Sources */,
-				BF_149583612787 /* STPPaymentCardTextFieldViewModel.m in Sources */,
-				BF_218427460037 /* STPPaymentConfiguration.m in Sources */,
-				BF_252672099139 /* STPPaymentContext.m in Sources */,
-				BF_127051381386 /* STPPaymentContextAmountModel.m in Sources */,
-				BF_329590708976 /* STPPaymentMethodTableViewCell.m in Sources */,
-				BF_399406404906 /* STPPaymentMethodTuple.m in Sources */,
-				BF_765883201183 /* STPPaymentMethodsInternalViewController.m in Sources */,
-				BF_511432964645 /* STPPaymentMethodsViewController.m in Sources */,
-				BF_530927397099 /* STPPaymentResult.m in Sources */,
-				BF_747326481621 /* STPPhoneNumberValidator.m in Sources */,
-				BF_762619699159 /* STPPostalCodeValidator.m in Sources */,
-				BF_659595653922 /* STPPromise.m in Sources */,
-				BF_288475203867 /* STPRedirectContext.m in Sources */,
-				BF_868227706673 /* STPSectionHeaderView.m in Sources */,
-				BF_700378609220 /* STPShippingAddressViewController.m in Sources */,
-				BF_920949703527 /* STPShippingMethodTableViewCell.m in Sources */,
-				BF_905699555770 /* STPShippingMethodsViewController.m in Sources */,
-				BF_921453502635 /* STPSource.m in Sources */,
-				BF_264569632952 /* STPSourceCardDetails.m in Sources */,
-				BF_651740250714 /* STPSourceOwner.m in Sources */,
-				BF_885266926004 /* STPSourceParams.m in Sources */,
-				BF_289807868980 /* STPSourcePoller.m in Sources */,
-				BF_884680354641 /* STPSourceReceiver.m in Sources */,
-				BF_180246982391 /* STPSourceRedirect.m in Sources */,
-				BF_345965387817 /* STPSourceSEPADebitDetails.m in Sources */,
-				BF_511263762622 /* STPSourceVerification.m in Sources */,
-				BF_854573230512 /* STPStringUtils.m in Sources */,
-				BF_184553022665 /* STPSwitchTableViewCell.m in Sources */,
-				BF_716146555260 /* STPTelemetryClient.m in Sources */,
-				BF_688863603246 /* STPTheme.m in Sources */,
-				BF_227164771933 /* STPToken.m in Sources */,
-				BF_782481571388 /* STPURLCallbackHandler.m in Sources */,
-				BF_864531662511 /* STPUserInformation.m in Sources */,
-				BF_741839336888 /* STPValidatedTextField.m in Sources */,
-				BF_994959222749 /* StripeError.m in Sources */,
-				BF_222042484068 /* UIBarButtonItem+Stripe.m in Sources */,
-				BF_450867024855 /* UIImage+Stripe.m in Sources */,
-				BF_277334165247 /* UINavigationBar+Stripe_Theme.m in Sources */,
-				BF_367020795115 /* UINavigationController+Stripe_Completion.m in Sources */,
-				BF_404707853042 /* UITableViewCell+Stripe_Borders.m in Sources */,
-				BF_754839459209 /* UIToolbar+Stripe_InputAccessory.m in Sources */,
-				BF_590736093727 /* UIView+Stripe_FirstResponder.m in Sources */,
-				BF_157778036284 /* UIView+Stripe_SafeAreaBounds.m in Sources */,
-				BF_619043295407 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */,
-				BF_537243679458 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */,
-				BF_568983631361 /* UIViewController+Stripe_ParentViewController.m in Sources */,
-				BF_850485617255 /* UIViewController+Stripe_Promises.m in Sources */,
+				BF_483091065104 /* Tests.m in Sources */,
+				BF_649865701797 /* Tests2.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_40652102921 /* Sources */ = {
+		SBP_42613153924 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_322601378894 /* Stub.m in Sources */,
+				BF_340779968144 /* PINOperationGroup.m in Sources */,
+				BF_827791661966 /* PINOperationQueue.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_40950323780 /* Sources */ = {
+		SBP_44237896483 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_204127504215 /* Stub.m in Sources */,
+				BF_718867892239 /* AppDelegate.m in Sources */,
+				BF_564028199175 /* NoArc.m in Sources */,
+				BF_842548931220 /* Some.cc in Sources */,
+				BF_485594525880 /* UrlGetViewController.m in Sources */,
+				BF_322952319846 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_42012706858 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_830785039128 /* AppJerry.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_44650584080 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_877506999100 /* PINCache.m in Sources */,
-				BF_694891200528 /* PINMemoryCache.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_45505050575 /* Sources */ = {
+		SBP_49018065050 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_51545646825 /* Sources */ = {
+		SBP_50072837247 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_419189536555 /* PINDiskCache.m in Sources */,
+				BF_899127884349 /* AppDelegate.m in Sources */,
+				BF_524325989975 /* NoArc.m in Sources */,
+				BF_773372457985 /* Some.cc in Sources */,
+				BF_708126553435 /* UrlGetViewController.m in Sources */,
+				BF_452681027169 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_54065910816 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_281049355718 /* Stub.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_54281535779 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_717739686355 /* AppDelegate.m in Sources */,
-				BF_944282656193 /* NoArc.m in Sources */,
-				BF_386619076258 /* Some.cc in Sources */,
-				BF_913254331471 /* UrlGetViewController.m in Sources */,
-				BF_409148396445 /* main.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_60605076682 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_108242733761 /* Tests.m in Sources */,
-				BF_572483412207 /* Tests2.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_62327648914 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_870532528736 /* NSArray+Stripe.m in Sources */,
-				BF_853779262143 /* NSBundle+Stripe_AppName.m in Sources */,
-				BF_130835634102 /* NSCharacterSet+Stripe.m in Sources */,
-				BF_339765826756 /* NSDecimalNumber+Stripe_Currency.m in Sources */,
-				BF_624121435354 /* NSDictionary+Stripe.m in Sources */,
-				BF_824727108130 /* NSError+Stripe.m in Sources */,
-				BF_863030455665 /* NSMutableURLRequest+Stripe.m in Sources */,
-				BF_681339998507 /* NSString+Stripe.m in Sources */,
-				BF_362490869856 /* NSURLComponents+Stripe.m in Sources */,
-				BF_717854369550 /* PKPayment+Stripe.m in Sources */,
-				BF_126340360597 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */,
-				BF_794851605037 /* STPAPIClient+ApplePay.m in Sources */,
-				BF_116037651642 /* STPAPIClient.m in Sources */,
-				BF_232285685203 /* STPAPIRequest.m in Sources */,
-				BF_836567493548 /* STPAddCardViewController.m in Sources */,
-				BF_762901813901 /* STPAddress.m in Sources */,
-				BF_320665594632 /* STPAddressFieldTableViewCell.m in Sources */,
-				BF_681822233576 /* STPAddressViewModel.m in Sources */,
-				BF_402375562608 /* STPAnalyticsClient.m in Sources */,
-				BF_110357559807 /* STPApplePayPaymentMethod.m in Sources */,
-				BF_892293230903 /* STPAspects.m in Sources */,
-				BF_572886501248 /* STPBINRange.m in Sources */,
-				BF_327255107530 /* STPBankAccount.m in Sources */,
-				BF_866458893589 /* STPBankAccountParams.m in Sources */,
-				BF_114471101614 /* STPBundleLocator.m in Sources */,
-				BF_336829476801 /* STPCard.m in Sources */,
-				BF_322096687583 /* STPCardIOProxy.m in Sources */,
-				BF_571286316834 /* STPCardParams.m in Sources */,
-				BF_312952331484 /* STPCardValidator.m in Sources */,
-				BF_296999096933 /* STPCategoryLoader.m in Sources */,
-				BF_666754536474 /* STPColorUtils.m in Sources */,
-				BF_359556006908 /* STPConnectAccountParams.m in Sources */,
-				BF_115608921764 /* STPCoreScrollViewController.m in Sources */,
-				BF_830707417459 /* STPCoreTableViewController.m in Sources */,
-				BF_578222277700 /* STPCoreViewController.m in Sources */,
-				BF_692924768908 /* STPCustomer+SourceTuple.m in Sources */,
-				BF_399903588308 /* STPCustomer.m in Sources */,
-				BF_709949473572 /* STPCustomerContext.m in Sources */,
-				BF_749296953649 /* STPDelegateProxy.m in Sources */,
-				BF_182065974583 /* STPDispatchFunctions.m in Sources */,
-				BF_891898890632 /* STPEmailAddressValidator.m in Sources */,
-				BF_409727823462 /* STPEphemeralKey.m in Sources */,
-				BF_846807679897 /* STPEphemeralKeyManager.m in Sources */,
-				BF_568450192494 /* STPFile.m in Sources */,
-				BF_334317196081 /* STPFormEncoder.m in Sources */,
-				BF_380811578651 /* STPFormTextField.m in Sources */,
-				BF_166279340518 /* STPImageLibrary.m in Sources */,
-				BF_873274540292 /* STPLegalEntityParams.m in Sources */,
-				BF_252773349615 /* STPLocalizationUtils.m in Sources */,
-				BF_240229285012 /* STPMultipartFormDataEncoder.m in Sources */,
-				BF_177629582576 /* STPMultipartFormDataPart.m in Sources */,
-				BF_557796894054 /* STPPaymentActivityIndicatorView.m in Sources */,
-				BF_241788126271 /* STPPaymentCardTextField.m in Sources */,
-				BF_493409401178 /* STPPaymentCardTextFieldCell.m in Sources */,
-				BF_678407634641 /* STPPaymentCardTextFieldViewModel.m in Sources */,
-				BF_612299065256 /* STPPaymentConfiguration.m in Sources */,
-				BF_775562182682 /* STPPaymentContext.m in Sources */,
-				BF_717459077016 /* STPPaymentContextAmountModel.m in Sources */,
-				BF_141009703626 /* STPPaymentMethodTableViewCell.m in Sources */,
-				BF_688646249911 /* STPPaymentMethodTuple.m in Sources */,
-				BF_415575403969 /* STPPaymentMethodsInternalViewController.m in Sources */,
-				BF_829996789142 /* STPPaymentMethodsViewController.m in Sources */,
-				BF_840912639158 /* STPPaymentResult.m in Sources */,
-				BF_295863033575 /* STPPhoneNumberValidator.m in Sources */,
-				BF_890330557077 /* STPPostalCodeValidator.m in Sources */,
-				BF_292535522668 /* STPPromise.m in Sources */,
-				BF_248488222131 /* STPRedirectContext.m in Sources */,
-				BF_107640671612 /* STPSectionHeaderView.m in Sources */,
-				BF_880308943657 /* STPShippingAddressViewController.m in Sources */,
-				BF_864173425247 /* STPShippingMethodTableViewCell.m in Sources */,
-				BF_537009746287 /* STPShippingMethodsViewController.m in Sources */,
-				BF_789772667851 /* STPSource.m in Sources */,
-				BF_915120825897 /* STPSourceCardDetails.m in Sources */,
-				BF_348584325092 /* STPSourceOwner.m in Sources */,
-				BF_354310531169 /* STPSourceParams.m in Sources */,
-				BF_227375850827 /* STPSourcePoller.m in Sources */,
-				BF_436060695556 /* STPSourceReceiver.m in Sources */,
-				BF_428554468212 /* STPSourceRedirect.m in Sources */,
-				BF_474704211148 /* STPSourceSEPADebitDetails.m in Sources */,
-				BF_910355536240 /* STPSourceVerification.m in Sources */,
-				BF_684731147515 /* STPStringUtils.m in Sources */,
-				BF_419281111160 /* STPSwitchTableViewCell.m in Sources */,
-				BF_176098569769 /* STPTelemetryClient.m in Sources */,
-				BF_831554238419 /* STPTheme.m in Sources */,
-				BF_575495041980 /* STPToken.m in Sources */,
-				BF_570993978338 /* STPURLCallbackHandler.m in Sources */,
-				BF_573833408368 /* STPUserInformation.m in Sources */,
-				BF_442034888602 /* STPValidatedTextField.m in Sources */,
-				BF_942886377746 /* StripeError.m in Sources */,
-				BF_694055106197 /* UIBarButtonItem+Stripe.m in Sources */,
-				BF_357673008284 /* UIImage+Stripe.m in Sources */,
-				BF_437010218142 /* UINavigationBar+Stripe_Theme.m in Sources */,
-				BF_687822364709 /* UINavigationController+Stripe_Completion.m in Sources */,
-				BF_594000401878 /* UITableViewCell+Stripe_Borders.m in Sources */,
-				BF_879803241770 /* UIToolbar+Stripe_InputAccessory.m in Sources */,
-				BF_555427361566 /* UIView+Stripe_FirstResponder.m in Sources */,
-				BF_601614893583 /* UIView+Stripe_SafeAreaBounds.m in Sources */,
-				BF_470103336482 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */,
-				BF_226798571849 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */,
-				BF_331706236912 /* UIViewController+Stripe_ParentViewController.m in Sources */,
-				BF_301371454701 /* UIViewController+Stripe_Promises.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_62954860864 /* Sources */ = {
+		SBP_50368809625 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_64541152154 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_254215603294 /* PINDiskCache.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_68225230092 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_528644484773 /* AppIntent.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_72275540073 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_565788009969 /* Stub.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_76619575893 /* Sources */ = {
+		SBP_52125838070 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_82635932625 /* Sources */ = {
+		SBP_53882159556 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_231519883198 /* PINCache.m in Sources */,
-				BF_273949134835 /* PINMemoryCache.m in Sources */,
+				BF_338809556807 /* empty-main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_84865241696 /* Sources */ = {
+		SBP_56129304997 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_866026142598 /* AppDelegate.m in Sources */,
-				BF_328588753540 /* NoArc.m in Sources */,
-				BF_476586354355 /* Some.cc in Sources */,
-				BF_539410623152 /* UrlGetViewController.m in Sources */,
-				BF_724404388963 /* main.m in Sources */,
+				BF_629330710435 /* PINCache.m in Sources */,
+				BF_855832788961 /* PINMemoryCache.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_85434226617 /* Sources */ = {
+		SBP_61700479011 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_210628983297 /* Generated.m in Sources */,
-				BF_374068575975 /* main.m in Sources */,
+				BF_474165361269 /* AppJerry.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_85601774915 /* Sources */ = {
+		SBP_63768123619 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_88899582246 /* Sources */ = {
+		SBP_64312921369 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_335855908002 /* PINOperationGroup.m in Sources */,
-				BF_586572211287 /* PINOperationQueue.m in Sources */,
+				BF_551919418156 /* AppIntent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_90352475889 /* Sources */ = {
+		SBP_65506563774 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_628907856271 /* Stub.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_70897405926 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_841215260506 /* NSArray+Stripe.m in Sources */,
+				BF_698602061822 /* NSBundle+Stripe_AppName.m in Sources */,
+				BF_368597544029 /* NSCharacterSet+Stripe.m in Sources */,
+				BF_109764027775 /* NSDecimalNumber+Stripe_Currency.m in Sources */,
+				BF_269150351537 /* NSDictionary+Stripe.m in Sources */,
+				BF_348622537075 /* NSError+Stripe.m in Sources */,
+				BF_184896725550 /* NSMutableURLRequest+Stripe.m in Sources */,
+				BF_608543729113 /* NSString+Stripe.m in Sources */,
+				BF_343062773610 /* NSURLComponents+Stripe.m in Sources */,
+				BF_690196366010 /* PKPayment+Stripe.m in Sources */,
+				BF_114932459163 /* PKPaymentAuthorizationViewController+Stripe_Blocks.m in Sources */,
+				BF_260820706082 /* STPAPIClient+ApplePay.m in Sources */,
+				BF_581598615267 /* STPAPIClient.m in Sources */,
+				BF_847957075797 /* STPAPIRequest.m in Sources */,
+				BF_316621845845 /* STPAddCardViewController.m in Sources */,
+				BF_259633161334 /* STPAddress.m in Sources */,
+				BF_216421196016 /* STPAddressFieldTableViewCell.m in Sources */,
+				BF_644049822046 /* STPAddressViewModel.m in Sources */,
+				BF_959817918427 /* STPAnalyticsClient.m in Sources */,
+				BF_357875023006 /* STPApplePayPaymentMethod.m in Sources */,
+				BF_716153568345 /* STPAspects.m in Sources */,
+				BF_171630640450 /* STPBINRange.m in Sources */,
+				BF_178296374184 /* STPBankAccount.m in Sources */,
+				BF_232883660073 /* STPBankAccountParams.m in Sources */,
+				BF_757939644928 /* STPBundleLocator.m in Sources */,
+				BF_894661147087 /* STPCard.m in Sources */,
+				BF_257491728292 /* STPCardIOProxy.m in Sources */,
+				BF_208200642556 /* STPCardParams.m in Sources */,
+				BF_837786396469 /* STPCardValidator.m in Sources */,
+				BF_701234805690 /* STPCategoryLoader.m in Sources */,
+				BF_580367071544 /* STPColorUtils.m in Sources */,
+				BF_356314905143 /* STPConnectAccountParams.m in Sources */,
+				BF_815247147431 /* STPCoreScrollViewController.m in Sources */,
+				BF_224938006679 /* STPCoreTableViewController.m in Sources */,
+				BF_264893894510 /* STPCoreViewController.m in Sources */,
+				BF_790384308722 /* STPCustomer+SourceTuple.m in Sources */,
+				BF_461602219286 /* STPCustomer.m in Sources */,
+				BF_373917923789 /* STPCustomerContext.m in Sources */,
+				BF_870269234462 /* STPDelegateProxy.m in Sources */,
+				BF_880020110019 /* STPDispatchFunctions.m in Sources */,
+				BF_455098719663 /* STPEmailAddressValidator.m in Sources */,
+				BF_507288906199 /* STPEphemeralKey.m in Sources */,
+				BF_500739021385 /* STPEphemeralKeyManager.m in Sources */,
+				BF_651911975680 /* STPFile.m in Sources */,
+				BF_875094752518 /* STPFormEncoder.m in Sources */,
+				BF_382837408791 /* STPFormTextField.m in Sources */,
+				BF_291239156030 /* STPImageLibrary.m in Sources */,
+				BF_599011362417 /* STPLegalEntityParams.m in Sources */,
+				BF_100274673343 /* STPLocalizationUtils.m in Sources */,
+				BF_183102629175 /* STPMultipartFormDataEncoder.m in Sources */,
+				BF_607249397858 /* STPMultipartFormDataPart.m in Sources */,
+				BF_467710876165 /* STPPaymentActivityIndicatorView.m in Sources */,
+				BF_749484612661 /* STPPaymentCardTextField.m in Sources */,
+				BF_684471668015 /* STPPaymentCardTextFieldCell.m in Sources */,
+				BF_142196224122 /* STPPaymentCardTextFieldViewModel.m in Sources */,
+				BF_568722685766 /* STPPaymentConfiguration.m in Sources */,
+				BF_534610655903 /* STPPaymentContext.m in Sources */,
+				BF_648450929643 /* STPPaymentContextAmountModel.m in Sources */,
+				BF_444528772797 /* STPPaymentMethodTableViewCell.m in Sources */,
+				BF_241045157010 /* STPPaymentMethodTuple.m in Sources */,
+				BF_952635031943 /* STPPaymentMethodsInternalViewController.m in Sources */,
+				BF_243036252140 /* STPPaymentMethodsViewController.m in Sources */,
+				BF_636805722397 /* STPPaymentResult.m in Sources */,
+				BF_685721334739 /* STPPhoneNumberValidator.m in Sources */,
+				BF_769304845478 /* STPPostalCodeValidator.m in Sources */,
+				BF_123753384584 /* STPPromise.m in Sources */,
+				BF_315928120735 /* STPRedirectContext.m in Sources */,
+				BF_602469051456 /* STPSectionHeaderView.m in Sources */,
+				BF_666060374727 /* STPShippingAddressViewController.m in Sources */,
+				BF_701211932660 /* STPShippingMethodTableViewCell.m in Sources */,
+				BF_762847527121 /* STPShippingMethodsViewController.m in Sources */,
+				BF_814879537018 /* STPSource.m in Sources */,
+				BF_846935922558 /* STPSourceCardDetails.m in Sources */,
+				BF_818902966270 /* STPSourceOwner.m in Sources */,
+				BF_125972534564 /* STPSourceParams.m in Sources */,
+				BF_851511694779 /* STPSourcePoller.m in Sources */,
+				BF_134718521602 /* STPSourceReceiver.m in Sources */,
+				BF_409849167455 /* STPSourceRedirect.m in Sources */,
+				BF_307104635179 /* STPSourceSEPADebitDetails.m in Sources */,
+				BF_279334644411 /* STPSourceVerification.m in Sources */,
+				BF_322268505656 /* STPStringUtils.m in Sources */,
+				BF_917532833583 /* STPSwitchTableViewCell.m in Sources */,
+				BF_364211303092 /* STPTelemetryClient.m in Sources */,
+				BF_280227026388 /* STPTheme.m in Sources */,
+				BF_885374270340 /* STPToken.m in Sources */,
+				BF_503266929639 /* STPURLCallbackHandler.m in Sources */,
+				BF_527066927242 /* STPUserInformation.m in Sources */,
+				BF_585752695549 /* STPValidatedTextField.m in Sources */,
+				BF_386820352239 /* StripeError.m in Sources */,
+				BF_814672412075 /* UIBarButtonItem+Stripe.m in Sources */,
+				BF_835019889165 /* UIImage+Stripe.m in Sources */,
+				BF_704563056890 /* UINavigationBar+Stripe_Theme.m in Sources */,
+				BF_189548205092 /* UINavigationController+Stripe_Completion.m in Sources */,
+				BF_275638145040 /* UITableViewCell+Stripe_Borders.m in Sources */,
+				BF_491370786528 /* UIToolbar+Stripe_InputAccessory.m in Sources */,
+				BF_261816938453 /* UIView+Stripe_FirstResponder.m in Sources */,
+				BF_735320918610 /* UIView+Stripe_SafeAreaBounds.m in Sources */,
+				BF_167030847429 /* UIViewController+Stripe_KeyboardAvoiding.m in Sources */,
+				BF_773761127283 /* UIViewController+Stripe_NavigationItemProxy.m in Sources */,
+				BF_576094170042 /* UIViewController+Stripe_ParentViewController.m in Sources */,
+				BF_449328693163 /* UIViewController+Stripe_Promises.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_72905613042 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_95496141142 /* Sources */ = {
+		SBP_76573117406 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_164869574590 /* Stub.m in Sources */,
+				BF_234401736452 /* PINDiskCache.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_85279693508 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_633442669538 /* PINDiskCache.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_89127189342 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_89602432109 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_457671294607 /* PINCache.m in Sources */,
+				BF_491638567810 /* PINMemoryCache.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_90700514734 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_131133471911 /* Stub.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		TD_121281603735 /* PBXTargetDependency */ = {
+		TD_207516869133 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_406521029219 /* share-extension */;
-			targetProxy = CIP_12128160373 /* PBXContainerItemProxy */;
+			target = NT_393790783742 /* ios-app */;
+			targetProxy = CIP_20751686913 /* PBXContainerItemProxy */;
 		};
-		TD_263965622171 /* PBXTargetDependency */ = {
+		TD_233991864906 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_409503237802 /* strings-extension */;
-			targetProxy = CIP_26396562217 /* PBXContainerItemProxy */;
+			target = NT_907005147347 /* siri-extension */;
+			targetProxy = CIP_23399186490 /* PBXContainerItemProxy */;
 		};
-		TD_354942992784 /* PBXTargetDependency */ = {
+		TD_436368260124 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_210478864884 /* ios-app */;
-			targetProxy = CIP_35494299278 /* PBXContainerItemProxy */;
+			target = NT_207408458888 /* strings-extension */;
+			targetProxy = CIP_43636826012 /* PBXContainerItemProxy */;
 		};
-		TD_406283096221 /* PBXTargetDependency */ = {
+		TD_696565615504 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_210478864884 /* ios-app */;
-			targetProxy = CIP_40628309622 /* PBXContainerItemProxy */;
+			target = NT_339590863894 /* share-extension */;
+			targetProxy = CIP_69656561550 /* PBXContainerItemProxy */;
 		};
-		TD_770656248467 /* PBXTargetDependency */ = {
+		TD_774091882821 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = NT_954961411422 /* siri-extension */;
-			targetProxy = CIP_77065624846 /* PBXContainerItemProxy */;
+			target = NT_393790783742 /* ios-app */;
+			targetProxy = CIP_77409188282 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
-		VG_114608902985 /* AppIntentVocabulary.plist */ = {
+		VG_389377991035 /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
-				FR_114608902985 /* Base */,
-				FR_137752412410 /* cs */,
-				FR_381353028354 /* zh-Hans */,
-			);
-			name = AppIntentVocabulary.plist;
-			sourceTree = "<group>";
-		};
-		VG_155022079262 /* Localizable.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				FR_129216172055 /* de */,
-				FR_155022079262 /* en */,
-				FR_388580610033 /* es */,
-				FR_232638777097 /* fi */,
-				FR_774182455908 /* fr */,
-				FR_206010141299 /* it */,
-				FR_106744743166 /* ja */,
-				FR_129440935020 /* nl */,
-				FR_560286231490 /* zh-Hans */,
+				FR_717035337333 /* de */,
+				FR_389377991035 /* en */,
+				FR_181564135531 /* es */,
+				FR_278953099320 /* fi */,
+				FR_474849171272 /* fr */,
+				FR_627448499289 /* it */,
+				FR_480377833594 /* ja */,
+				FR_784002482892 /* nl */,
+				FR_379475835433 /* zh-Hans */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
 		};
-		VG_678627904183 /* InfoPlist.strings */ = {
+		VG_786904937064 /* AppIntentVocabulary.plist */ = {
 			isa = PBXVariantGroup;
 			children = (
-				FR_678627904183 /* Base */,
-				FR_696955024788 /* cs */,
-				FR_505660890208 /* en-GB */,
-				FR_723941053046 /* zh-Hant */,
+				FR_786904937064 /* Base */,
+				FR_874071751772 /* cs */,
+				FR_192476533600 /* zh-Hans */,
+			);
+			name = AppIntentVocabulary.plist;
+			sourceTree = "<group>";
+		};
+		VG_843603205312 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				FR_843603205312 /* Base */,
+				FR_302162599226 /* cs */,
+				FR_364137728612 /* en-GB */,
+				FR_589053450594 /* zh-Hant */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -3675,117 +3677,9 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		BC_110911883796 /* Release */ = {
+		BC_117181722199 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"\".\"",
-					"\"Vendor/GoogleAppIndexing/Frameworks\"",
-					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
-				PRODUCT_NAME = UITests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_117155748321 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"\".\"",
-					"\"Vendor/GoogleAppIndexing/Frameworks\"",
-					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
-				);
-				HEADER_SEARCH_PATHS = external;
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/UrlGet/UrlGet-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
-				OTHER_LDFLAGS = "-ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet;
-				PRODUCT_NAME = "ios-app";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_139917300954 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_150621858460 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		BC_169740105700 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				CLANG_ENABLE_MODULES = NO;
@@ -3795,461 +3689,8 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "strings-ext-bin";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_184537790990 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wno-everything -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "Stripe-ios-9.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_187101092080 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"\".\"",
-				);
-				HEADER_SEARCH_PATHS = external;
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/ShareExtension/ShareExtension-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-share-extension_entitlements.entitlements";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.ShareExtension;
-				PRODUCT_NAME = "share-extension";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_188690671337 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"\".\"",
-				);
-				HEADER_SEARCH_PATHS = external;
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/SiriExtension-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-siri-extension_entitlements.entitlements";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.SiriExtension;
-				PRODUCT_NAME = "siri-extension";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_190337549444 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "PINCache-Core-ios-9.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_194667162303 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"\".\"",
-					"\"Vendor/GoogleAppIndexing/Frameworks\"",
-					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
-				);
-				HEADER_SEARCH_PATHS = external;
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/UrlGet/UrlGet-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
-				OTHER_LDFLAGS = "-ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet;
-				PRODUCT_NAME = "ios-app";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_210761284576 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"\".\"",
-					"\"Vendor/GoogleAppIndexing/Frameworks\"",
-					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
-				PRODUCT_NAME = UnitTests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_218404434640 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		BC_220129782512 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		BC_230071728200 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "PINOperation-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_245963174475 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				LIBRARY_SEARCH_PATHS = "";
-				OTHER_CFLAGS = "";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				TARGETED_DEVICE_FAMILY = "";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_271500455838 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"\".\"",
-					"\"Vendor/GoogleAppIndexing/Frameworks\"",
-					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
-				PRODUCT_NAME = UnitTestsWithHost;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_289357895108 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		BC_309998579718 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		BC_320881675570 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "ios-ext-bin";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_324145370928 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/Localization/Base.lproj/AppIntentVocabulary.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "siri-ext-bin";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_362470988603 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		BC_365074157763 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "ios-app-bin-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_370056796998 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "HeaderLib-ios-9.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_382687079397 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -4267,121 +3708,9 @@
 			};
 			name = Release;
 		};
-		BC_399832733236 /* Debug */ = {
+		BC_135740809787 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "HeaderLib-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_425321227990 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "ios-ext-bin";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_427535732488 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "PINOperation-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_434255076726 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-fobjc-arc-exceptions -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "PINCache-Arc-exception-safe-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_446069699096 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				CLANG_ENABLE_OBJC_ARC = YES;
@@ -4394,6 +3723,401 @@
 					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"\".\"",
 				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/StringsExtension/Resources/StringsExtension-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-strings-extension_entitlements.entitlements";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.StringsExtension;
+				PRODUCT_NAME = "strings-extension";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_142442004990 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_166416381664 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -fobjc-arc-exceptions -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "PINCache-Arc-exception-safe-ios-9.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_170310259182 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "PINCache-Core-ios-9.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_185433509870 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "UrlGetClasses-ios-9.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_194515208846 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
+				PRODUCT_NAME = UnitTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_233314622511 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_237841757804 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "ios-ext-bin";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_282894734274 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "strings-ext-bin";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_305650925272 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "PINOperation-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_320089394545 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "ios-app-bin-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_328927905806 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/SiriExtension-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-siri-extension_entitlements.entitlements";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.SiriExtension;
+				PRODUCT_NAME = "siri-extension";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_334587889643 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "HeaderLib-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_356070702326 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = external;
 				INFOPLIST_FILE = "$(SRCROOT)/ios-app/StringsExtension/Resources/StringsExtension-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -4412,16 +4136,1223 @@
 			};
 			name = Debug;
 		};
-		BC_447232414742 /* Debug */ = {
+		BC_373165712910 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "HeaderLib-ios-9.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_376390426793 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -fobjc-arc-exceptions -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "PINCache-Arc-exception-safe-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_376942035468 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "ios-ext-bin";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_403892639446 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_407450855247 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_873994371050 /* Analyzer.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wno-everything -Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "Stripe-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_408100935645 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		BC_411549963861 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_873994371050 /* Analyzer.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wno-everything -Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "Stripe-ios-9.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_412463236261 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		BC_420886103796 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/Localization/Base.lproj/AppIntentVocabulary.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "siri-ext-bin";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_421675438846 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		BC_423838356746 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
+				PRODUCT_NAME = UnitTestsWithHost;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_433963668782 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "UrlGetClasses-ios-9.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_483041203608 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
+				PRODUCT_NAME = UnitTestsWithHost;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_491415690738 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/ShareExtension/ShareExtension-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-share-extension_entitlements.entitlements";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.ShareExtension;
+				PRODUCT_NAME = "share-extension";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_497839252839 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/ShareExtension/ShareExtension-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-share-extension_entitlements.entitlements";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.ShareExtension;
+				PRODUCT_NAME = "share-extension";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_513547653269 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "UrlGetClasses-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_520405970072 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_528004664767 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_556479179760 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "PINCache-Core-ios-9.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_590429648542 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "PINOperation-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_602257399297 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "HeaderLib-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_607449207016 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/Localization/Base.lproj/AppIntentVocabulary.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "siri-ext-bin";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_620672018069 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
+				PRODUCT_NAME = UnitTests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_649825156636 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		BC_651398781887 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/UrlGet/UrlGet-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
+				OTHER_LDFLAGS = "-ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet;
+				PRODUCT_NAME = "ios-app";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_700794875573 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -fobjc-arc-exceptions -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "PINCache-Arc-exception-safe-ios-9.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_701135392151 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "strings-ext-bin";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_715835469344 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		BC_716695747056 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
+				PRODUCT_NAME = UITests;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_735267783818 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "PINOperation-ios-9.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_740824605305 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_873994371050 /* Analyzer.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wno-everything -Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "Stripe-ios-9.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_748966912130 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "PINCache-Core-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_750071534248 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		BC_751285097717 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_760900726782 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/SiriExtension-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-siri-extension_entitlements.entitlements";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.SiriExtension;
+				PRODUCT_NAME = "siri-extension";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_789455977455 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		BC_807360739782 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
+					"\".\"",
+					"\"Vendor/GoogleAppIndexing/Frameworks\"",
+					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
+					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				INFOPLIST_FILE = "$(SRCROOT)/ios-app/UrlGet/UrlGet-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
+				OTHER_LDFLAGS = "-ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-ios-app_entitlements.entitlements";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet;
+				PRODUCT_NAME = "ios-app";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_812114312125 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "PINOperation-ios-9.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_845725077389 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_848420023639 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "ios-app-bin-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_868650691896 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_873994371050 /* Analyzer.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wno-everything -Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "Stripe-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_879797207798 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				
 			};
 			name = Debug;
 		};
-		BC_476602049518 /* Debug */ = {
+		BC_888119033248 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
+			buildSettings = {
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_894431821962 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
+				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -fobjc-arc-exceptions -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
+				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "PINCache-Arc-exception-safe-ios-12.0";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_897946825383 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_898269433813 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				OTHER_CFLAGS = "";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_899224958872 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				CLANG_ENABLE_MODULES = NO;
@@ -4432,6 +5363,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = external;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LIBRARY_SEARCH_PATHS = "";
@@ -4446,8 +5378,9 @@
 			};
 			name = Debug;
 		};
-		BC_491328159843 /* Release */ = {
+		BC_904086411849 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				CLANG_ENABLE_MODULES = YES;
@@ -4458,344 +5391,13 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "-Wnon-modular-include-in-framework-module -Wno-error=nonportable-include-path";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = "";
 				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "PINCache-Core-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_492318871976 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-fobjc-arc-exceptions -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "PINCache-Arc-exception-safe-ios-9.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_498980328456 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "UrlGetClasses-ios-9.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_503835760555 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wno-everything -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "Stripe-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_509459556955 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -DEXAMPLE_DEF=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "ios-app-bin-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_513947127784 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_532163083584 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"\".\"",
-				);
-				HEADER_SEARCH_PATHS = external;
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/SiriExtension-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-siri-extension_entitlements.entitlements";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.SiriExtension;
-				PRODUCT_NAME = "siri-extension";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_542562433408 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				LIBRARY_SEARCH_PATHS = "";
-				OTHER_CFLAGS = "";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				TARGETED_DEVICE_FAMILY = "";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_546265919656 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_548516957022 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "HeaderLib-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_554607720652 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
-					"\".\"",
-					"\"Vendor/GoogleAppIndexing/Frameworks\"",
-					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.bazelbuild.rulesapple.Tests;
-				PRODUCT_NAME = UnitTests;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_555117290238 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				LIBRARY_SEARCH_PATHS = "";
-				OTHER_CFLAGS = "";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				TARGETED_DEVICE_FAMILY = "";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_556574813047 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module";
 				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
 				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
 				OTHER_SWIFT_FLAGS = "";
@@ -4807,42 +5409,9 @@
 			};
 			name = Debug;
 		};
-		BC_565136169657 /* Release */ = {
+		BC_908142364004 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"\".\"",
-				);
-				HEADER_SEARCH_PATHS = external;
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/StringsExtension/Resources/StringsExtension-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-strings-extension_entitlements.entitlements";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.StringsExtension;
-				PRODUCT_NAME = "strings-extension";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_606904188094 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
+			baseConfigurationReference = FR_115188359612 /* Diags.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -4854,507 +5423,28 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks",
 					"\".\"",
 					"\"Vendor/GoogleAppIndexing/Frameworks\"",
 					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
 					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
 					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
 				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
 				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LIBRARY_SEARCH_PATHS = "";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
+				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -framework SystemConfiguration -weak_framework UIKit";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
 				PRODUCT_NAME = UITests;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_607425331887 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-fobjc-arc-exceptions -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "PINCache-Arc-exception-safe-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_621879196080 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "PINCache-Core-ios-9.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_622871343929 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_667865453065 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks",
-					"\".\"",
-					"\"Vendor/GoogleAppIndexing/Frameworks\"",
-					"\"Vendor/GoogleAuthUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleNetworkingUtilities/Frameworks/frameworks\"",
-					"\"Vendor/GoogleSymbolUtilities/Frameworks/frameworks\"",
-				);
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1 $(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -framework XCTest -framework CoreGraphics -framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents -framework SystemConfiguration -framework CoreText -framework SafariServices -framework WebKit -framework PassKit -framework Contacts -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGetTests;
-				PRODUCT_NAME = UnitTestsWithHost;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ios-app.app/ios-app";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_671516182068 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				LIBRARY_SEARCH_PATHS = "";
-				OTHER_CFLAGS = "";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				TARGETED_DEVICE_FAMILY = "";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_685115041786 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "PINOperation-ios-9.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_685747785851 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wno-everything -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "Stripe-ios-9.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_717380365451 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"\".\"",
-				);
-				HEADER_SEARCH_PATHS = external;
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/ShareExtension/ShareExtension-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/UrlGet.xcodeproj/XCHammerAssets/ios-app-share-extension_entitlements.entitlements";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = Google.UrlGet.ShareExtension;
-				PRODUCT_NAME = "share-extension";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_733685691463 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-fobjc-arc-exceptions -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public/PINCache/ -fmodule-name=PINCache_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation -weak_framework UIKit";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -weak_framework UIKit";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "PINCache-Arc-exception-safe-ios-9.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_736318706675 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				LIBRARY_SEARCH_PATHS = "";
-				OTHER_CFLAGS = "";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				TARGETED_DEVICE_FAMILY = "";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_776797576035 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		BC_798491664702 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wno-everything -Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public/Stripe/ -fmodule-name=Stripe_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation -framework Security -framework WebKit -framework PassKit -framework Contacts -framework CoreLocation";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "Stripe-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_815128483007 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "strings-ext-bin";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_815186165823 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "UrlGetClasses-ios-12.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_816260012650 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				LIBRARY_SEARCH_PATHS = "";
-				OTHER_CFLAGS = "";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				TARGETED_DEVICE_FAMILY = "";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_861777524381 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public external";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				MODULEMAP_FILE = "$(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map/module.modulemap";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-Wnon-modular-include-in-framework-module -g -stdlib=libc++ -DCOCOAPODS=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -fdiagnostics-show-note-include-stack -fno-common -fembed-bitcode-marker -fmessage-length=0 -fpascal-strings -fstrict-aliasing -Wno-error=nonportable-include-path -DPOD_CONFIGURATION_RELEASE=0 -I$(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public/PINOperation/ -fmodule-name=PINOperation_pod_module -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework Foundation";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework Foundation";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "PINOperation-ios-9.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_889379715948 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				INFOPLIST_FILE = "$(SRCROOT)/ios-app/SiriExtension/Resources/Localization/Base.lproj/AppIntentVocabulary.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "siri-ext-bin";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_890878123710 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FR_823746509568 /* Diags.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks $(SRCROOT)/Vendor/GoogleSymbolUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAuthUtilities/Frameworks/frameworks $(SRCROOT)/Vendor/GoogleAppIndexing/Frameworks $(SRCROOT)/Vendor/GoogleNetworkingUtilities/Frameworks/frameworks";
-				HEADER_SEARCH_PATHS = "$(inherited) $(SRCROOT)/bazel-genfiles/Vendor/GoogleAppIndexing/GoogleAppIndexing_module_map $(SRCROOT)/Vendor/GoogleAppIndexing/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleAuthUtilities/GoogleAuthUtilities_module_map $(SRCROOT)/Vendor/GoogleAuthUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleNetworkingUtilities/GoogleNetworkingUtilities_module_map $(SRCROOT)/Vendor/GoogleNetworkingUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/GoogleSymbolUtilities/GoogleSymbolUtilities_module_map $(SRCROOT)/Vendor/GoogleSymbolUtilities/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINCache/PINCache_module_map $(SRCROOT)/Vendor/PINCache/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/PINOperation/PINOperation_module_map $(SRCROOT)/Vendor/PINOperation/pod_support/Headers/Public $(SRCROOT)/bazel-genfiles/Vendor/Stripe/Stripe_module_map $(SRCROOT)/Vendor/Stripe/pod_support/Headers/Public external";
-				INFOPLIST_FILE = Vendor/GoogleAppIndexing/Resources/GoogleAppIndexingResources.bundle/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited) -D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-framework CoreLocation -framework AudioToolbox -framework Security -framework UIKit -framework CoreGraphics -framework QuartzCore -framework Foundation -framework CoreImage -framework Intents";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "UrlGetClasses-ios-9.0";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
@@ -5363,295 +5453,295 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		CL_101452471709 /* Build configuration list for PBXNativeTarget "UITests" */ = {
+		CL_132248253085 /* Build configuration list for PBXNativeTarget "UnitTestsWithHost" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_606904188094 /* Debug */,
-				BC_110911883796 /* Release */,
+				BC_423838356746 /* Debug */,
+				BC_483041203608 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_114615400230 /* Build configuration list for PBXNativeTarget "ios-ext-bin" */ = {
+		CL_140209500333 /* Build configuration list for PBXNativeTarget "ios-app-bin-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_425321227990 /* Debug */,
-				BC_320881675570 /* Release */,
+				BC_848420023639 /* Debug */,
+				BC_320089394545 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_135115533237 /* Build configuration list for PBXNativeTarget "PINOperation-ios-9.0" */ = {
+		CL_140640746934 /* Build configuration list for PBXNativeTarget "ios-app-bin-ios-12.0-Bazel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_861777524381 /* Debug */,
-				BC_685115041786 /* Release */,
+				BC_528004664767 /* Debug */,
+				BC_142442004990 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_210478864884 /* Build configuration list for PBXNativeTarget "ios-app" */ = {
+		CL_140931474443 /* Build configuration list for PBXNativeTarget "UnitTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_117155748321 /* Debug */,
-				BC_194667162303 /* Release */,
+				BC_194515208846 /* Debug */,
+				BC_620672018069 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_273923590342 /* Build configuration list for PBXNativeTarget "ios-app-bin-ios-12.0-Bazel" */ = {
+		CL_158773525708 /* Build configuration list for PBXNativeTarget "Stripe-ios-9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_816260012650 /* Debug */,
-				BC_245963174475 /* Release */,
+				BC_740824605305 /* Debug */,
+				BC_411549963861 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_279102286816 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */ = {
+		CL_207408458888 /* Build configuration list for PBXNativeTarget "strings-extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_220129782512 /* Debug */,
-				BC_289357895108 /* Release */,
+				BC_356070702326 /* Debug */,
+				BC_135740809787 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_363951351315 /* Build configuration list for PBXNativeTarget "UnitTestsWithHost" */ = {
+		CL_273845325521 /* Build configuration list for PBXNativeTarget "PINOperation-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_271500455838 /* Debug */,
-				BC_667865453065 /* Release */,
+				BC_305650925272 /* Debug */,
+				BC_590429648542 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_375541906091 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */ = {
+		CL_275539566864 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_362470988603 /* Debug */,
-				BC_218404434640 /* Release */,
+				BC_845725077389 /* Debug */,
+				BC_751285097717 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_404433001070 /* Build configuration list for PBXNativeTarget "Stripe-ios-9.0" */ = {
+		CL_308849640290 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_685747785851 /* Debug */,
-				BC_184537790990 /* Release */,
+				BC_412463236261 /* Debug */,
+				BC_789455977455 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_406521029219 /* Build configuration list for PBXNativeTarget "share-extension" */ = {
+		CL_330859604680 /* Build configuration list for PBXProject "UrlGet" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_187101092080 /* Debug */,
-				BC_717380365451 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_409503237802 /* Build configuration list for PBXNativeTarget "strings-extension" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_446069699096 /* Debug */,
-				BC_565136169657 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_420127068589 /* Build configuration list for PBXNativeTarget "strings-ext-bin" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_169740105700 /* Debug */,
-				BC_815128483007 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_446505840808 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-12.0" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_556574813047 /* Debug */,
-				BC_491328159843 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_455050505758 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_542562433408 /* Debug */,
-				BC_736318706675 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_500600761176 /* Build configuration list for PBXProject "UrlGet" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_447232414742 /* Debug */,
-				BC_150621858460 /* Release */,
+				BC_879797207798 /* Debug */,
+				BC_421675438846 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		CL_515456468255 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-12.0" */ = {
+		CL_339590863894 /* Build configuration list for PBXNativeTarget "share-extension" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_434255076726 /* Debug */,
-				BC_607425331887 /* Release */,
+				BC_497839252839 /* Debug */,
+				BC_491415690738 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_540659108168 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-12.0" */ = {
+		CL_393790783742 /* Build configuration list for PBXNativeTarget "ios-app" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_513947127784 /* Debug */,
-				BC_546265919656 /* Release */,
+				BC_807360739782 /* Debug */,
+				BC_651398781887 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_542815357791 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-9.0" */ = {
+		CL_413571327928 /* Build configuration list for PBXNativeTarget "UITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_498980328456 /* Debug */,
-				BC_890878123710 /* Release */,
+				BC_716695747056 /* Debug */,
+				BC_908142364004 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_606050766824 /* Build configuration list for PBXNativeTarget "UnitTests" */ = {
+		CL_426131539244 /* Build configuration list for PBXNativeTarget "PINOperation-ios-9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_210761284576 /* Debug */,
-				BC_554607720652 /* Release */,
+				BC_735267783818 /* Debug */,
+				BC_812114312125 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_623276489142 /* Build configuration list for PBXNativeTarget "Stripe-ios-12.0" */ = {
+		CL_442378964830 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_798491664702 /* Debug */,
-				BC_503835760555 /* Release */,
+				BC_185433509870 /* Debug */,
+				BC_433963668782 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_629548608649 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-12.0" */ = {
+		CL_490180650504 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_399832733236 /* Debug */,
-				BC_548516957022 /* Release */,
+				BC_899224958872 /* Debug */,
+				BC_373165712910 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_645411521541 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-9.0" */ = {
+		CL_500728372472 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_733685691463 /* Debug */,
-				BC_492318871976 /* Release */,
+				BC_513547653269 /* Debug */,
+				BC_117181722199 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_682252300927 /* Build configuration list for PBXNativeTarget "siri-ext-bin" */ = {
+		CL_503688096250 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_889379715948 /* Debug */,
-				BC_324145370928 /* Release */,
+				BC_750071534248 /* Debug */,
+				BC_715835469344 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_722755400736 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-9.0" */ = {
+		CL_521258380702 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_139917300954 /* Debug */,
-				BC_622871343929 /* Release */,
+				BC_403892639446 /* Debug */,
+				BC_898269433813 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_766195758934 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */ = {
+		CL_538821595566 /* Build configuration list for PBXNativeTarget "ios-ext-bin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_776797576035 /* Debug */,
-				BC_309998579718 /* Release */,
+				BC_376942035468 /* Debug */,
+				BC_237841757804 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_826359326254 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-9.0" */ = {
+		CL_561293049977 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_621879196080 /* Debug */,
-				BC_190337549444 /* Release */,
+				BC_904086411849 /* Debug */,
+				BC_748966912130 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_848652416968 /* Build configuration list for PBXNativeTarget "UrlGetClasses-ios-12.0" */ = {
+		CL_617004790111 /* Build configuration list for PBXNativeTarget "strings-ext-bin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_815186165823 /* Debug */,
-				BC_382687079397 /* Release */,
+				BC_701135392151 /* Debug */,
+				BC_282894734274 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_854342266175 /* Build configuration list for PBXNativeTarget "ios-app-bin-ios-12.0" */ = {
+		CL_637681236190 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_509459556955 /* Debug */,
-				BC_365074157763 /* Release */,
+				BC_408100935645 /* Debug */,
+				BC_649825156636 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_856017749152 /* Build configuration list for PBXNativeTarget "share-extension-Bazel" */ = {
+		CL_643129213697 /* Build configuration list for PBXNativeTarget "siri-ext-bin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_555117290238 /* Debug */,
-				BC_671516182068 /* Release */,
+				BC_607449207016 /* Debug */,
+				BC_420886103796 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_888995822461 /* Build configuration list for PBXNativeTarget "PINOperation-ios-12.0" */ = {
+		CL_655065637744 /* Build configuration list for PBXNativeTarget "Stripe-Stripe_Bundle_Stripe-ios-9.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_230071728200 /* Debug */,
-				BC_427535732488 /* Release */,
+				BC_233314622511 /* Debug */,
+				BC_897946825383 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_903524758896 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-9.0" */ = {
+		CL_708974059261 /* Build configuration list for PBXNativeTarget "Stripe-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_476602049518 /* Debug */,
-				BC_370056796998 /* Release */,
+				BC_407450855247 /* Debug */,
+				BC_868650691896 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_954961411422 /* Build configuration list for PBXNativeTarget "siri-extension" */ = {
+		CL_729056130422 /* Build configuration list for PBXNativeTarget "HeaderLib-ios-12.0" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_188690671337 /* Debug */,
-				BC_532163083584 /* Release */,
+				BC_602257399297 /* Debug */,
+				BC_334587889643 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_765731174060 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-12.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_894431821962 /* Debug */,
+				BC_376390426793 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_852796935086 /* Build configuration list for PBXNativeTarget "PINCache-Arc-exception-safe-ios-9.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_700794875573 /* Debug */,
+				BC_166416381664 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_891271893429 /* Build configuration list for PBXNativeTarget "share-extension-Bazel" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_888119033248 /* Debug */,
+				BC_520405970072 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_896024321091 /* Build configuration list for PBXNativeTarget "PINCache-Core-ios-9.0" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_170310259182 /* Debug */,
+				BC_556479179760 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_907005147347 /* Build configuration list for PBXNativeTarget "siri-extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_760900726782 /* Debug */,
+				BC_328927905806 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = P_5006007611764 /* Project object */;
+	rootObject = P_3308596046809 /* Project object */;
 }

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests-Bazel.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UITests.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests-Bazel.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost-Bazel.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/UnitTestsWithHost.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-Bazel.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -44,7 +44,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "envVar"
-            value = "blahblah($SRCROOT)"
+            value = "$SRCROOT"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -76,7 +76,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "envVar"
-            value = "blahblah($SRCROOT)"
+            value = "$SRCROOT"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -104,7 +104,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "envVar"
-            value = "blahblah($SRCROOT)"
+            value = "$SRCROOT"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-bin-ios-12.0-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-bin-ios-12.0-Bazel.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-bin-ios-12.0.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app-bin-ios-12.0.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -116,7 +116,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "envVar"
-            value = "blahblah($SRCROOT)"
+            value = "$SRCROOT"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -148,7 +148,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "envVar"
-            value = "blahblah($SRCROOT)"
+            value = "$SRCROOT"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>
@@ -176,7 +176,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "envVar"
-            value = "blahblah($SRCROOT)"
+            value = "$SRCROOT"
             isEnabled = "YES">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension-Bazel.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension.xcscheme
+++ b/IntegrationTests/Goldmaster/UrlGet.xcodeproj/xcshareddata/xcschemes/share-extension.xcscheme
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   version = "1.3"
-   LastUpgradeVersion = "9.2">
+   LastUpgradeVersion = "9.2"
+   version = "1.3">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/IntegrationTests/Goldmaster/WorkspaceSource.xcodeproj/project.pbxproj
+++ b/IntegrationTests/Goldmaster/WorkspaceSource.xcodeproj/project.pbxproj
@@ -7,184 +7,168 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		BF_258036196413 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_614465880679 /* main.m */; };
-		BF_353699704842 = {isa = PBXBuildFile; fileRef = FR_726296517992 /* Some.a */; };
-		BF_375137737692 = {isa = PBXBuildFile; fileRef = FR_484473617036 /* ios-app-Bazel.app */; };
-		BF_435206293492 = {isa = PBXBuildFile; fileRef = FR_713558116485 /* ios-app.app */; };
-		BF_486156737874 /* libios-app-main.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_612396383529 /* libios-app-main.a */; };
-		BF_545062504496 /* libSome.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_112296237438 /* libSome.a */; };
-		BF_715329936370 = {isa = PBXBuildFile; fileRef = FR_586534483093 /* ios-app-main.a */; };
-		BF_730281858833 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_276921814636 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
-		BF_814002908008 /* some.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_852024820486 /* some.m */; };
+		BF_138494853283 /* Stub.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_295308032100 /* Stub.m */; settings = {COMPILER_FLAGS = "-x objective-c -std=gnu99"; }; };
+		BF_195336946084 = {isa = PBXBuildFile; fileRef = FR_237850395315 /* ios-app-main.a */; };
+		BF_249495985633 /* libios-app-main.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_144244140627 /* libios-app-main.a */; };
+		BF_265052477171 = {isa = PBXBuildFile; fileRef = FR_897219047907 /* Some.a */; };
+		BF_535806123334 /* some.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_474369595644 /* some.m */; };
+		BF_567308915796 = {isa = PBXBuildFile; fileRef = FR_315144319434 /* ios-app-Bazel.app */; };
+		BF_700520785793 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = FR_874971823544 /* main.m */; };
+		BF_737029649769 /* libSome.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FR_227467719582 /* libSome.a */; };
+		BF_781573814682 = {isa = PBXBuildFile; fileRef = FR_304018121132 /* ios-app.app */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		FR_112296237438 /* libSome.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libSome.a; sourceTree = "<group>"; };
-		FR_276921814636 /* Stub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Stub.m; sourceTree = "<group>"; };
-		FR_484473617036 /* ios-app-Bazel.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app-Bazel.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_586534483093 /* ios-app-main.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-app-main.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_612396383529 /* libios-app-main.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-app-main.a"; sourceTree = "<group>"; };
-		FR_614465880679 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		FR_713558116485 /* ios-app.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_721433334182 /* some.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = some.h; sourceTree = "<group>"; };
-		FR_726296517992 /* Some.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = Some.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		FR_820566739975 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		FR_852024820486 /* some.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = some.m; sourceTree = "<group>"; };
+		FR_144244140627 /* libios-app-main.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = "libios-app-main.a"; sourceTree = "<group>"; };
+		FR_227467719582 /* libSome.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libSome.a; sourceTree = "<group>"; };
+		FR_237850395315 /* ios-app-main.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = "ios-app-main.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_295308032100 /* Stub.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Stub.m; sourceTree = "<group>"; };
+		FR_304018121132 /* ios-app.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_315144319434 /* ios-app-Bazel.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = "ios-app-Bazel.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR_474369595644 /* some.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = some.m; sourceTree = "<group>"; };
+		FR_499207271634 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		FR_546748966815 /* some.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = some.h; sourceTree = "<group>"; };
+		FR_874971823544 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		FR_897219047907 /* Some.a */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = archive.ar; path = Some.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		FBP_71355811648 /* Frameworks */ = {
+		FBP_30401812113 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_486156737874 /* libios-app-main.a in Frameworks */,
-				BF_545062504496 /* libSome.a in Frameworks */,
+				BF_737029649769 /* libSome.a in Frameworks */,
+				BF_249495985633 /* libios-app-main.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		G_1377348339005 /* Products */ = {
+		G_1201142684894 /* XCHammerAssets */ = {
 			isa = PBXGroup;
 			children = (
-				FR_484473617036 /* ios-app-Bazel.app */,
-				FR_586534483093 /* ios-app-main.a */,
-				FR_713558116485 /* ios-app.app */,
-				FR_726296517992 /* Some.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		G_2163897752666 /* XCHammerAssets */ = {
-			isa = PBXGroup;
-			children = (
-				FR_276921814636 /* Stub.m */,
+				FR_295308032100 /* Stub.m */,
 			);
 			path = XCHammerAssets;
 			sourceTree = "<group>";
 		};
-		G_3014487891267 /* Some */ = {
+		G_3600524832096 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				FR_721433334182 /* some.h */,
-				FR_852024820486 /* some.m */,
+				FR_315144319434 /* ios-app-Bazel.app */,
+				FR_237850395315 /* ios-app-main.a */,
+				FR_304018121132 /* ios-app.app */,
+				FR_897219047907 /* Some.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		G_5199494154145 /* Some */ = {
+			isa = PBXGroup;
+			children = (
+				FR_546748966815 /* some.h */,
+				FR_474369595644 /* some.m */,
 			);
 			path = Some;
 			sourceTree = "<group>";
 		};
-		G_5092960820101 /* external */ = {
+		G_5227465309804 /* external */ = {
 			isa = PBXGroup;
 			children = (
-				G_3014487891267 /* Some */,
+				G_5199494154145 /* Some */,
 			);
 			path = external;
 			sourceTree = "<group>";
 		};
-		G_5965789015147 /* Frameworks */ = {
+		G_5590307095198 /* WorkspaceSource.xcodeproj */ = {
 			isa = PBXGroup;
 			children = (
-				FR_612396383529 /* libios-app-main.a */,
-				FR_112296237438 /* libSome.a */,
+				G_1201142684894 /* XCHammerAssets */,
 			);
-			name = Frameworks;
+			path = WorkspaceSource.xcodeproj;
 			sourceTree = "<group>";
 		};
-		G_6155445260004 = {
+		G_8695492350269 = {
 			isa = PBXGroup;
 			children = (
-				FR_820566739975 /* Info.plist */,
-				FR_614465880679 /* main.m */,
-				G_5092960820101 /* external */,
-				G_7102079962959 /* WorkspaceSource.xcodeproj */,
-				G_5965789015147 /* Frameworks */,
-				G_1377348339005 /* Products */,
+				FR_499207271634 /* Info.plist */,
+				FR_874971823544 /* main.m */,
+				G_5227465309804 /* external */,
+				G_5590307095198 /* WorkspaceSource.xcodeproj */,
+				G_8921522542625 /* Frameworks */,
+				G_3600524832096 /* Products */,
 			);
 			indentWidth = 4;
 			sourceTree = "<group>";
 			tabWidth = 4;
 			usesTabs = 0;
 		};
-		G_7102079962959 /* WorkspaceSource.xcodeproj */ = {
+		G_8921522542625 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				G_2163897752666 /* XCHammerAssets */,
+				FR_144244140627 /* libios-app-main.a */,
+				FR_227467719582 /* libSome.a */,
 			);
-			path = WorkspaceSource.xcodeproj;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXLegacyTarget section */
-		LT_253801448423 /* GeneratedFiles */ = {
-			isa = PBXLegacyTarget;
-			buildArgumentsString = "-c '[[ \"$(ACTION)\" == \"clean\" ]] && (__PWD__/sample/WorkspaceSource/tools/bazelwrapper clean) || (__PWD__/sample/WorkspaceSource/WorkspaceSource.xcodeproj/XCHammerAssets/retry.sh __PWD__/sample/WorkspaceSource/tools/bazelwrapper build --experimental_show_artifacts //WorkspaceSource.xcodeproj/XCHammerAssets:-ios-app_entitlements)'";
-			buildConfigurationList = CL_253801448423 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */;
-			buildPhases = (
-				SBP_25380144842 /* Sources */,
-			);
-			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/WorkspaceSource;
-			dependencies = (
-			);
-			name = GeneratedFiles;
-			passBuildSettingsInEnvironment = 1;
-			productName = GeneratedFiles;
-		};
-		LT_370728357627 /* UpdateXcodeProject */ = {
-			isa = PBXLegacyTarget;
-			buildArgumentsString = "-c __PWD__/sample/WorkspaceSource/WorkspaceSource.xcodeproj/XCHammerAssets/updateXcodeProj.sh";
-			buildConfigurationList = CL_370728357627 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */;
-			buildPhases = (
-				SBP_37072835762 /* Sources */,
-			);
-			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/WorkspaceSource;
-			dependencies = (
-			);
-			name = UpdateXcodeProject;
-			passBuildSettingsInEnvironment = 1;
-			productName = UpdateXcodeProject;
-		};
-		LT_764261940747 /* ResetLLDBInit */ = {
+		LT_436844664534 /* ResetLLDBInit */ = {
 			isa = PBXLegacyTarget;
 			buildArgumentsString = "-c 'echo \"settings clear target.source-map\" > ~/.lldbinit-tulsiproj'";
-			buildConfigurationList = CL_764261940747 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */;
+			buildConfigurationList = CL_436844664534 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */;
 			buildPhases = (
-				SBP_76426194074 /* Sources */,
+				SBP_43684466453 /* Sources */,
 			);
 			buildToolPath = /bin/bash;
-			buildWorkingDirectory = __PWD__/sample/WorkspaceSource;
+			buildWorkingDirectory = "__PWD__/sample/WorkspaceSource";
 			dependencies = (
 			);
 			name = ResetLLDBInit;
 			passBuildSettingsInEnvironment = 1;
 			productName = ResetLLDBInit;
 		};
+		LT_495484788578 /* GeneratedFiles */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "-c '[[ \"$(ACTION)\" == \"clean\" ]] && (__PWD__/sample/WorkspaceSource/tools/bazelwrapper clean) || (__PWD__/sample/WorkspaceSource/WorkspaceSource.xcodeproj/XCHammerAssets/retry.sh __PWD__/sample/WorkspaceSource/tools/bazelwrapper build --experimental_show_artifacts //WorkspaceSource.xcodeproj/XCHammerAssets:-ios-app_entitlements)'";
+			buildConfigurationList = CL_495484788578 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */;
+			buildPhases = (
+				SBP_49548478857 /* Sources */,
+			);
+			buildToolPath = /bin/bash;
+			buildWorkingDirectory = "__PWD__/sample/WorkspaceSource";
+			dependencies = (
+			);
+			name = GeneratedFiles;
+			passBuildSettingsInEnvironment = 1;
+			productName = GeneratedFiles;
+		};
+		LT_645944854015 /* UpdateXcodeProject */ = {
+			isa = PBXLegacyTarget;
+			buildArgumentsString = "-c __PWD__/sample/WorkspaceSource/WorkspaceSource.xcodeproj/XCHammerAssets/updateXcodeProj.sh";
+			buildConfigurationList = CL_645944854015 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */;
+			buildPhases = (
+				SBP_64594485401 /* Sources */,
+			);
+			buildToolPath = /bin/bash;
+			buildWorkingDirectory = "__PWD__/sample/WorkspaceSource";
+			dependencies = (
+			);
+			name = UpdateXcodeProject;
+			passBuildSettingsInEnvironment = 1;
+			productName = UpdateXcodeProject;
+		};
 /* End PBXLegacyTarget section */
 
 /* Begin PBXNativeTarget section */
-		NT_484473617036 /* ios-app-Bazel */ = {
+		NT_237850395315 /* ios-app-main */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_484473617036 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */;
+			buildConfigurationList = CL_237850395315 /* Build configuration list for PBXNativeTarget "ios-app-main" */;
 			buildPhases = (
-				SSBP_4093559547 /* Bazel build */,
-				SBP_48447361703 /* Sources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ios-app-Bazel";
-			productName = "ios-app-Bazel";
-			productReference = FR_484473617036 /* ios-app-Bazel.app */;
-			productType = "com.apple.product-type.application";
-		};
-		NT_586534483093 /* ios-app-main */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL_586534483093 /* Build configuration list for PBXNativeTarget "ios-app-main" */;
-			buildPhases = (
-				SBP_58653448309 /* Sources */,
+				SBP_23785039531 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -192,16 +176,16 @@
 			);
 			name = "ios-app-main";
 			productName = "ios-app-main";
-			productReference = FR_586534483093 /* ios-app-main.a */;
+			productReference = FR_237850395315 /* ios-app-main.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		NT_713558116485 /* ios-app */ = {
+		NT_304018121132 /* ios-app */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_713558116485 /* Build configuration list for PBXNativeTarget "ios-app" */;
+			buildConfigurationList = CL_304018121132 /* Build configuration list for PBXNativeTarget "ios-app" */;
 			buildPhases = (
-				SBP_71355811648 /* Sources */,
-				FBP_71355811648 /* Frameworks */,
-				SSBP_3973133904 /* Process IPA */,
+				SBP_30401812113 /* Sources */,
+				FBP_30401812113 /* Frameworks */,
+				SSBP_8046799506 /* Process IPA */,
 			);
 			buildRules = (
 			);
@@ -209,14 +193,30 @@
 			);
 			name = "ios-app";
 			productName = "ios-app";
-			productReference = FR_713558116485 /* ios-app.app */;
+			productReference = FR_304018121132 /* ios-app.app */;
 			productType = "com.apple.product-type.application";
 		};
-		NT_726296517992 /* Some */ = {
+		NT_315144319434 /* ios-app-Bazel */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CL_726296517992 /* Build configuration list for PBXNativeTarget "Some" */;
+			buildConfigurationList = CL_315144319434 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */;
 			buildPhases = (
-				SBP_72629651799 /* Sources */,
+				SSBP_3532636893 /* Bazel build */,
+				SBP_31514431943 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ios-app-Bazel";
+			productName = "ios-app-Bazel";
+			productReference = FR_315144319434 /* ios-app-Bazel.app */;
+			productType = "com.apple.product-type.application";
+		};
+		NT_897219047907 /* Some */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL_897219047907 /* Build configuration list for PBXNativeTarget "Some" */;
+			buildPhases = (
+				SBP_89721904790 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -224,69 +224,55 @@
 			);
 			name = Some;
 			productName = Some;
-			productReference = FR_726296517992 /* Some.a */;
+			productReference = FR_897219047907 /* Some.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		P_1915470090485 /* Project object */ = {
+		P_4225216229833 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0930;
 				TargetAttributes = {
-					NT_484473617036 = {
+					NT_237850395315 = {
 						ProvisioningStyle = manual;
 					};
-					NT_586534483093 = {
+					NT_304018121132 = {
 						ProvisioningStyle = manual;
 					};
-					NT_713558116485 = {
+					NT_315144319434 = {
 						ProvisioningStyle = manual;
 					};
-					NT_726296517992 = {
+					NT_897219047907 = {
 						ProvisioningStyle = manual;
 					};
 				};
 			};
-			buildConfigurationList = CL_191547009048 /* Build configuration list for PBXProject "WorkspaceSource" */;
+			buildConfigurationList = CL_422521622983 /* Build configuration list for PBXProject "WorkspaceSource" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = G_6155445260004;
+			mainGroup = G_8695492350269;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				LT_253801448423 /* GeneratedFiles */,
-				LT_764261940747 /* ResetLLDBInit */,
-				NT_726296517992 /* Some */,
-				LT_370728357627 /* UpdateXcodeProject */,
-				NT_713558116485 /* ios-app */,
-				NT_484473617036 /* ios-app-Bazel */,
-				NT_586534483093 /* ios-app-main */,
+				LT_495484788578 /* GeneratedFiles */,
+				LT_436844664534 /* ResetLLDBInit */,
+				NT_897219047907 /* Some */,
+				LT_645944854015 /* UpdateXcodeProject */,
+				NT_304018121132 /* ios-app */,
+				NT_315144319434 /* ios-app-Bazel */,
+				NT_237850395315 /* ios-app-main */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		SSBP_3973133904 /* Process IPA */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Process IPA";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "__PWD__/.build/debug/XCHammer process-ipa";
-		};
-		SSBP_4093559547 /* Bazel build */ = {
+		SSBP_3532636893 /* Bazel build */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -300,65 +286,85 @@
 			shellPath = /bin/sh;
 			shellScript = "export TULSI_USE_HAMMER_DEBUG_CONFIG=YES\n__PWD__/.build/debug/bazel_build.py //:ios-app --bazel __PWD__/sample/WorkspaceSource/tools/bazelwrapper";
 		};
+		SSBP_8046799506 /* Process IPA */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Process IPA";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "__PWD__/.build/debug/XCHammer process-ipa";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		SBP_25380144842 /* Sources */ = {
+		SBP_23785039531 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_700520785793 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_30401812113 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF_138494853283 /* Stub.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP_31514431943 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_37072835762 /* Sources */ = {
+		SBP_43684466453 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_48447361703 /* Sources */ = {
+		SBP_49548478857 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_58653448309 /* Sources */ = {
+		SBP_64594485401 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_258036196413 /* main.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		SBP_71355811648 /* Sources */ = {
+		SBP_89721904790 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BF_730281858833 /* Stub.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_72629651799 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				BF_814002908008 /* some.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		SBP_76426194074 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
+				BF_535806123334 /* some.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		BC_158839075006 /* Release */ = {
+		BC_126634353294 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		BC_175142835143 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -370,6 +376,7 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = external;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = "";
@@ -384,19 +391,40 @@
 			};
 			name = Release;
 		};
-		BC_242823987269 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		BC_301455034240 /* Debug */ = {
+		BC_363661781993 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		BC_341662229104 /* Release */ = {
+		BC_404208858852 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = "ios-app-main";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_528424932664 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "";
@@ -410,6 +438,7 @@
 					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
 					"\".\"",
 				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = external;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
@@ -426,9 +455,54 @@
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
 			};
+			name = Debug;
+		};
+		BC_593242437969 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
 			name = Release;
 		};
-		BC_368649955131 /* Release */ = {
+		BC_698246813158 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		BC_720209978589 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		BC_727552058401 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_NAME = Some;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		BC_755189734831 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGNING_REQUIRED = NO;
@@ -436,43 +510,14 @@
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
 				HEADER_SEARCH_PATHS = "";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = "";
 				OTHER_CFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				TARGETED_DEVICE_FAMILY = "";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Release;
-		};
-		BC_481312081777 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"\".\"",
-				);
-				HEADER_SEARCH_PATHS = external;
-				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_LDFLAGS = "-ObjC";
-				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/WorkspaceSource.xcodeproj/XCHammerAssets/-ios-app_entitlements.entitlements";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_BUNDLE_IDENTIFIER = com.Sample;
-				PRODUCT_NAME = "ios-app";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -480,83 +525,22 @@
 			};
 			name = Debug;
 		};
-		BC_552369968888 /* Debug */ = {
+		BC_776479110169 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGNING_REQUIRED = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
+				FRAMEWORK_SEARCH_PATHS = "";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_CFLAGS = "";
 				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = Some;
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_564014637560 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "ios-app-main";
-				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TULSI_WR = $SOURCE_ROOT;
-				USE_HEADERMAP = NO;
-			};
-			name = Debug;
-		};
-		BC_585271997400 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		BC_630063876016 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = "";
-				CLANG_ENABLE_MODULES = NO;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGNING_REQUIRED = NO;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				CODE_SIGN_STYLE = manual;
-				ENABLE_BITCODE = NO;
-				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
-				HEADER_SEARCH_PATHS = external;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LIBRARY_SEARCH_PATHS = "";
-				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
-				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = Some;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
@@ -564,133 +548,161 @@
 			};
 			name = Release;
 		};
-		BC_651266656279 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		BC_724337951379 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		BC_763284512588 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		BC_778627452449 /* Debug */ = {
+		BC_793584446687 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				
 			};
 			name = Debug;
 		};
-		BC_823865494698 /* Release */ = {
+		BC_793995022528 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		BC_842379002706 /* Debug */ = {
+		BC_825071723585 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_MODULES = NO;
+				CLANG_ENABLE_OBJC_ARC = YES;
 				CODE_SIGNING_REQUIRED = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = manual;
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LIBRARY_SEARCH_PATHS = "";
-				OTHER_CFLAGS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
 				OTHER_SWIFT_FLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PYTHONPATH = "${PYTHONPATH}:$(PROJECT_FILE_PATH)/XCHammerAssets";
-				TARGETED_DEVICE_FAMILY = "";
+				PRODUCT_NAME = Some;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				TULSI_WR = $SOURCE_ROOT;
 				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_901257190416 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CODE_SIGNING_REQUIRED = NO;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = manual;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
+					"\".\"",
+				);
+				HAMMER_DIAGNOSTIC_FLAGS = "";
+				HEADER_SEARCH_PATHS = external;
+				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LIBRARY_SEARCH_PATHS = "";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = "-D_FORTIFY_SOURCE=1 -D_FORTIFY_SOURCE=1";
+				OTHER_LDFLAGS = "-ObjC";
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = "-ObjC -sectcreate __TEXT __entitlements $(SRCROOT)/bazel-genfiles/WorkspaceSource.xcodeproj/XCHammerAssets/-ios-app_entitlements.entitlements";
+				OTHER_SWIFT_FLAGS = "";
+				PRODUCT_BUNDLE_IDENTIFIER = com.Sample;
+				PRODUCT_NAME = "ios-app";
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TULSI_WR = $SOURCE_ROOT;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
+		};
+		BC_910342378076 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
 			};
 			name = Debug;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		CL_191547009048 /* Build configuration list for PBXProject "WorkspaceSource" */ = {
+		CL_237850395315 /* Build configuration list for PBXNativeTarget "ios-app-main" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_778627452449 /* Debug */,
-				BC_242823987269 /* Release */,
+				BC_404208858852 /* Debug */,
+				BC_175142835143 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_304018121132 /* Build configuration list for PBXNativeTarget "ios-app" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_528424932664 /* Debug */,
+				BC_901257190416 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_315144319434 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_755189734831 /* Debug */,
+				BC_776479110169 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		CL_422521622983 /* Build configuration list for PBXProject "WorkspaceSource" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC_793584446687 /* Debug */,
+				BC_593242437969 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		CL_253801448423 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */ = {
+		CL_436844664534 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_301455034240 /* Debug */,
-				BC_651266656279 /* Release */,
+				BC_363661781993 /* Debug */,
+				BC_793995022528 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_370728357627 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */ = {
+		CL_495484788578 /* Build configuration list for PBXLegacyTarget "GeneratedFiles" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_763284512588 /* Debug */,
-				BC_724337951379 /* Release */,
+				BC_910342378076 /* Debug */,
+				BC_720209978589 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_484473617036 /* Build configuration list for PBXNativeTarget "ios-app-Bazel" */ = {
+		CL_645944854015 /* Build configuration list for PBXLegacyTarget "UpdateXcodeProject" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_842379002706 /* Debug */,
-				BC_368649955131 /* Release */,
+				BC_126634353294 /* Debug */,
+				BC_698246813158 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
-		CL_586534483093 /* Build configuration list for PBXNativeTarget "ios-app-main" */ = {
+		CL_897219047907 /* Build configuration list for PBXNativeTarget "Some" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC_564014637560 /* Debug */,
-				BC_158839075006 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_713558116485 /* Build configuration list for PBXNativeTarget "ios-app" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_481312081777 /* Debug */,
-				BC_341662229104 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_726296517992 /* Build configuration list for PBXNativeTarget "Some" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_552369968888 /* Debug */,
-				BC_630063876016 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = "";
-		};
-		CL_764261940747 /* Build configuration list for PBXLegacyTarget "ResetLLDBInit" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC_585271997400 /* Debug */,
-				BC_823865494698 /* Release */,
+				BC_727552058401 /* Debug */,
+				BC_825071723585 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = "";
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = P_1915470090485 /* Project object */;
+	rootObject = P_4225216229833 /* Project object */;
 }

--- a/IntegrationTests/Goldmaster/WorkspaceSource.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
+++ b/IntegrationTests/Goldmaster/WorkspaceSource.xcodeproj/xcshareddata/xcschemes/ios-app.xcscheme
@@ -3,8 +3,8 @@
    version = "1.3"
    LastUpgradeVersion = "9.2">
    <BuildAction
-      parallelizeBuildables = "NO"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      parallelizeBuildables = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -140,7 +140,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      revealArchiveInOrganizer = "YES"
-      buildConfiguration = "Debug">
+      buildConfiguration = "Debug"
+      revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/sample/Tailor/AppDelegate.swift
+++ b/sample/Tailor/AppDelegate.swift
@@ -1,5 +1,8 @@
 import UIKit
 
+// FIXME: Module name here is automatically pinned to the name of the lib
+import tailor
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?

--- a/sample/Tailor/BUILD
+++ b/sample/Tailor/BUILD
@@ -11,12 +11,23 @@ ios_application(
     families = ["iphone"],
     infoplists = ["Info.plist"],
     visibility = ["//visibility:public"],
-    deps = ["ios-app-main"],
+    deps = [":ios-app-main"],
 )
 
 swift_library(
     name = "ios-app-main",
     srcs = [
         "AppDelegate.swift",
-    ]
+    ],
+    deps = [":tailor"]
+)
+
+swift_library(
+    name = "tailor",
+    srcs = [
+        "Tailor.swift",
+    ],
+    # TODO: Add the ability to customize a module name.
+    # This works, but not in Xcode!
+    module_name = "tailor"
 )

--- a/sample/Tailor/Tailor.swift
+++ b/sample/Tailor/Tailor.swift
@@ -1,0 +1,2 @@
+
+public let ConstantValue = 42

--- a/sample/Tailor/XCHammer.yaml
+++ b/sample/Tailor/XCHammer.yaml
@@ -1,5 +1,5 @@
 targets:
-    - ":ios-app"
+    - "//:ios-app"
 
 projects:
     "Tailor":


### PR DESCRIPTION
This commit adds an example to Tailor to exemplify a basic dependency on
a `swift_library`.

More minimal examples of `swift_library` will be added to `Tailor` to
validate they work correctly