### PR TITLE
Extract Swift version from copts

### DIFF
--- a/sample/Tailor/BUILD
+++ b/sample/Tailor/BUILD
@@ -29,5 +29,8 @@ swift_library(
     ],
     # TODO: Add the ability to customize a module name.
     # This works, but not in Xcode!
-    module_name = "tailor"
+    module_name = "tailor",
+    copts = [
+      "-swift-version 4.2"
+    ]
 )


### PR DESCRIPTION
- Explicitly define logic for other means of determining the swift version
- Update sample project to specify swiftcopt `-swift-version 4.2`