### PR TITLE
[RFC] Local developer metrics API and implementation

### DIFF
--- a/Sources/XCHammer/XCHammerConfig.swift
+++ b/Sources/XCHammer/XCHammerConfig.swift
@@ -151,11 +151,23 @@ struct XCHammerConfig: Codable {
     /// All of the projects keyed by Project name
     let projects: [String: XCHammerProjectConfig]
 
+    /// A metrics executable.
+    /// XCHammer pipes metrics to this executable in the background to track
+    /// generation times. Additionally, Xcode schemes are setup to log build
+    /// times.
+    ///
+    /// @note It supports the statsd format.
+    /// To write to statsd on localhost, simply provide a
+    /// `metricsExecutable` via nc
+    /// nc -w1 localhost 1337
+    let metricsExecutable: String?
+
     func getTargetConfig(for label: String) -> XCHammerTargetConfig? {
         return targetConfig?[label]
     }
 
-    static let empty: XCHammerConfig = XCHammerConfig(targets: [], targetConfig: [:], projects: [:])
+    static let empty: XCHammerConfig = XCHammerConfig(targets: [], targetConfig:
+            [:], projects: [:], metricsExecutable: nil)
 }
 
 enum XCHammerConfigValidationError : Error {

--- a/Sources/XCHammer/XCHammerLogger.swift
+++ b/Sources/XCHammer/XCHammerLogger.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import PathKit
+import ShellOut
 
 /// Warning: this logger is not thread safe
 public class XCHammerLogger {
@@ -140,8 +141,22 @@ public class XCHammerProfiler {
 }
 
 extension XCHammerProfiler {
-    public func logEnd(_ dumpToStandardOutput: Bool = false) {
+    public func logEnd(_ dumpToStandardOutput: Bool = false, metricsExecutable:
+            String? = nil) {
         end()
+        if let metricsExecutable = metricsExecutable {
+            let currentTS = String(format: "%.0f", Date().timeIntervalSince1970)
+            let elapsedMS = String(format: "%.4f",
+                    endDate!.timeIntervalSince(startDate) * 1000)
+            // TODO: Add hostname
+            let tsd = "put xchammer.\(name) \(currentTS) \(elapsedMS)"
+            let command: String = ([
+                "/bin/bash",
+                "-c",
+                "'echo \(tsd) | \(metricsExecutable) &'" 
+            ]).joined(separator: " ")
+            let _ = try? ShellOut.shellOut(to: [command])
+        }
         XCHammerLogger.shared().log(loggableDescription(), dumpToStandardOutput: dumpToStandardOutput)
     }
 }


### PR DESCRIPTION
This commit adds the ability to log generation and build times to statsd
in XCHammmer. Through `XCHammerConfig`, user provides XCHammer with a
binary that can recieve statsd events on standard input and act on
events.