### PR TITLE
Correct XCHammer config bazel options docstrings

### DIFF
--- a/Sources/XCHammer/XCHammerConfig.swift
+++ b/Sources/XCHammer/XCHammerConfig.swift
@@ -24,10 +24,10 @@ struct XCHammerTargetConfig: Codable {
 
     /// Bazel Target options
 
-    /// Build options passed to the Bazel invocation
+    /// Options passed to `bazel build`.
     let buildBazelOptions: String?
 
-    /// Startup options passed to the Bazel build invocation
+    /// Options passed to `bazel` itself. This applies to any subcommand.
     let buildBazelStartupOptions: String?
 
     /// Template for the `Bazel build` runscript relative to the


### PR DESCRIPTION
By my interpretation, the documentation for `buildBazelOptions` and `buildBazelStartupOptions` are reversed. Specifically, `buildBazelStartupOptions` referred to "Bazel build invocation" and `buildBazelOptions` referred just to "Bazel invocation".

This change is an attempt to try to make the distinction between the two configs more clear.