### PR TITLE
Experimental Xcode project Skylark DSL

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,6 +23,16 @@ load(
     "namespaced_name",
 )
 
+load(
+    "//tools:xchammerconfig.bzl",
+    "xchammer_config",
+    "gen_xchammer_config",
+    "project_config",
+    "target_config",
+    "execution_action",
+    "scheme_action_config",
+)
+
 swift_library(
     name = "Sources",
     srcs = glob(["Sources/**/*.swift"]),
@@ -63,4 +73,13 @@ macos_application(
 buildifier(
     name = "buildifier"
 )
+
+xchammer_config = xchammer_config(
+    targets=["//:xchammer"],
+    projects={ 
+        "xchammer-bazel":
+            project_config(paths=["**"])
+    })
+
+gen_xchammer_config(name="xchammer_config", config=xchammer_config)
 

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,12 @@ workspace_spm: aspects generate_xcodeproj
 # - this is under development and doesn't fully work
 # - incremental builds are currently not working with Bazel
 # - run with `force` for development
+# - the DSL is not fully integrated into XCHammer - this make target needs to
+#   create the XCHammer.yaml out of band.
 workspace_xchammer: build
+	tools/bazelwrapper build :xchammer_config
 	$(XCHAMMER_BIN) generate \
-	    $(ROOT_DIR)/XCHammer.yaml \
+		bazel-genfiles/xchammer_config/XCHammer.json \
 	    --bazel $(ROOT_DIR)/tools/bazelwrapper \
 	    --force
 
@@ -247,3 +250,7 @@ ci: clean bazelrc_home test run_perf_ci run_swift
 
 format:
 	$(ROOT_DIR)/tools/bazelwrapper run buildifier
+
+.PHONY:
+xchammer_config:
+	tools/bazelwrapper build xchammer_config

--- a/Sources/XCHammer/main.swift
+++ b/Sources/XCHammer/main.swift
@@ -36,7 +36,13 @@ enum CommandError: Error {
 
 func getHammerConfig(path: Path) throws -> XCHammerConfig {
     let data = try Data(contentsOf: URL(fileURLWithPath: path.string))
-    let config = try YAMLDecoder().decode(XCHammerConfig.self, from: String(data: data, encoding: .utf8)!)
+    let config: XCHammerConfig
+    if path.extension?.lowercased() == "json" {
+        config = try JSONDecoder().decode(XCHammerConfig.self, from: data)
+    } else {
+        config = try YAMLDecoder().decode(XCHammerConfig.self, from:
+                String(data: data, encoding: .utf8)!)
+    }
     return config
 }
 

--- a/XCHammer.yaml
+++ b/XCHammer.yaml
@@ -1,7 +1,0 @@
-targets:
-    - "//:xchammer"
-
-projects:
-    "xchammer-bazel":
-        paths:
-            - "**"

--- a/tools/xchammerconfig.bzl
+++ b/tools/xchammerconfig.bzl
@@ -1,0 +1,81 @@
+# Experimental XCHammer DSL.
+
+def _gen_dsl_impl(ctx):
+    ctx.file_action(
+        content=ctx.attr.ast,
+        output=ctx.outputs.xchammerconfig
+    )
+
+
+_gen_dsl = rule(
+    implementation=_gen_dsl_impl,
+    output_to_genfiles=True,
+    attrs={
+        "ast": attr.string(mandatory=True),
+    },
+    outputs={"xchammerconfig": "%{name}/XCHammer.json"}
+)
+
+
+def gen_dsl(
+        name,
+        ast):
+    m = ast.to_json()
+    _gen_dsl(name=name, ast=m)
+
+def gen_xchammer_config(name, config):
+    gen_dsl(name=name, ast=config)
+
+
+def scheme_action_config(
+    command_line_arguments=None,  # [String: Bool]?
+    environment_variables=None, # [EnvironmentVariable]
+    pre_actions=None,  # [ExecutionAction]?
+    post_actions=None  # [ExecutionAction]?
+):
+    return struct(command_line_arguments=command_line_arguments, environment_variables=environment_variables, pre_actions=pre_actions, post_actions=post_actions)
+
+
+def execution_action(
+    script,  # String
+    name=None,  # String
+    settings_target=None  # String
+):
+    return struct(script=script, name=name, settings_target=settings_target)
+
+
+def environment_variable(
+    variable,  # String
+    value,  # String
+    enabled=None  # Bool
+):
+    return struct(variable=variable, value=value, enabled=enabled)
+
+
+def target_config(
+    scheme_config, # [String /*SchemeActionType*/ : XCHammerSchemeActionConfig]?
+    build_bazel_options=None,  # String?
+    # Startup options passed to the Bazel build invocation
+    build_bazel_startup_options=None,  # String?
+    build_bazel_template=None,  # String?
+    xcconfig_overrides=None  # [String: String]?
+):
+    return struct(scheme_config=scheme_config, build_bazel_options=build_bazel_options, build_bazel_startup_options=build_bazel_startup_options,build_bazel_template=build_bazel_template, xcconfig_overrides=xcconfig_overrides)
+
+
+def project_config(
+    paths,  # [String]?
+    build_bazel_platform_options=None,  # [String: [String]]?
+    generate_transitive_xcode_targets=None,  # Bool
+    generate_xcode_schemes=None,  # Bool
+    xcconfig_overrides=None  # : [String: String]?
+):
+    return struct(paths=paths, build_bazel_platform_options=build_bazel_platform_options, generate_transitive_xcode_targets=generate_transitive_xcode_targets, generate_xcode_schemes=generate_xcode_schemes, xcconfig_overrides=xcconfig_overrides)
+
+
+def xchammer_config(
+    targets,  # [String]
+    projects,  # [String: XCHammerProjectConfig]
+    target_config=None  # [String: XCHammerTargetConfig]?
+):
+    return struct(targets=targets, target_config=target_config, projects=projects)


### PR DESCRIPTION
This patch makes it possible to setup Xcode projects as rules inside of
Bazel through a DSL.

Going down the path of user provided runscripts complicates the painful
YAML XCHammerConfig.

Open questions about this include:
- Overall E2E perf impact
- How to automatically build the DSL from XCHammer directly.

Right now, this is just experimental and those questions should be
resolved in the future.