### PR TITLE
Pass target build options to Tulsi aspect

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -105,7 +105,7 @@
         "repositoryURL": "https://github.com/pinterest/Tulsi.git",
         "state": {
           "branch": null,
-          "revision": "654784aa316a9ab936c18afe644fdf545e25d0a5",
+          "revision": "f6f7601b94ab78a73966b0c3fffa60804723dc0e",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
 
         // Changes reside in the xchammer branch
         .package(url: "https://github.com/pinterest/Tulsi.git",
-            .revision("654784aa316a9ab936c18afe644fdf545e25d0a5")),
+            .revision("f6f7601b94ab78a73966b0c3fffa60804723dc0e")),
 
         // Note: XcodeGen now transitively depends on this one, so the versions
         // must match!

--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -864,8 +864,9 @@ enum Generator {
         logger.logInfo("Reading Bazel configurations")
         let workspaceInfoResult = doResult {
             return try TulsiHooks.getWorkspaceInfo(labels:
-                config.buildTargetLabels, bazelPath: bazelPath,
-                workspaceRootPath: workspaceRootPath)
+                config.buildTargetLabels, options:
+                config.targetConfig?.compactMap { $0.value.buildBazelOptions },
+                bazelPath: bazelPath, workspaceRootPath: workspaceRootPath)
         }
         entryMapProfiler.logEnd(true)
 

--- a/Sources/XCHammer/TulsiHooks.swift
+++ b/Sources/XCHammer/TulsiHooks.swift
@@ -17,15 +17,20 @@ import TulsiGenerator
 import PathKit
 
 enum TulsiHooks {
-    static func getWorkspaceInfo(labels: [BuildLabel], bazelPath: Path,
-            workspaceRootPath: Path) throws ->
+    static func getWorkspaceInfo(labels: [BuildLabel], options: [String]?,
+            bazelPath: Path, workspaceRootPath: Path) throws ->
         XCHammerBazelWorkspaceInfo {
         let ungeneratedProjectName = "Some"
+        let options = options.map {
+            [TulsiOptionKey.BazelBuildOptionsDebug.rawValue: [
+                TulsiOption.ProjectValueKey: $0.joined(separator: " ")
+            ]]
+        }
         let config = TulsiGeneratorConfig(projectName: ungeneratedProjectName,
                 buildTargetLabels: labels,
                 pathFilters: Set(),
                 additionalFilePaths: [],
-                options: TulsiOptionSet(),
+                options: TulsiOptionSet(fromDictionary: options ?? [:]),
                 bazelURL: TulsiParameter(value: bazelPath.url,
                     source: .options))
         return try TulsiRuleEntryMapExtractor.extract(config:

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -228,8 +228,8 @@ def xchammer_dependencies():
 
     namespaced_git_repository(
         name = "Tulsi",
-        remote = "https://github.com/pinterest/Tulsi.git",
-        commit = "654784aa316a9ab936c18afe644fdf545e25d0a5",
+        remote = "https://github.com/kastiglione/Tulsi.git",
+        commit = "f6f7601b94ab78a73966b0c3fffa60804723dc0e",
         patch_cmds = [
             """
          sed -i '' 's/\:__subpackages__/visibility\:public/g' src/TulsiGenerator/BUILD


### PR DESCRIPTION
Our setup makes use configurable attributes using [`select()`](https://docs.bazel.build/versions/master/be/functions.html#select). These `--define key=value` flags are required when running the tulsi aspect to resolve those attributes. This change passes `buildBazelOptions` through to `BazelWorkspaceInfoExtractor` so that the aspect can run successfully.

To do this, a few things in Tulsi needed to be made `public`. For this change to work, will I need to make a pull request to https://github.com/pinterest/Tulsi?