### PR TITLE
Migrate away from genfiles directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ workspace_spm: aspects generate_xcodeproj
 workspace_xchammer: build
 	tools/bazelwrapper build :xchammer_config
 	$(XCHAMMER_BIN) generate \
-		bazel-genfiles/xchammer_config/XCHammer.json \
+		bazel-bin/xchammer_config/XCHammer.json \
 	    --bazel $(ROOT_DIR)/tools/bazelwrapper \
 	    --force
 

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -239,7 +239,7 @@ public class XcodeTarget: Hashable, Equatable {
         case .sourceFile:
             return "$(SRCROOT)/" + resolveExternalPath(for: fileInfo.subPath)
         case .generatedFile:
-            return "$(SRCROOT)/bazel-genfiles/" + fileInfo.subPath
+            return "$(SRCROOT)/bazel-bin/" + fileInfo.subPath
         }
     }
 
@@ -248,7 +248,7 @@ public class XcodeTarget: Hashable, Equatable {
         case .sourceFile:
             return resolveExternalPath(for: fileInfo.subPath)
         case .generatedFile:
-            return "bazel-genfiles/" + fileInfo.subPath
+            return "bazel-bin/" + fileInfo.subPath
         }
     }
 
@@ -571,7 +571,7 @@ public class XcodeTarget: Hashable, Equatable {
                             return processedOpt
                         } else {
                             return opt.replacingOccurrences(of: "__BAZEL_GEN_DIR__",
-                                with: "$(SRCROOT)/bazel-genfiles")
+                                with: "$(SRCROOT)/bazel-bin")
                         }
                     }
                     settings.copts <>= processedOpts
@@ -667,7 +667,7 @@ public class XcodeTarget: Hashable, Equatable {
                 .filter { !$0.0.contains("tulsi-includes") }
                 .foldMap { (path: String, isRecursive: Bool) in
                 if path.hasSuffix("module_map") {
-                    return ["$(SRCROOT)/bazel-genfiles/\(path)"]
+                    return ["$(SRCROOT)/bazel-bin/\(path)"]
                 } else if isRecursive {
                     return ["$(SRCROOT)/\(path)/**"]
                 } else {
@@ -951,7 +951,7 @@ public class XcodeTarget: Hashable, Equatable {
                 .replacingOccurrences(of: genOptions.workspaceRootPath.string,
                                     with: "")
         let targetName = label.asFullPBXTargetName!
-        return "$(SRCROOT)/bazel-genfiles" + relativeProjDir + "/XCHammerAssets/" + targetName + ".entitlements"
+        return "$(SRCROOT)/bazel-bin" + relativeProjDir + "/XCHammerAssets/" + targetName + ".entitlements"
     }
 
     var mobileProvisionProfileFile: String? {
@@ -1050,7 +1050,7 @@ public class XcodeTarget: Hashable, Equatable {
             .map {
                 return getXCSourceRootAbsolutePath(for: $0)
                     // __BAZEL_GEN_DIR__ is a custom toolchain make variable
-                    // resolve that to $(SRCROOT)/bazel-genfiles.
+                    // resolve that to $(SRCROOT)/bazel-bin.
                     .replacingOccurrences(of: "__BAZEL_GEN_DIR__", with: "")
              }
     }

--- a/XCHammerAssets/Hammer.bzl
+++ b/XCHammerAssets/Hammer.bzl
@@ -52,7 +52,6 @@ entitlements_writer = rule(
     attrs = {
         "entitlements": attr.label(mandatory = True),
     },
-    output_to_genfiles = True,
 )
 
 def export_entitlements(

--- a/sample/UrlGet/Vendor/rules_pods/BazelExtensions/extensions.bzl
+++ b/sample/UrlGet/Vendor/rules_pods/BazelExtensions/extensions.bzl
@@ -141,7 +141,6 @@ def _make_module_map_impl(ctx):
 
 _gen_module_map = rule(
     implementation = _make_module_map_impl,
-    output_to_genfiles = True,
     attrs = {
         "pod_name": attr.string(mandatory = True),
         "hdrs": attr.label_list(mandatory = True),

--- a/sample/UrlGet/ios-app/BUILD
+++ b/sample/UrlGet/ios-app/BUILD
@@ -104,6 +104,7 @@ genrule(
     # builds, during build time. If you don't use Xcode build, this tag doesn't
     # matter. ( See Docs/XCHammerFAQ.md for more info )
     tags = ["xchammer"],
+    output_to_bindir = True,
 )
 
 load("@build_bazel_rules_apple//apple:ios.bzl", "ios_unit_test")

--- a/tools/xchammerconfig.bzl
+++ b/tools/xchammerconfig.bzl
@@ -9,7 +9,6 @@ def _gen_dsl_impl(ctx):
 
 _gen_dsl = rule(
     implementation=_gen_dsl_impl,
-    output_to_genfiles=True,
     attrs={
         "ast": attr.string(mandatory=True),
     },


### PR DESCRIPTION
As mentioned in #136, Bazel will be removing the `bazel-genfiles` symlink. Maybe there's better ways to transition XCHammer users, but one way is to require that people enable `output_to_bindir` on their `genrules`. This would be a breaking change.