### PR TITLE
Add target and system info to statsd events

### DIFF
--- a/tools/instrumentation_helpers/README.md
+++ b/tools/instrumentation_helpers/README.md
@@ -1,0 +1,53 @@
+# XCHammer instrumentation helpers
+
+A collection of scripts to add the ability to log stats on local build time and
+generation events via `statsd`.
+
+Note: this is a work in progress and is highly subject to change.
+
+## Installation
+
+First import the scripts wherever XCHammer is running from ( e.g. the main repo )
+
+Next, instrumentation can be added as a post and pre action:
+
+e.g. Using the `XCHammerConfig` DSL or setting this in  `XCHammerConfig` directly
+
+```
+
+script_base = "$SRCROOT/tools/instrumentation_helpers"
+
+log_build_start_action = execution_action(
+    name="Track build start",
+    script="{}/statsd_pre_build_action.sh".format(script_base))
+
+log_build_end_action = execution_action(
+    name="Report build end",
+    script="python {}/statsd_post_build_action.py &".format(script_base)
+)
+
+app_scheme_config={
+    "Build": scheme_action_config(
+        post_actions=[log_build_end_action],
+        pre_actions=[log_build_start_action])
+}
+
+# Setup an app target config, to use the scheme actions
+app_target_config = target_config(
+    build_bazel_template="tools/V2XCHammerBuildRunscriptTemplate.sh.tpl",
+    build_bazel_options="$(SPAWN_OPTS)",
+    build_bazel_startup_options="$(STARTUP_OPTS)",
+    scheme_config=app_scheme_config)
+
+xchammer_config = xchammer_config(
+    targets=[
+        "//Pinterest/iOS/App:PinterestDevelopment",
+    ],
+    target_config={
+        "//Pinterest/iOS/App:PinterestDevelopment": app_target_config,
+    }
+)
+
+gen_xchammer_config(name="xchammer_config", config=xchammer_config)
+```
+

--- a/tools/instrumentation_helpers/instrumentor.py
+++ b/tools/instrumentation_helpers/instrumentor.py
@@ -1,23 +1,90 @@
 import os
 import time
+import re
 import socket
 import json
+import platform
+import multiprocessing
+import getpass
 
+# Set this to the value of the statsd backend
+# Consider:
+# - allowing the user to specify this as a config
+# - adding the ability to load hooks as an external repo.
 TSD_HOST = ""
 TSD_PORT = 80
-
 TSD_TIMEOUT_SEC = 5
+INVALID_LABEL_REG = re.compile(r"[^\._a-zA-Z0-9]")
+
+
+def extract_profile_line(line, item):
+    if item in line:
+        result = line.split(item + ": ")
+        if len(result) > 1:
+            return result[1]
+    return None
+
+
+def get_system_profile():
+    process = os.popen("system_profiler SPHardwareDataType")
+    result = process.read()
+    lines = result.split("\n")
+    output = {}
+    for line in lines:
+        memory = extract_profile_line(line, "Memory")
+        if memory:
+            output["memory"] = memory
+
+        model_identifier = extract_profile_line(line, "Model Identifier")
+        if model_identifier:
+            output["model_identifier"] = model_identifier
+
+        processor_speed  = extract_profile_line(line, "Processor Speed")
+        if processor_speed:
+            output["processor_speed"] = processor_speed
+
+        processor_name  = extract_profile_line(line, "Processor Name")
+        if processor_name:
+            output["processor_name"] = processor_name
+
+        # Get some stats about the host
+        output["os_version"] = platform.mac_ver()[0]
+
+        # This will optionally print the number of virtual cores - see docs for more info
+        output["cpu_count"] = multiprocessing.cpu_count()
+
+        output["host"] = socket.gethostname()
+
+        output["username"] = getpass.getuser()
+    return output
+
+
+def get_tsd(tags_dict):
+    items = []
+    for key, value in tags_dict.items():
+        str_val = str(value)
+        items.append("{}={}".format(key, INVALID_LABEL_REG.sub("_", str_val)))
+    return " ".join(items)
+
 
 def write_tsd(metric, delta):
     timestamp = int(round(time.time()))
-    tags = "host={}".format(socket.gethostname())
-    tsd = "put {metric} {timestamp} {delta} {tags}\n".format(metric=metric,
-                                                           timestamp=timestamp,
-                                                           delta=delta,
-                                                           tags=tags)
+
+    tags_dict = get_system_profile()
+    build_target = os.environ.get("TARGET_NAME")
+    if build_target:
+        tags_dict["target"] = build_target
+
+    tags = get_tsd(tags_dict)
+    tsd = "put {metric} {timestamp} {delta} {tags}\n".format(
+        metric=metric,
+        timestamp=timestamp,
+        delta=delta,
+        tags=tags)
     try:
-        sock = socket.create_connection((TSD_HOST, TSD_PORT),
-                                        timeout=TSD_TIMEOUT_SEC)
+        sock = socket.create_connection(
+            (TSD_HOST, TSD_PORT),
+            timeout=TSD_TIMEOUT_SEC)
         sock.sendall(tsd)
         sock.close()
     except Exception:
@@ -26,20 +93,20 @@ def write_tsd(metric, delta):
 
 def write_build_metric():
     start_time_f = os.path.join(
-        os.environ.get('TARGET_BUILD_DIR'),'xchammer.build_start')
+        os.environ.get("TARGET_BUILD_DIR"), "xchammer.build_start")
     start_time = os.path.getmtime(start_time_f)
     delta = ((time.time()-start_time)*1000)
     write_tsd("xchammer.build", delta)
 
 
 def write_last_generation_metric():
-    build_dir = os.environ.get('OBJROOT')
+    build_dir = os.environ.get("OBJROOT")
     if build_dir:
         base_path = build_dir
     else:
         base_path = "/private/var/tmp"
 
-    last_generation_log = os.path.join(base_path, 'xchammer.log')
+    last_generation_log = os.path.join(base_path, "xchammer.log")
     with open(last_generation_log, "r") as f:
         for l, i in enumerate(f):
             json_str = i.split("\n")[0]

--- a/tools/instrumentation_helpers/instrumentor.py
+++ b/tools/instrumentation_helpers/instrumentor.py
@@ -69,12 +69,7 @@ def get_tsd(tags_dict):
 
 def write_tsd(metric, delta):
     timestamp = int(round(time.time()))
-
     tags_dict = get_system_profile()
-    build_target = os.environ.get("TARGET_NAME")
-    if build_target:
-        tags_dict["target"] = build_target
-
     tags = get_tsd(tags_dict)
     tsd = "put {metric} {timestamp} {delta} {tags}\n".format(
         metric=metric,
@@ -96,7 +91,12 @@ def write_build_metric():
         os.environ.get("TARGET_BUILD_DIR"), "xchammer.build_start")
     start_time = os.path.getmtime(start_time_f)
     delta = ((time.time()-start_time)*1000)
-    write_tsd("xchammer.build", delta)
+    metric = "xchammer.build"
+    build_target = os.environ.get("TARGET_NAME")
+    if build_target:
+        metric += "." + build_target
+
+    write_tsd(metric, delta)
 
 
 def write_last_generation_metric():

--- a/tools/instrumentation_helpers/statsd_post_generate_action.py
+++ b/tools/instrumentation_helpers/statsd_post_generate_action.py
@@ -1,4 +1,3 @@
 import instrumentor
-# Write the build metric and then write the last generation metric
 instrumentor.write_last_generation_metric()
 


### PR DESCRIPTION
This PR adds the ability to differentiate between Xcode targets e.g.
`PinterestDevelopment`
and
`PinterestDevelopment-Bazel`

Additionally, write info along with `xchammer.generate` and
`xchammer.build` to statsd.