### PR TITLE
Update to Bazel 0.21.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ PREFIX := /usr/local
 
 aspects:
 ifneq ($(BAZEL_BUILD),true)
-	swift package resolve
 	# Export the tulsi workspace to PWD. We need this for
 	# Xcode, because there is no way to correctly install
 	# resources.

--- a/Package.resolved
+++ b/Package.resolved
@@ -105,7 +105,7 @@
         "repositoryURL": "https://github.com/pinterest/Tulsi.git",
         "state": {
           "branch": null,
-          "revision": "654784aa316a9ab936c18afe644fdf545e25d0a5",
+          "revision": "bd3132735414ce30650a622aed5399c02105cc14",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
 
         // Changes reside in the xchammer branch
         .package(url: "https://github.com/pinterest/Tulsi.git",
-            .revision("654784aa316a9ab936c18afe644fdf545e25d0a5")),
+            .revision("bd3132735414ce30650a622aed5399c02105cc14")),
 
         // Note: XcodeGen now transitively depends on this one, so the versions
         // must match!

--- a/Sources/XCHammer/TulsiRuleEntryMapExtractor.swift
+++ b/Sources/XCHammer/TulsiRuleEntryMapExtractor.swift
@@ -41,6 +41,7 @@ public enum TulsiRuleEntryMapExtractor {
                 platformConfigOption:
                 config.options[.ProjectGenerationPlatformConfiguration],
                 prioritizeSwiftOption: config.options[.ProjectPrioritizesSwift],
+                useArm64_32Option: config.options[.UseArm64_32],
                 features: features)
         return XCHammerBazelWorkspaceInfo(bazelExecRoot: execRoot, ruleEntryMap:
                 ruleEntryMap)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,23 +1,16 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.8.0",
+    tag = "0.12.0",
 )
 
 load(
     "@build_bazel_rules_apple//apple:repositories.bzl",
     "apple_rules_dependencies",
 )
-
 apple_rules_dependencies()
-
-git_repository(
-    name = "build_bazel_rules_swift",
-    remote = "https://github.com/bazelbuild/rules_swift.git",
-    commit = "8f594d9a9b39ce471064cc13d35c07ea77a24628",
-)
 
 load(
     "@build_bazel_rules_swift//swift:repositories.bzl",
@@ -25,6 +18,14 @@ load(
 )
 
 swift_rules_dependencies()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+http_file(
+    name = "xctestrunner",
+    executable = 1,
+    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.6/ios_test_runner.par"],
+)
 
 ## SPM Dependencies
 

--- a/export_tulsi_aspect_dir.sh
+++ b/export_tulsi_aspect_dir.sh
@@ -4,17 +4,17 @@ if [[ $(basename $EXPORT_DIR) != "tulsi-aspects" ]]; then
 	echo "Path must end in tulsi-aspects"
 	exit 0
 fi
-echo "Working around Swift Package managers ability to handle Tulsi..."
 
-ROOT_DIR=$PWD
-TULSI=$(ls -t -d $PWD/.build/checkouts/Tulsi.git-* | head -n1)
+# Fetch xchammer
+tools/bazelwrapper fetch xchammer
 
-cd $TULSI
-echo "Building Tulsi resources"
-xcodebuild build -quiet -scheme TulsiApp -derivedDataPath $PWD/tulsi_build -project src/Tulsi.xcodeproj/ -configuration Release
+TULSI_DIR="$(tools/bazelwrapper info output_base)/external/xchammer-Tulsi"
 
-echo "Exporting resources to $1"
-# Export resources
 rm -rf $EXPORT_DIR
+mkdir $EXPORT_DIR
 
-cp -r tulsi_build/Build/Products/Release/TulsiGenerator.framework/Resources/ $EXPORT_DIR
+mkdir $EXPORT_DIR/tulsi/
+ditto $TULSI_DIR/src/TulsiGenerator/Bazel/* $EXPORT_DIR/tulsi/
+
+ditto $TULSI_DIR/src/TulsiGenerator/Scripts/* $EXPORT_DIR
+

--- a/sample/Frankenstein/tools/bazelwrapper
+++ b/sample/Frankenstein/tools/bazelwrapper
@@ -10,8 +10,8 @@ trap popd > /dev/null ERR EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.18.0"
-BAZEL_VERSION_SHA="6f07346c72d9eaea0561386a1dc49ae0b8a60f39b180cbbab930e705f3d7a3c4"
+BAZEL_VERSION="0.21.0"
+BAZEL_VERSION_SHA="5e40dcf12a18990ffe5830fb5c83297aed090fd6e6c7c5b2eb720c19a33044fc"
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"

--- a/sample/SnapshotMe/tools/bazelwrapper
+++ b/sample/SnapshotMe/tools/bazelwrapper
@@ -10,8 +10,8 @@ trap popd > /dev/null ERR EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.18.0"
-BAZEL_VERSION_SHA="6f07346c72d9eaea0561386a1dc49ae0b8a60f39b180cbbab930e705f3d7a3c4"
+BAZEL_VERSION="0.21.0"
+BAZEL_VERSION_SHA="5e40dcf12a18990ffe5830fb5c83297aed090fd6e6c7c5b2eb720c19a33044fc"
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"

--- a/sample/Tailor/tools/bazelwrapper
+++ b/sample/Tailor/tools/bazelwrapper
@@ -10,8 +10,8 @@ trap popd > /dev/null ERR EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.18.0"
-BAZEL_VERSION_SHA="6f07346c72d9eaea0561386a1dc49ae0b8a60f39b180cbbab930e705f3d7a3c4"
+BAZEL_VERSION="0.21.0"
+BAZEL_VERSION_SHA="5e40dcf12a18990ffe5830fb5c83297aed090fd6e6c7c5b2eb720c19a33044fc"
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"

--- a/sample/UrlGet/Vendor/rules_pods/tools/bazelwrapper
+++ b/sample/UrlGet/Vendor/rules_pods/tools/bazelwrapper
@@ -7,12 +7,16 @@ SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
 pushd "$SCRIPTPATH/.." > /dev/null
 trap popd > /dev/null ERR EXIT
 
-BAZEL_VERSION="0.12.0rc1"
-BAZEL_VERSION_SHA="fe9bf6e4d920c668f28a37d5d2ea11cee38871e90ccf5c2a52c7a327dd6de9a9"
-BAZEL_VERSION_URL="https://releases.bazel.build/0.12.0/rc1/bazel-0.12.0rc1-installer-darwin-x86_64.sh"
+# Go to bazel release page
+# These are typically posted in groups.google
+# https://groups.google.com/forum/#!forum/bazel-discuss
+BAZEL_VERSION="0.21.0"
+BAZEL_VERSION_SHA="5e40dcf12a18990ffe5830fb5c83297aed090fd6e6c7c5b2eb720c19a33044fc"
+BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"
 BAZEL_PATH="$BAZEL_ROOT/bin/bazel"
+XCODE_SELECT_ENV_PATH="${SCRIPTPATH}/.xcode_select_env"
 LEGACY_BAZEL_PATH="$SCRIPTPATH/../Scripts/bazel/bin/bazel"
 
 BAZEL=""
@@ -50,7 +54,38 @@ if ! [[ -e "$BAZEL" ]]; then
 fi
 
 if [[ -x "${BAZEL}" ]]; then
-    exec -a "$0" /usr/bin/env - TERM=$TERM SHELL=$SHELL PATH=$PATH HOME=$HOME "${BAZEL}" "$@"
+  CURRENT_XCODE_PATH="$(/usr/bin/xcode-select -p)"
+  XCODE_VERSION=$(/usr/bin/xcodebuild -version | grep Xcode | cut -d ' ' -f2)
+  CURRENT_XCODE_HASH="${CURRENT_XCODE_PATH}-${XCODE_VERSION}-${BAZEL_VERSION}"
+  if [[ -f "${XCODE_SELECT_ENV_PATH}" ]]; then
+    EXISTING_XCODE_HASH="$(cat "${XCODE_SELECT_ENV_PATH}")"
+    if [[ $EXISTING_XCODE_HASH != $CURRENT_XCODE_HASH ]]; then
+      echo "Xcode select path or Bazel version has changed, must clear cached data"
+      $BAZEL clean --expunge
+    fi
+  fi
+  echo "${CURRENT_XCODE_HASH}" > $XCODE_SELECT_ENV_PATH
+
+  # Make variable support
+  # In the context of Xcode builds, variables are defined as "Make variable"
+  # strings.
+  # In practice, the variables are stored as strings, and then later assigned to
+  # the value of the current environment.
+  ARGS=()
+  for ARG in "$@"; do
+      if [[ "$ARG" =~ \$(.*) ]]; then
+        # Get the name of the make variable
+        MAKEVAR=$(echo $ARG | sed 's,.*\$(\(.*\)).*,\1,g')
+        # Next, parameter expansion of the variable by name
+        VALUE="${!MAKEVAR}"
+        REPLACED="$(echo $ARG | sed "s,\$(\(.*\)),$VALUE,g")"
+        ARGS+=(${REPLACED})
+      else
+        ARGS+=("${ARG}")
+      fi
+  done
+
+  exec -a "$0" /usr/bin/env - TERM=$TERM SHELL=$SHELL PATH=$PATH HOME=$HOME "${BAZEL}" "${ARGS[@]}"
 else
   echo "WARNING: Missing installation of bazel" >&2;
   exit 1

--- a/sample/UrlGet/WORKSPACE
+++ b/sample/UrlGet/WORKSPACE
@@ -1,9 +1,9 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", system_git_repository = "git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.8.0",
+    tag = "0.12.0"
 )
 
 load(
@@ -13,8 +13,17 @@ load(
 
 apple_rules_dependencies()
 
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
 http_file(
     name = "xctestrunner",
     executable = 1,
-    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.3/ios_test_runner.par"],
+    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.6/ios_test_runner.par"],
 )

--- a/sample/UrlGet/tools/bazelwrapper
+++ b/sample/UrlGet/tools/bazelwrapper
@@ -10,8 +10,8 @@ trap popd > /dev/null ERR EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.18.0"
-BAZEL_VERSION_SHA="6f07346c72d9eaea0561386a1dc49ae0b8a60f39b180cbbab930e705f3d7a3c4"
+BAZEL_VERSION="0.21.0"
+BAZEL_VERSION_SHA="5e40dcf12a18990ffe5830fb5c83297aed090fd6e6c7c5b2eb720c19a33044fc"
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"

--- a/sample/WorkspaceSource/tools/bazelwrapper
+++ b/sample/WorkspaceSource/tools/bazelwrapper
@@ -10,8 +10,8 @@ trap popd > /dev/null ERR EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.18.0"
-BAZEL_VERSION_SHA="6f07346c72d9eaea0561386a1dc49ae0b8a60f39b180cbbab930e705f3d7a3c4"
+BAZEL_VERSION="0.21.0"
+BAZEL_VERSION_SHA="5e40dcf12a18990ffe5830fb5c83297aed090fd6e6c7c5b2eb720c19a33044fc"
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -229,7 +229,7 @@ def xchammer_dependencies():
     namespaced_git_repository(
         name = "Tulsi",
         remote = "https://github.com/pinterest/Tulsi.git",
-        commit = "654784aa316a9ab936c18afe644fdf545e25d0a5",
+        commit = "bd3132735414ce30650a622aed5399c02105cc14",
         patch_cmds = [
             """
          sed -i '' 's/\:__subpackages__/visibility\:public/g' src/TulsiGenerator/BUILD

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -10,8 +10,8 @@ trap popd > /dev/null ERR EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.18.0"
-BAZEL_VERSION_SHA="6f07346c72d9eaea0561386a1dc49ae0b8a60f39b180cbbab930e705f3d7a3c4"
+BAZEL_VERSION="0.21.0"
+BAZEL_VERSION_SHA="5e40dcf12a18990ffe5830fb5c83297aed090fd6e6c7c5b2eb720c19a33044fc"
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"


### PR DESCRIPTION
This commit includes several changes for Bazel 0.21.0, including:

- Bump XCHammer to latest rules_apple, Tulsi
- Rewrite export script to use bazel ( Xcode project is gone )
- Fix TulsiGenerator update errors
- Bump Tulsi for Swift 4.2 fixes
- Update UrlGet rules_apple, test runners
- Update all bazelwrappers to 0.21.0