### PR TITLE
Fix SPM build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,11 @@ else
 	@ditto $(ASPECTDIR) .build/$(CONFIG)/
 endif
 
-# Build impl doesn't build aspects because it is slow.
 build: aspects build-debug
-	@ln -sf $(PWD)/.build/debug sample/UrlGet/tools/XCHammer
+	@# Hacks for SPM build
+	@rm -rf .build/debug/debug || true # This creates a cycle
+	@[[ "$(SAMPLE)" ]] && \
+	    (ditto $(PWD)/.build/debug sample/$(SAMPLE)/tools/XCHammer || true)
 
 test: build
 	XCHAMMER_BIN=$(XCHAMMER_BIN) SAMPLE=UrlGet $(ROOT_DIR)/IntegrationTests/run_tests.sh

--- a/export_tulsi_aspect_dir.sh
+++ b/export_tulsi_aspect_dir.sh
@@ -16,5 +16,12 @@ mkdir $EXPORT_DIR
 mkdir $EXPORT_DIR/tulsi/
 ditto $TULSI_DIR/src/TulsiGenerator/Bazel/* $EXPORT_DIR/tulsi/
 
+# Need to move the workspace file
+mv $EXPORT_DIR/tulsi/WORKSPACE $EXPORT_DIR
+
 ditto $TULSI_DIR/src/TulsiGenerator/Scripts/* $EXPORT_DIR
+rm -rf $EXPORT_DIR/BUILD
+
+# Cleanup unused test files
+find $EXPORT_DIR -name *tests\.py -exec rm -rf {} \;
 

--- a/sample/Frankenstein/WORKSPACE
+++ b/sample/Frankenstein/WORKSPACE
@@ -1,9 +1,9 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", system_git_repository = "git_repository")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.8.0",
+    tag = "0.12.0"
 )
 
 load(
@@ -13,8 +13,17 @@ load(
 
 apple_rules_dependencies()
 
+load(
+    "@build_bazel_rules_swift//swift:repositories.bzl",
+    "swift_rules_dependencies",
+)
+
+swift_rules_dependencies()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
 http_file(
     name = "xctestrunner",
     executable = 1,
-    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.3/ios_test_runner.par"],
+    urls = ["https://github.com/google/xctestrunner/releases/download/0.2.6/ios_test_runner.par"],
 )


### PR DESCRIPTION
A few quick fixes to issues found in SPM builds. In Bazel `0.21`, there is a `glob *` added, which picks up a circular symlink which _may_ exist in samples.