### PR TITLE
Update to the latest bazel (0.23.2) and rules_apple (0.14.0) releases

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,7 +3,7 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.13.0",
+    tag = "0.14.0",
 )
 
 load(

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -64,9 +64,8 @@ swift_c_module(
         module_map = module_map,
     ))
 
-def namespaced_swift_library(name, srcs, deps = None, cc_libs = None, defines = None):
+def namespaced_swift_library(name, srcs, deps = None, defines = None):
     deps = [] if deps == None else deps
-    cc_libs = [] if cc_libs == None else cc_libs
     defines = [] if defines == None else defines
     return """
 swift_library(
@@ -75,13 +74,11 @@ swift_library(
     module_name = "{name}",
     deps = [{deps}],
     defines = [{defines}],
-    cc_libs = [{cc_libs}]
 )""".format(**dict(
         name = name,
         srcs = ",\n".join(['"%s"' % x for x in srcs]),
         defines = ",\n".join(['"%s"' % x for x in defines]),
         deps = ",\n".join(['"%s"' % namespaced_dep_name(x) for x in deps]),
-        cc_libs = ",\n".join(['"%s"' % namespaced_dep_name(x) for x in cc_libs]),
     ))
 
 def xchammer_dependencies():
@@ -312,8 +309,7 @@ module CYaml {
             namespaced_swift_library(
                 name = "Yams",
                 srcs = ["Sources/Yams/*.swift"],
-                deps = [":CYaml"],
-                cc_libs = [":CYamlLib"],
+                deps = [":CYaml", ":CYamlLib"],
                 defines = ["SWIFT_PACKAGE"],
             ),
         ]),

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -10,8 +10,8 @@ trap popd > /dev/null ERR EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.21.0"
-BAZEL_VERSION_SHA="5e40dcf12a18990ffe5830fb5c83297aed090fd6e6c7c5b2eb720c19a33044fc"
+BAZEL_VERSION="0.23.2"
+BAZEL_VERSION_SHA="53fa727fd0bcce3e1953eef2eddd6b4c6f959cb34cb453f57787fd55874b6bc3"
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"


### PR DESCRIPTION
This change updates our repository to pass cc_libs as deps. The
current implementation uses the CcInfo provider to get cc_libs vs having
a separate argument entirely.