### PR TITLE
Pure Xcode Swift support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,8 @@
 
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-PRODUCT=xchammer
-XCHAMMER_BIN_BASE=$(ROOT_DIR)/xchammer.app/Contents/MacOS
-
-XCHAMMER_BIN := $(XCHAMMER_BIN_BASE)/$(PRODUCT)
+PRODUCT := xchammer.app
+XCHAMMER_BIN := $(ROOT_DIR)/$(PRODUCT)/Contents/MacOS/XCHammer
 
 PREFIX := /usr/local
 
@@ -22,7 +20,6 @@ workspace: build
 clean:
 	$(ROOT_DIR)/tools/bazelwrapper clean
 
-archive: CONFIG = release
 archive: build-release
 
 # Brew support
@@ -43,7 +40,6 @@ compile_commands.json:
 	cat .build/commands_build.log | spm-vim compile_commands
 
 
-build-debug: CONFIG = debug
 build-debug: BAZELFLAGS = --announce_rc \
 	--disk_cache=$(HOME)/Library/Caches/Bazel
 build-debug: build-impl
@@ -96,10 +92,10 @@ run: build
 # FIXME: add code to handle `xcworkspace` to `run`
 run_workspace: build
 	$(XCHAMMER_BIN) generate \
-		$(ROOT_DIR)/sample/SnapshotMe/XCHammer.yaml \
-	    --workspace_root $(ROOT_DIR)/sample/SnapshotMe \
-	    --xcworkspace $(ROOT_DIR)/sample/SnapshotMe/SnapshotMe.xcworkspace \
-	    --bazel $(ROOT_DIR)/sample/SnapshotMe/tools/bazelwrapper
+               $(ROOT_DIR)/sample/SnapshotMe/XCHammer.yaml \
+           --workspace_root $(ROOT_DIR)/sample/SnapshotMe \
+           --xcworkspace $(ROOT_DIR)/sample/SnapshotMe/SnapshotMe.xcworkspace \
+           --bazel $(ROOT_DIR)/sample/SnapshotMe/tools/bazelwrapper
 
 run_force: build
 	$(XCHAMMER_BIN) generate \

--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -162,6 +162,7 @@ struct XCBuildSettings: Encodable {
     var mobileProvisionProfileFile: First<String>?
     var codeSignEntitlementsFile: First<String>?
     var moduleMapFile: First<String>?
+    var moduleName: First<String>?
     // Disable Xcode derived headermaps, be explicit to avoid divergence
     var useHeaderMap: First<String>? = First("NO")
     var swiftVersion: First<String>?
@@ -176,6 +177,7 @@ struct XCBuildSettings: Encodable {
         // Add to this list the known XCConfig keys
         case copts = "OTHER_CFLAGS"
         case productName = "PRODUCT_NAME"
+        case moduleName = "PRODUCT_MODULE_NAME"
         case enableModules = "CLANG_ENABLE_MODULES"
         case headerSearchPaths = "HEADER_SEARCH_PATHS"
         case frameworkSearchPaths = "FRAMEWORK_SEARCH_PATHS"
@@ -256,6 +258,7 @@ struct XCBuildSettings: Encodable {
         try mobileProvisionProfileFile.map { try container.encode($0.v, forKey: .mobileProvisionProfileFile) }
         try codeSignEntitlementsFile.map { try container.encode($0.v, forKey: .codeSignEntitlementsFile) }
         try moduleMapFile.map { try container.encode($0.v, forKey: .moduleMapFile) }
+        try moduleName.map { try container.encode($0.v, forKey: .moduleName) }
         try useHeaderMap.map { try container.encode($0.v, forKey: .useHeaderMap) }
         try testTargetName.map { try container.encode($0.v, forKey: .testTargetName) }
         try pythonPath.map { try container.encode($0.v, forKey: .pythonPath) }
@@ -305,6 +308,7 @@ extension XCBuildSettings: Monoid {
             mobileProvisionProfileFile: lhs.mobileProvisionProfileFile <> rhs.mobileProvisionProfileFile,
             codeSignEntitlementsFile: lhs.codeSignEntitlementsFile <> rhs.codeSignEntitlementsFile,
             moduleMapFile: lhs.moduleMapFile <> rhs.moduleMapFile,
+            moduleName: lhs.moduleName <> rhs.moduleName,
             useHeaderMap: lhs.useHeaderMap <> rhs.useHeaderMap,
             swiftVersion: lhs.swiftVersion <> rhs.swiftVersion,
             swiftCopts: lhs.swiftCopts <> rhs.swiftCopts,

--- a/Sources/XCHammer/XcodeTargetMap.swift
+++ b/Sources/XCHammer/XcodeTargetMap.swift
@@ -24,7 +24,7 @@ func flattenedInner(targetMap: XcodeTargetMap) -> [XcodeTarget] {
     return targetMap.allTargets
         .filter(shouldFlatten)
         .flatMap { $0.unfilteredDependencies }
-        .filter { $0.type.contains("ios_application") == false }
+        .filter { $0.type.contains("application") == false }
         .filter { !$0.label.value.hasPrefix("//Vendor") }
 }
 

--- a/sample/SnapshotMe/WORKSPACE
+++ b/sample/SnapshotMe/WORKSPACE
@@ -1,9 +1,12 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.13.0",
+    # This is 1 commit behind 0.16.1 which upgraded to a broken verison of
+    # rules_swift on Bazel 0.24.1
+    commit = "eaf5817105d1aa8c473b4e5c3ddfdc34b36b071f",
 )
 
 load(

--- a/sample/SnapshotMe/ios-app/BUILD
+++ b/sample/SnapshotMe/ios-app/BUILD
@@ -12,6 +12,7 @@ ios_application(
     infoplists = ["Info.plist"],
     visibility = ["//visibility:public"],
     deps = [":ios-app-main"],
+    minimum_os_version = "12.0"
 )
 
 objc_library(

--- a/sample/SnapshotMe/tools/bazelwrapper
+++ b/sample/SnapshotMe/tools/bazelwrapper
@@ -5,13 +5,23 @@ set -e
 # Make sure we're in the project root directory.
 SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
 pushd "$SCRIPTPATH/.." > /dev/null
-trap popd > /dev/null ERR EXIT
+
+function exit_trap() {
+  popd 2 &> /dev/null
+  if [[ ! -z $BAZEL_DEBUG_ACTION_CACHE ]]; then
+    echo "INFO: dumping action cache post"
+    mkdir -p bazel-diags
+    $BAZEL dump --action_cache > bazel-diags/bazel-action-cache-post.txt
+  fi
+}
+
+trap exit_trap EXIT
 
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.21.0"
-BAZEL_VERSION_SHA="5e40dcf12a18990ffe5830fb5c83297aed090fd6e6c7c5b2eb720c19a33044fc"
+BAZEL_VERSION="0.24.1"
+BAZEL_VERSION_SHA="5fe570423945424a8c44b35c6d171fdde92e9ed90c3c321b83f2e380bcc966b9"
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 
 BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"

--- a/sample/WorkspaceSource/WORKSPACE
+++ b/sample/WorkspaceSource/WORKSPACE
@@ -36,12 +36,6 @@ http_file(
     urls = ["https://github.com/google/xctestrunner/releases/download/0.2.6/ios_test_runner.par"],
 )
 
-## SPM Dependencies
-
-load("//third_party:repositories.bzl", "xchammer_dependencies")
-
-xchammer_dependencies()
-
 ## Buildifier deps (Bazel file formatting)
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -37,7 +37,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_c_module",
 
 def namespaced_swift_c_library(name, srcs, hdrs, includes, module_map):
     return """
-cc_library(
+objc_library(
   name = "{name}Lib",
   srcs = glob([
     {srcs}
@@ -47,8 +47,7 @@ cc_library(
   ]),
   includes = [
     {includes}
-  ],
-  linkstatic = True
+  ]
 )
 
 swift_c_module(
@@ -74,7 +73,7 @@ swift_library(
     module_name = "{name}",
     deps = [{deps}],
     defines = [{defines}],
-    copts = [{copts}],
+    copts = ["-DSWIFT_PACKAGE", {copts}],
 )""".format(**dict(
         name = name,
         srcs = ",\n".join(['"%s"' % x for x in srcs]),
@@ -261,7 +260,7 @@ def xchammer_dependencies():
     namespaced_git_repository(
         name = "Tulsi",
         remote = "https://github.com/pinterest/Tulsi.git",
-        commit = "0e17ac96f76a64c014785f9fdf1a49e8bc8dc006",
+        commit = "badd7b512abde05524a620c466e9acc17a7268a5",
         patch_cmds = [
             """
          sed -i '' 's/\:__subpackages__/visibility\:public/g' src/TulsiGenerator/BUILD


### PR DESCRIPTION
This PR gets swift programs ( and XCHammer ) building with Xcode to fix
indexing and semantic editor features.

It uses Bazel specified module maps, and fully uses Xcode's build system
to build the swift modules. This approach is as "vanilla" as possible:
it doesn't use Bazel to build anything, and Bazel builds its own swift
modules.

Includes:
- Tulsi bump ( propagate module name for swift fix )
- Using objc library, for deps in repositories.bzl as cc_library is busted
- Better support for bundled sources
- Include resolution to _tulsi_includes
- Propagation of swift_c_module

Known issues, TODOS, and FIXMES:
- swift module dependencies are built with Target deps ATM, which is
incompatible with mutli project mode.
- It passes the module name to the compiler from Xcode. This will
probably conflict and cause issues where it's set elsewhere so more
testing is required.
- It hardcodes `DSWIFT_PACKAGE` which will belong in an XCHammer xcconfig