### PR TITLE
Remove unneeded version mismatch warning

### DIFF
--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -132,10 +132,6 @@ enum Generator {
         # This file is governed by XCHammer
         set -e
 
-        if [[ "\(BinaryVersion)" != "\(CommandLine.arguments[0]) --version" ]]; then 
-            echo "warning: XCHammer version mismatch"
-        fi
-
         if [[ $ACTION == "clean" ]]; then
             exit 0
         fi


### PR DESCRIPTION
This was broken and didn't actually do anything anyways.