### PR TITLE
Add codepath to sign plugins

### DIFF
--- a/XCHammerAssets/codesigner.sh
+++ b/XCHammerAssets/codesigner.sh
@@ -32,5 +32,6 @@ echo "Signing.."
 ditto $PROFILE $WORK_DIR/embedded.mobileprovision
 
 ls $WORK_DIR/Frameworks/* >& /dev/null && /usr/bin/codesign --force --sign $VERIFIED_ID --entitlements $ENTITLEMENTS $WORK_DIR/Frameworks/*
+ls $WORK_DIR/PlugIns/* >& /dev/null && /usr/bin/codesign --force --sign $VERIFIED_ID --entitlements $ENTITLEMENTS $WORK_DIR/PlugIns/*
 
 /usr/bin/codesign --force --sign $VERIFIED_ID --entitlements $ENTITLEMENTS $WORK_DIR


### PR DESCRIPTION
Previously, we only signed frameworks. This is needed for running test
bundles on devices from Xcode