### PR TITLE
Prevent `make install` from polluting /usr/local/bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,10 @@ archive: build-release
 install: archive
 	mkdir -p $(PREFIX)/bin
 	ditto $(PRODUCT) $(PREFIX)/bin/$(PRODUCT)
+	ln -s $(PREFIX)/bin/$(PRODUCT)/Contents/MacOS/xchammer $(PREFIX)/bin/xchammer
 
 uninstall:
+	unlink $(PREFIX)/bin/xchammer
 	rm -rf $(PREFIX)/bin/$(PRODUCT)
 
 .PHONY: compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ archive: build-release
 # Brew support
 install: archive
 	mkdir -p $(PREFIX)/bin
-	ditto $(PRODUCT) $(PREFIX)/bin/
+	ditto $(PRODUCT) $(PREFIX)/bin/$(PRODUCT)
 
 uninstall:
-	rm -rf $(PREFIX)/bin/*
+	rm -rf $(PREFIX)/bin/$(PRODUCT)
 
 .PHONY: compile_commands.json
 # https://github.com/swift-vim/SwiftPackageManager.vim
@@ -155,7 +155,7 @@ bazelrc_home:
 	echo "build --disk_cache=$(HOME)/Library/Caches/Bazel \\" > ~/.bazelrc
 	echo "     --spawn_strategy=standalone" >> ~/.bazelrc
 
-ci: bazelrc_home test run_perf_ci run_swift 
+ci: bazelrc_home test run_perf_ci run_swift
 
 format:
 	$(ROOT_DIR)/tools/bazelwrapper run buildifier


### PR DESCRIPTION
- When running `make install`, a directory will be created at `/usr/local/bin/xchammer.app` instead of moving the contents of `xchammer.app` to `/usr/local/bin`
- When running `make uninstall`, the directory `/usr/local/bin/xchammer.app` will be removed instead of the contents of `/usr/local/bin`
- A symlink from `/usr/local/bin/xchammer.app/Contents/MacOS/xchammer` to `/usr/local/bin/xchammer` will be created so that `xchammer` commands can be run from Terminal

Fixes #76 
Fixes #170 

