### PR TITLE
Add more instrumentation around gen

### DIFF
--- a/Sources/XCHammer/ProjectWriter.swift
+++ b/Sources/XCHammer/ProjectWriter.swift
@@ -48,10 +48,16 @@ enum ProjectWriter {
         }
 
         // generate the project from the spec
+        // The time to convert from XcodeGen -> xcproj
+        let genProfiler = XCHammerProfiler("xcode_gen.generate_xcproj")
         let generator = ProjectGenerator(project: xcodeGenSpec)
         let xcproj = try generator.generateXcodeProject()
-        try xcproj.write(path: xcodeProjPath)
+        genProfiler.logEnd(true)
 
+        // The time to actually write an xcproj
+        let writeProfiler = XCHammerProfiler("xcproj.write")
+        try xcproj.write(path: xcodeProjPath)
+        writeProfiler.logEnd(true)
 
         /*
              MyProject.xcodeproj


### PR DESCRIPTION
Add fine grained insturmentation to split out the difference between
generating an xcproj and writing it to disk.

This allows us to visualize the difference in the 2 phases