### PR TITLE
Enable new build system by default

### DIFF
--- a/Sources/XCHammer/ProjectWriter.swift
+++ b/Sources/XCHammer/ProjectWriter.swift
@@ -78,8 +78,6 @@ enum ProjectWriter {
                         <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
                         <plist version="1.0">
                         <dict>
-                            <key>BuildSystemType</key>
-                            <string>Original</string>
                             <key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
                             <false/>
                         </dict>


### PR DESCRIPTION
We had the new build system disabled for a reason that has been resolved, let’s enable
It again