### PR TITLE
Xcode target configuration aspect

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,6 +43,16 @@ apple_resource_group(
     ]),
 )
 
+
+
+load(
+    "//BazelExtensions:xcode_configuration_provider.bzl",
+    "declare_target_config",
+)
+
+# This is an example of declaring a target config.
+declare_target_config(name="XCHammerSourcesXcodeConfig", config=target_config())
+
 swift_library(
     name = "XCHammerSources",
     srcs = glob(["Sources/**/*.swift"]),
@@ -64,7 +74,7 @@ swift_library(
         "XcodeGen//:ProjectSpec",
         "XcodeProj//:XcodeProj",
         "Yams//:Yams",
-    ]],
+    ]] + [":XCHammerSourcesXcodeConfig" ],
     copts = [
         "-swift-version",
         "4.2"
@@ -133,9 +143,11 @@ load(
     "xcode_project",
 )
 
+
+
 xcode_project(
     name="workspace_v2",
-    targets=["//:xchammer", "//tools/XCConfigExporter:xcconfig-exporter"],
+    targets=["//:xchammer",  "//tools/XCConfigExporter:xcconfig-exporter"],
     bazel="tools/bazelwrapper",
     xchammer="xchammer.app"
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -143,13 +143,12 @@ load(
     "xcode_project",
 )
 
-
-
 xcode_project(
     name="workspace_v2",
     targets=["//:xchammer",  "//tools/XCConfigExporter:xcconfig-exporter"],
     bazel="tools/bazelwrapper",
-    xchammer="xchammer.app"
+    xchammer="xchammer.app",
+    project_config=project_config(["**"])
 )
 
 

--- a/BazelExtensions/xchammerconfig.bzl
+++ b/BazelExtensions/xchammerconfig.bzl
@@ -1,5 +1,6 @@
 # Experimental XCHammer DSL.
 
+
 def _gen_dsl_impl(ctx):
     ctx.file_action(
         content = ctx.attr.ast,

--- a/BazelExtensions/xcode_configuration_provider.bzl
+++ b/BazelExtensions/xcode_configuration_provider.bzl
@@ -1,0 +1,56 @@
+XcodeProjectTargetInfo = provider(
+fields = {"target_config_json_str":"""
+JSON string of target_config
+Note: this must be a string as it's a rule input
+"""})
+
+def _declare_target_config_impl(ctx):
+  return struct(
+     providers=[XcodeProjectTargetInfo(target_config_json_str=ctx.attr.json)],
+     objc=apple_common.new_objc_provider(),
+  )
+
+_declare_target_config = rule(
+    implementation=_declare_target_config_impl,
+    output_to_genfiles=True,
+    attrs = {
+        "json": attr.string(mandatory=True),
+    },
+)
+
+def declare_target_config(name, config):
+    """ Declare a target configuration for an Xcode project
+    This rule takes a `target_config` from XCHammerConfig
+    and aggregates it onto the depgraph
+    """
+    _declare_target_config(name=name, json=config.to_json())
+
+XcodeConfigurationAspectInfo = provider(
+fields = {"value":"""This is the value of the JSON
+"""})
+
+def _target_config_aspect_impl(itarget, ctx):
+    infos = []
+    if XcodeProjectTargetInfo in itarget:
+        target = itarget
+        json = struct(label=str(itarget.label), value=target[XcodeProjectTargetInfo].target_config_json_str)
+        infos.extend([XcodeConfigurationAspectInfo(value=json)])
+
+    # Assumptions:
+    # A target has a dep of a single XcodeProjectTargetInfo
+    if hasattr(ctx.rule.attr, "deps"):
+        for target in ctx.rule.attr.deps:
+            if XcodeConfigurationAspectInfo in target:
+                infos.append(XcodeConfigurationAspectInfo(value=target[XcodeConfigurationAspectInfo].value))
+
+            if XcodeProjectTargetInfo in target:
+                json = struct(label=str(itarget.label), value=target[XcodeProjectTargetInfo].target_config_json_str)
+                infos.extend([XcodeConfigurationAspectInfo(value=json)])
+
+    return infos
+
+target_config_aspect = aspect(
+    implementation = _target_config_aspect_impl,
+    attr_aspects = ["deps"],
+)
+

--- a/BazelExtensions/xcode_configuration_provider.bzl
+++ b/BazelExtensions/xcode_configuration_provider.bzl
@@ -1,56 +1,64 @@
 XcodeProjectTargetInfo = provider(
-fields = {"target_config_json_str":"""
+    fields={
+        "target_config_json_str": """
 JSON string of target_config
 Note: this must be a string as it's a rule input
-"""})
+"""
+    }
+)
+
 
 def _declare_target_config_impl(ctx):
-  return struct(
-     providers=[XcodeProjectTargetInfo(target_config_json_str=ctx.attr.json)],
-     objc=apple_common.new_objc_provider(),
-  )
+    return struct(
+        providers=[XcodeProjectTargetInfo(target_config_json_str=ctx.attr.json)],
+        objc=apple_common.new_objc_provider(),
+    )
+
 
 _declare_target_config = rule(
     implementation=_declare_target_config_impl,
     output_to_genfiles=True,
-    attrs = {
-        "json": attr.string(mandatory=True),
-    },
+    attrs={"json": attr.string(mandatory=True)},
 )
 
-def declare_target_config(name, config):
+
+def declare_target_config(name, config, **kwargs):
     """ Declare a target configuration for an Xcode project
     This rule takes a `target_config` from XCHammerConfig
     and aggregates it onto the depgraph
     """
-    _declare_target_config(name=name, json=config.to_json())
+    _declare_target_config(name=name, json=config.to_json().replace("\\", ""), **kwargs)
+
 
 XcodeConfigurationAspectInfo = provider(
-fields = {"value":"""This is the value of the JSON
-"""})
+    fields={
+        "values": """This is the value of the JSON
+"""
+    }
+)
+
 
 def _target_config_aspect_impl(itarget, ctx):
     infos = []
+    if ctx.rule.kind == "_declare_target_config":
+        return []
+    info_map = {}
     if XcodeProjectTargetInfo in itarget:
         target = itarget
-        json = struct(label=str(itarget.label), value=target[XcodeProjectTargetInfo].target_config_json_str)
-        infos.extend([XcodeConfigurationAspectInfo(value=json)])
+        info_map[str(itarget.label)] = target[XcodeProjectTargetInfo].target_config_json_str
 
-    # Assumptions:
-    # A target has a dep of a single XcodeProjectTargetInfo
     if hasattr(ctx.rule.attr, "deps"):
         for target in ctx.rule.attr.deps:
             if XcodeConfigurationAspectInfo in target:
-                infos.append(XcodeConfigurationAspectInfo(value=target[XcodeConfigurationAspectInfo].value))
+                for info in target[XcodeConfigurationAspectInfo].values:
+                    info_map[info] = target[XcodeConfigurationAspectInfo].values[info]
 
-            if XcodeProjectTargetInfo in target:
-                json = struct(label=str(itarget.label), value=target[XcodeProjectTargetInfo].target_config_json_str)
-                infos.extend([XcodeConfigurationAspectInfo(value=json)])
+            elif XcodeProjectTargetInfo in target:
+                info_map[str(itarget.label)] = target[XcodeProjectTargetInfo].target_config_json_str
 
-    return infos
+    return XcodeConfigurationAspectInfo(values=info_map)
+
 
 target_config_aspect = aspect(
-    implementation = _target_config_aspect_impl,
-    attr_aspects = ["deps"],
+    implementation=_target_config_aspect_impl, attr_aspects=["*"]
 )
-

--- a/BazelExtensions/xcodeproject.bzl
+++ b/BazelExtensions/xcodeproject.bzl
@@ -1,48 +1,63 @@
 # Load the sources aspect from Tulsi
-load("@xchammer_resources//:tulsi/tulsi_aspects.bzl", "tulsi_sources_aspect", "TulsiSourcesAspectInfo")
+load(
+    "@xchammer_resources//:tulsi/tulsi_aspects.bzl",
+    "tulsi_sources_aspect",
+    "TulsiSourcesAspectInfo",
+)
 load(":xchammerconfig.bzl", "xchammer_config", "gen_xchammer_config", "project_config")
 
 load(
     ":xcode_configuration_provider.bzl",
     "XcodeProjectTargetInfo",
     "XcodeConfigurationAspectInfo",
-    "target_config_aspect"
+    "target_config_aspect",
 )
+
+# Why are we rendering JSON here?
+# - the XCHammerConfig is modeled as structs which are passed to rules as strings
+# - calling to_json() recursivly renders a dict as a string
+# To fix this, we could _try_ to refactor xchammerconfig.bzl and express the
+# entire DSL as providers.
+def _dict_to_json(value):
+    entries = []
+    for key in value:
+        entries.append("\"" + key + "\":" + value[key] + "")
+    return "{ " + ",".join([t for t in entries]) + " }"
+
+def _array_to_json(value):
+    return "[ " + ",".join(["\"" + t + "\""  for t in value]) + " ]"
 
 def _xcode_project_impl(ctx):
     # Collect Target configuration JSON from deps
     # Then, merge them to a list
-    aggregate_target_config = []
+    aggregate_target_config = {}
     for dep in ctx.attr.targets:
         if XcodeConfigurationAspectInfo in dep:
-            info = dep[XcodeConfigurationAspectInfo].value
-            aggregate_target_config.append({ str(info.label) : info.value})
-
+            for info in dep[XcodeConfigurationAspectInfo].values:
+                aggregate_target_config[info] = dep[XcodeConfigurationAspectInfo].values[info]
 
     xchammerconfig_json = ctx.actions.declare_file("xchammer_config.json")
-
     target_config_attr = ctx.attr.target_config if ctx.attr.target_config else None
-    # Consider adding this ability
+
+    # Consider adding the ability to support this
     if len(aggregate_target_config) > 0 and ctx.attr.target_config:
         print("warning: cannot use aggregate target config and target config directly")
-        target_config = aggregate_target_config
+        target_config_json =  _dict_to_json(aggregate_target_config)
     elif len(aggregate_target_config) > 0:
-        target_config = aggregate_target_config
+        target_config_json =  _dict_to_json(aggregate_target_config)
     else:
-        target_config = ctx.attr.target_config
-
-    project_config_attr = ctx.attr.project_config if ctx.attr.project_config else project_config(paths = ["**"])
-    xchammerconfig=struct(
-        target_config=target_config,
-        projects={ ctx.attr.project_name : project_config_attr },
-        targets =[str(t.label) for t in ctx.attr.targets]
+        target_config_json = ctx.attr.target_config
+    projects_json = (
+        ctx.attr.project_config
+        if ctx.attr.project_config
+        else project_config(paths=["**"]).to_json()
     )
-
-    print(xchammerconfig.to_json())
-    ctx.file_action(
-        content = xchammerconfig.to_json(),
-        output = xchammerconfig_json,
-    )
+    xchammerconfig = _dict_to_json({
+        "targetConfig" : target_config_json,
+        "projects" : _dict_to_json({ctx.attr.project_name: projects_json}),
+        "targets": _array_to_json([str(t.label) for t in ctx.attr.targets])
+    })
+    ctx.file_action(content=xchammerconfig, output=xchammerconfig_json)
 
     artifacts = []
 
@@ -51,24 +66,21 @@ def _xcode_project_impl(ctx):
             artifacts.append(a)
 
     xchammer_info_json = ctx.actions.declare_file("xchammer_info.json")
-    xchammer_info=struct(
+    xchammer_info = struct(
         tulsiinfos=[a.path for a in artifacts],
         # This is used by bazel_build_settings.py and replaced by
         # install_xcode_project.
         execRoot="__BAZEL_EXEC_ROOT__",
-
         # This rule is for the actual _imp. We want XCHammer to run the install
         # target.
         # TODO(V2): for workspace mode, we need a way to invoke this to include all
         # targets
         bazelTargets=[str(ctx.label)[:-5]],
-
-        xchammerPath=ctx.attr.xchammer if ctx.attr.xchammer[0] == "/" else "$SRCROOT/" + ctx.attr.xchammer
+        xchammerPath=ctx.attr.xchammer
+        if ctx.attr.xchammer[0] == "/"
+        else "$SRCROOT/" + ctx.attr.xchammer,
     )
-    ctx.file_action(
-        content=xchammer_info.to_json(),
-        output=xchammer_info_json
-    )
+    ctx.file_action(content=xchammer_info.to_json(), output=xchammer_info_json)
 
     # If we're doing a source build of XCHammer then do so
     # this is intended for development of XCHammer only
@@ -77,59 +89,60 @@ def _xcode_project_impl(ctx):
         xchammer_files = ctx.attr.xchammer_bazel_build_target.files.to_list()
         xchammer_zip = xchammer_files[0].path
         xchammer_command.append(
-            "unzip -o " + xchammer_zip  + " -d $(dirname $(readlink $PWD/WORKSPACE))/;")
+            "unzip -o " + xchammer_zip + " -d $(dirname $(readlink $PWD/WORKSPACE))/;"
+        )
     else:
         xchammer_files = []
 
     # TODO(V2): handle absolute paths here
-    xchammer_command.append(
-         ctx.attr.xchammer + "/Contents/MacOS/xchammer")
+    xchammer_command.append(ctx.attr.xchammer + "/Contents/MacOS/xchammer")
 
     project_name = ctx.attr.project_name + ".xcodeproj"
-    xchammer_command.extend([
-        "generate_v2",
-        xchammerconfig_json.path,
-
-        # Write the xcode project into the execroot. We need to copy to the
-        # bin-dir after generation for validation. This is not 100% safe 
-        # and needs patches in XcodeGen validation ( or remove XcodeGen )
-        # In order to keep this hermetic, the project is installed out of band
-        # in another non-hermetic rule which depends on this
-        "--workspace_root",
-        "$PWD",
-
-        "--bazel",
-        ctx.attr.bazel if ctx.attr.bazel[0] == "/" else "\$SRCROOT/" + ctx.attr.bazel,
-
-        "--xcode_project_rule_info",
-        xchammer_info_json.path,
-
-        # See above comment
-        "; ditto " + project_name + " " + ctx.bin_dir.path + "/" + project_name
-    ])
+    xchammer_command.extend(
+        [
+            "generate_v2",
+            xchammerconfig_json.path,
+            # Write the xcode project into the execroot. We need to copy to the
+            # bin-dir after generation for validation. This is not 100% safe
+            # and needs patches in XcodeGen validation ( or remove XcodeGen )
+            # In order to keep this hermetic, the project is installed out of band
+            # in another non-hermetic rule which depends on this
+            "--workspace_root",
+            "$PWD",
+            "--bazel",
+            ctx.attr.bazel
+            if ctx.attr.bazel[0] == "/"
+            else "\$SRCROOT/" + ctx.attr.bazel,
+            "--xcode_project_rule_info",
+            xchammer_info_json.path,
+            # See above comment
+            "; ditto " + project_name + " " + ctx.bin_dir.path + "/" + project_name,
+        ]
+    )
 
     ctx.actions.run_shell(
         mnemonic="XcodeProject",
         inputs=artifacts + [xchammerconfig_json, xchammer_info_json] + xchammer_files,
         command=" ".join(xchammer_command),
-        outputs=[ctx.outputs.out]
+        outputs=[ctx.outputs.out],
     )
 
+
 _xcode_project = rule(
-    implementation = _xcode_project_impl,
-    attrs = {
-        "targets" : attr.label_list(aspects = [tulsi_sources_aspect, target_config_aspect]),
-        "project_name" : attr.string(),
-        "bazel" : attr.string(default="bazel"),
-        "target_config" : attr.label(allow_single_file=True),
-        "project_config" : attr.label(allow_single_file=True),
-        "xchammer" : attr.string(mandatory=True),
-
-
+    implementation=_xcode_project_impl,
+    attrs={
+        "targets": attr.label_list(
+            aspects=[tulsi_sources_aspect, target_config_aspect]
+        ),
+        "project_name": attr.string(),
+        "bazel": attr.string(default="bazel"),
+        "target_config": attr.string(),
+        "project_config": attr.string(),
+        "xchammer": attr.string(mandatory=True),
         # This is used as a development option only
-        "xchammer_bazel_build_target" : attr.label(mandatory=False),
+        "xchammer_bazel_build_target": attr.label(mandatory=False),
     },
-    outputs={"out": "%{project_name}.xcodeproj"}
+    outputs={"out": "%{project_name}.xcodeproj"},
 )
 
 
@@ -138,29 +151,32 @@ def _install_xcode_project_impl(ctx):
     output_proj = "$(dirname $(readlink $PWD/WORKSPACE))/" + xcodeproj.basename
     command = [
         "ditto " + xcodeproj.path + " " + output_proj,
-        "sed -i '' \"s,__BAZEL_EXEC_ROOT__,$PWD,g\" " + output_proj + "/XCHammerAssets/bazel_build_settings.py",
+        "sed -i '' \"s,__BAZEL_EXEC_ROOT__,$PWD,g\" "
+        + output_proj
+        + "/XCHammerAssets/bazel_build_settings.py",
         # This is kind of a hack for reference bazel relative to the source
         # directory, as bazel_build_settings.py doesn't sub Xcode build
         # settings.
-        "sed -i '' \"s,\$SRCROOT,$(dirname $(readlink $PWD/WORKSPACE)),g\" " + output_proj + "/XCHammerAssets/bazel_build_settings.py",
+        "sed -i '' \"s,\$SRCROOT,$(dirname $(readlink $PWD/WORKSPACE)),g\" "
+        + output_proj
+        + "/XCHammerAssets/bazel_build_settings.py",
         "ln -sf $PWD/external $(dirname $(readlink $PWD/WORKSPACE))/external",
-        "echo \"" + output_proj + "\" > " + ctx.outputs.out.path
+        'echo "' + output_proj + '" > ' + ctx.outputs.out.path,
     ]
     ctx.actions.run_shell(
         inputs=ctx.attr.xcodeproj.files,
         command=";".join(command),
         use_default_shell_env=True,
-        outputs=[ctx.outputs.out]
+        outputs=[ctx.outputs.out],
     )
 
 
 _install_xcode_project = rule(
-    implementation = _install_xcode_project_impl,
-    attrs = {
-        "xcodeproj" : attr.label(mandatory=True),
-    },
-    outputs={"out": "%{name}.dummy"}
+    implementation=_install_xcode_project_impl,
+    attrs={"xcodeproj": attr.label(mandatory=True)},
+    outputs={"out": "%{name}.dummy"},
 )
+
 
 def xcode_project(**kwargs):
     """ Generate an Xcode project
@@ -186,14 +202,16 @@ def xcode_project(**kwargs):
         proj_args["project_name"] = kwargs["name"]
 
     # Build an XCHammer config Based on inputs
-    targets_attr = [str(t) for t in kwargs.get("targets")]
+    targets_json = [str(t) for t in kwargs.get("targets")]
 
     # XCHammer development only
     xchammer_target = "//:xchammer"
-    if xchammer_target in targets_attr:
+    if xchammer_target in targets_json:
         proj_args["xchammer_bazel_build_target"] = xchammer_target
 
-    proj_args["name"] =  rule_name + "_impl"
+    proj_args["name"] = rule_name + "_impl"
+    proj_args["project_config"] = proj_args["project_config"].to_json() if "project_config" in  proj_args else None
+    proj_args["target_config"] = proj_args["target_config"].to_json() if "target_config" in  proj_args else None
 
     _xcode_project(**proj_args)
 
@@ -202,4 +220,5 @@ def xcode_project(**kwargs):
     _install_xcode_project(
         name=rule_name,
         xcodeproj=kwargs["name"],
-        testonly=proj_args.get("testonly", False))
+        testonly=proj_args.get("testonly", False),
+    )

--- a/BazelExtensions/xcodeproject.bzl
+++ b/BazelExtensions/xcodeproject.bzl
@@ -18,12 +18,6 @@ def _xcode_project_impl(ctx):
             info = dep[XcodeConfigurationAspectInfo].value
             aggregate_target_config.append({ str(info.label) : info.value})
 
-        if hasattr(dep, "deps"):
-            for depdep in dep.deps:
-                if XcodeConfigurationAspectInfo in depdep:
-                    info = depdep[XcodeConfigurationAspectInfo].value
-                    aggregate_target_config.append({ str(info.label) : info.value})
-
 
     xchammerconfig_json = ctx.actions.declare_file("xchammer_config.json")
 
@@ -135,11 +129,6 @@ _xcode_project = rule(
         # This is used as a development option only
         "xchammer_bazel_build_target" : attr.label(mandatory=False),
     },
-    fragments = [
-        "apple",
-        "cpp",
-        "objc",
-    ],
     outputs={"out": "%{project_name}.xcodeproj"}
 )
 


### PR DESCRIPTION
The current API for XCHammer config doesn't provide a way to put
configuration adjacent to target definition.

This PR adds a provider to inject XCHammer Config onto Swift and Objc
targets.

It then injects these targets into the `xcode_project` rule via aspect
which is able to collect transitive target configuration.