### PR TITLE
xcode_project - build generated files via aspect

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -141,7 +141,9 @@ gen_xchammer_config(
 load(
     "//BazelExtensions:xcodeproject.bzl",
     "xcode_project",
+    "xcode_project_deps",
 )
+
 
 xcode_project(
     name="workspace_v2",
@@ -150,6 +152,4 @@ xcode_project(
     xchammer="xchammer.app",
     project_config=project_config(["**"])
 )
-
-
 

--- a/BazelExtensions/xcode_configuration_provider.bzl
+++ b/BazelExtensions/xcode_configuration_provider.bzl
@@ -84,13 +84,7 @@ def _extract_generated_sources(target):
 
 def _xcode_build_sources_aspect_impl(itarget, ctx):
     infos = []
-    if XcodeBuildSourceInfo in itarget:
-        target = itarget
-        infos.append(itarget.label)
-
-    trans = _extract_generated_sources(itarget)
-    infos.extend(trans)
-
+    infos.extend(_extract_generated_sources(itarget))
     if hasattr(ctx.rule.attr, "deps"):
         for target in ctx.rule.attr.deps:
             if XcodeBuildSourceInfo in target:

--- a/BazelExtensions/xcode_configuration_provider.bzl
+++ b/BazelExtensions/xcode_configuration_provider.bzl
@@ -62,3 +62,44 @@ def _target_config_aspect_impl(itarget, ctx):
 target_config_aspect = aspect(
     implementation=_target_config_aspect_impl, attr_aspects=["*"]
 )
+
+
+XcodeBuildSourceInfo = provider(
+    fields={
+        "values": """The values of source files
+"""
+    }
+)
+
+def _extract_generated_sources(target):
+    """ Collects all of the generated source files"""
+    if not hasattr(target, "objc"):
+        return []
+    objc_provider = target.objc
+    if hasattr(objc_provider, "source") and hasattr(objc_provider, "header"):
+        all_files = depset(transitive = [objc_provider.source, objc_provider.header])
+        return [f for f in all_files.to_list()  if not f.is_source]
+    return []
+
+
+def _xcode_build_sources_aspect_impl(itarget, ctx):
+    infos = []
+    if XcodeBuildSourceInfo in itarget:
+        target = itarget
+        infos.append(itarget.label)
+
+    trans = _extract_generated_sources(itarget)
+    infos.extend(trans)
+
+    if hasattr(ctx.rule.attr, "deps"):
+        for target in ctx.rule.attr.deps:
+            if XcodeBuildSourceInfo in target:
+                trans = _extract_generated_sources(target)
+                infos.extend(trans)
+    return XcodeBuildSourceInfo(values=infos)
+
+
+xcode_build_sources_aspect = aspect(
+    implementation=_xcode_build_sources_aspect_impl, attr_aspects=["*"]
+)
+

--- a/BazelExtensions/xcodeproject.bzl
+++ b/BazelExtensions/xcodeproject.bzl
@@ -11,7 +11,11 @@ load(
     "XcodeProjectTargetInfo",
     "XcodeConfigurationAspectInfo",
     "target_config_aspect",
+    "xcode_build_sources_aspect",
+    "XcodeBuildSourceInfo",
 )
+
+non_hermetic_execution_requirements = { "no-cache": "1", "no-remote": "1", "local": "1", "no-sandbox": "1" }
 
 # Why are we rendering JSON here?
 # - the XCHammerConfig is modeled as structs which are passed to rules as strings
@@ -145,6 +149,46 @@ _xcode_project = rule(
 )
 
 
+def _xcode_project_deps_impl(ctx):
+    """ Install Xcode project dependencies into the source root.
+    This is required as by default, Bazel only installs genfiles for those
+    genfiles which are passed to the Bazel command line.
+    """
+    inputs = []
+    cmd = []
+    cmd.append("base_path=$(dirname $(readlink $PWD/WORKSPACE))/")
+    for dep in ctx.attr.targets:
+        if XcodeBuildSourceInfo in dep:
+            for info in dep[XcodeBuildSourceInfo].values:
+                parts = info.path.split("/bin/")
+                if len(parts) > 0:
+                    inputs.append(info)
+                    last = parts[len(parts) - 1]
+                    cmd.append(
+                        "target_dir=$base_path/bazel-genfiles/$(dirname " + last + ")"
+                    )
+                    cmd.append("mkdir -p $target_dir")
+                    cmd.append("ditto " + info.path + " $target_dir")
+
+    cmd.append("touch " + ctx.outputs.out.path)
+    ctx.actions.run_shell(
+        inputs=inputs,
+        command="\n".join(cmd),
+        use_default_shell_env=True,
+        outputs=[ctx.outputs.out],
+        execution_requirements = non_hermetic_execution_requirements
+    )
+
+
+# Adds these targets as a dependency for Xcode.
+# This is required for Xcode builds and code completion
+xcode_project_deps = rule(
+    implementation=_xcode_project_deps_impl,
+    attrs={"targets": attr.label_list(aspects=[xcode_build_sources_aspect])},
+    outputs={"out": "%{name}-deps.dummy"},
+)
+
+
 def _install_xcode_project_impl(ctx):
     xcodeproj = ctx.attr.xcodeproj.files.to_list()[0]
     output_proj = "$(dirname $(readlink $PWD/WORKSPACE))/" + xcodeproj.basename
@@ -167,6 +211,7 @@ def _install_xcode_project_impl(ctx):
         command=";".join(command),
         use_default_shell_env=True,
         outputs=[ctx.outputs.out],
+        execution_requirements = non_hermetic_execution_requirements
     )
 
 
@@ -213,6 +258,11 @@ def xcode_project(**kwargs):
     proj_args["target_config"] = proj_args["target_config"].to_json() if "target_config" in  proj_args else None
 
     _xcode_project(**proj_args)
+
+    xcode_project_deps(
+        name=rule_name + "_xcode_project_deps",
+        targets=kwargs.get("targets"),
+    )
 
     # Note: _xcode_project does the hermetic, reproducible bits
     # and then, we install this xcode project into the root directory.

--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -795,9 +795,9 @@ enum Generator {
         return assetBase
     }
 
-    public static func getXCHammerPath(genOptions: XCHammerGenerateOptions) -> String {
+    public static func getXCHammerBinPath(genOptions: XCHammerGenerateOptions) -> String {
         if let path = genOptions.xcodeProjectRuleInfo?.xchammerPath {
-            return path
+            return path + "/Contents/MacOS/xchammer"
         }
         return CommandLine.arguments[0]
     }
@@ -860,8 +860,9 @@ enum Generator {
         // Listen to Tulsi logs. Assume this function is called 1 time
         let ruleEntryMap = workspaceInfo.ruleEntryMap
 
-        // TODO(V2): We need to pass this into the rule ( or get rid of it??)
-        let genfileLabels:[BuildLabel] = []
+        // Build all of the generated files.
+        let genfileLabels: [BuildLabel] = xcodeProjectRuleInfo
+            .bazelTargets.map { BuildLabel($0 + "_xcode_project_deps") }
 
         // For V2 we really don't need this and the rule is modeled as 1 thread.
         // ATM this is left perhaps we can refactor to support both use cases.

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -1284,7 +1284,8 @@ func shouldFlatten(xcodeTarget: XcodeTarget) -> Bool {
 private func makeScripts(for xcodeTarget: XcodeTarget, genOptions: XCHammerGenerateOptions, targetMap: XcodeTargetMap) -> ([ProjectSpec.BuildScript], [ProjectSpec.BuildScript]) {
     func getProcessScript() -> ProjectSpec.BuildScript {
         // Use whatever XCHammer this project was built with
-        let processContent = "\(Generator.getXCHammerPath(genOptions: genOptions)) process-ipa"
+        let xchammerBin = Generator.getXCHammerBinPath(genOptions: genOptions)
+        let processContent = "\(xchammerBin) process-ipa"
         return  ProjectSpec.BuildScript(path: nil, script: processContent, name: "Process IPA")
     }
 


### PR DESCRIPTION
Add an aspect to extract generated files from the Bazel build graph.

The output of this aspect is fed into a rule, which then builds
generated files for Xcode.  Finally, the rule installs them into
bazel-genfiles locally.

Additionally:
- Fix issue around binary path
- Specify non-hermetic rules for install too