### PR TITLE
Make process_ipa match formatting of other commands

### DIFF
--- a/IntegrationTests/Goldmaster/SnapshotMe/XcodeBazel.xcodeproj/project.pbxproj
+++ b/IntegrationTests/Goldmaster/SnapshotMe/XcodeBazel.xcodeproj/project.pbxproj
@@ -256,7 +256,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "$SRCROOT/tools/xchammer.app/Contents/MacOS/xchammer process-ipa";
+			shellScript = "$SRCROOT/tools/xchammer.app/Contents/MacOS/xchammer process_ipa";
 		};
 		EC5DAA8C92E46DBBD479C38A /* Bazel build */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/IntegrationTests/Goldmaster/Tailor/Tailor.xcodeproj/project.pbxproj
+++ b/IntegrationTests/Goldmaster/Tailor/Tailor.xcodeproj/project.pbxproj
@@ -321,7 +321,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "__PWD__/xchammer.app/Contents/MacOS/XCHammer process-ipa";
+			shellScript = "__PWD__/xchammer.app/Contents/MacOS/XCHammer process_ipa";
 		};
 		AF178F4820849A2350BB2BE8 /* Copy Swift Objective-C Interface Header */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/IntegrationTests/Goldmaster/Tailor/XcodeBazel.xcodeproj/project.pbxproj
+++ b/IntegrationTests/Goldmaster/Tailor/XcodeBazel.xcodeproj/project.pbxproj
@@ -287,7 +287,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "$SRCROOT/tools/xchammer.app/Contents/MacOS/xchammer process-ipa";
+			shellScript = "$SRCROOT/tools/xchammer.app/Contents/MacOS/xchammer process_ipa";
 		};
 		7F3961777130A44138A25177 /* Copy Swift Objective-C Interface Header */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/IntegrationTests/Goldmaster/UrlGet/UrlGet.xcodeproj/project.pbxproj
+++ b/IntegrationTests/Goldmaster/UrlGet/UrlGet.xcodeproj/project.pbxproj
@@ -4938,7 +4938,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "__PWD__/xchammer.app/Contents/MacOS/XCHammer process-ipa";
+			shellScript = "__PWD__/xchammer.app/Contents/MacOS/XCHammer process_ipa";
 		};
 		ECCBD99E01A8B9F7D830A5BD /* Bazel build */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/IntegrationTests/Goldmaster/UrlGet/XcodeBazel.xcodeproj/project.pbxproj
+++ b/IntegrationTests/Goldmaster/UrlGet/XcodeBazel.xcodeproj/project.pbxproj
@@ -739,7 +739,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "$SRCROOT/tools/xchammer.app/Contents/MacOS/xchammer process-ipa";
+			shellScript = "$SRCROOT/tools/xchammer.app/Contents/MacOS/xchammer process_ipa";
 		};
 		842D14047F234465AC7AB68E /* Bazel build */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/IntegrationTests/Goldmaster/WorkspaceSource/WorkspaceSource.xcodeproj/project.pbxproj
+++ b/IntegrationTests/Goldmaster/WorkspaceSource/WorkspaceSource.xcodeproj/project.pbxproj
@@ -323,7 +323,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "__PWD__/xchammer.app/Contents/MacOS/XCHammer process-ipa";
+			shellScript = "__PWD__/xchammer.app/Contents/MacOS/XCHammer process_ipa";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/IntegrationTests/Goldmaster/WorkspaceSource/XcodeBazel.xcodeproj/project.pbxproj
+++ b/IntegrationTests/Goldmaster/WorkspaceSource/XcodeBazel.xcodeproj/project.pbxproj
@@ -305,7 +305,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "$SRCROOT/tools/xchammer.app/Contents/MacOS/xchammer process-ipa";
+			shellScript = "$SRCROOT/tools/xchammer.app/Contents/MacOS/xchammer process_ipa";
 		};
 		EC5DAA8C92E46DBBD479C38A /* Bazel build */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -1365,7 +1365,7 @@ private func makeScripts(for xcodeTarget: XcodeTarget, genOptions: XCHammerGener
     func getProcessScript() -> ProjectSpec.BuildScript {
         // Use whatever XCHammer this project was built with
         let xchammerBin = Generator.getXCHammerBinPath(genOptions: genOptions)
-        let processContent = "\(xchammerBin) process-ipa"
+        let processContent = "\(xchammerBin) process_ipa"
         return  ProjectSpec.BuildScript(path: nil, script: processContent, name: "Process IPA")
     }
 

--- a/Sources/XCHammer/main.swift
+++ b/Sources/XCHammer/main.swift
@@ -246,7 +246,7 @@ struct GenerateCommandV2: CommandProtocol {
 
 
 struct ProcessIpaCommand: CommandProtocol {
-    let verb = "process-ipa"
+    let verb = "process_ipa"
     let function = "Process IPA after a build -- this is expected to be run in an environment with Xcode ENV vars"
 
     typealias Options = NoOptions<CommandError>


### PR DESCRIPTION
Some commands use underscores (such as `install_xcode_build_system`), but `process-ipa` uses a hyphen. This PR makes the format consistent.