### PR TITLE
Replace deprecated index(of:) with firstIndex(of:)

### DIFF
--- a/Sources/XCHammer/ProcessIpa.swift
+++ b/Sources/XCHammer/ProcessIpa.swift
@@ -34,7 +34,7 @@ private func processIpaExn(builtProductsDir: Path, codesigningFolderPath: Path) 
             let path = codesigningFolderPath + $0
 
             let components = path.components
-            if let bundleComponentIdx = (components.index { $0.contains("_Bundle_") }), path.extension == "bundle" {
+            if let bundleComponentIdx = (components.firstIndex { $0.contains("_Bundle_") }), path.extension == "bundle" {
                 let component = components[bundleComponentIdx]
                 let newComponent = component.components(separatedBy: "_Bundle_")[1]
 

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -476,7 +476,7 @@ public class XcodeTarget: Hashable, Equatable {
             .compactMap { inputPath in
             let path = Path(self.resolveExternalPath(for: inputPath.string))
             let pathComponents = path.components
-            if let specialIndex = (pathComponents.index { component in
+            if let specialIndex = (pathComponents.firstIndex { component in
                 DirectoriesAsFileSuffixes.map { component.hasSuffix("." + $0) }.any()
             }) {
                 let formattedPath =


### PR DESCRIPTION
In Swift 5, [`index(of:)`](https://developer.apple.com/documentation/swift/array/3126950-index) is deprecated and [`firstIndex(of:)`](https://developer.apple.com/documentation/swift/array/2994720-firstindex) is recommended instead.