### PR TITLE
Conditionally drop -Bazel suffix from schemes

### DIFF
--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -338,9 +338,12 @@ enum Generator {
             return []
         }
 
-
+        let projectConfig = genOptions.projectConfig
+        let generateXcodeSchemes = (projectConfig?.generateXcodeSchemes ?? true != false)
         return targets.map {
             xcodeTarget in
+            let schemeName = generateXcodeSchemes ? xcodeTarget.xcTargetName +
+                "-Bazel" : xcodeTarget.xcTargetName
             let name = xcodeTarget.xcTargetName + "-Bazel"
             let targetConfig = XcodeTarget.getTargetConfig(for:
                 xcodeTarget)
@@ -391,7 +394,7 @@ enum Generator {
                     preActions: profileConfig?.preActions ?? [],
                     postActions: profileConfig?.postActions ?? [])
 
-            return XcodeScheme(name: name, build: buildPhase, run: runPhase,
+            return XcodeScheme(name: schemeName, build: buildPhase, run: runPhase,
                     test: testPhase, profile: profilePhase)
         }
     }

--- a/Sources/XCHammer/XcodeScheme.swift
+++ b/Sources/XCHammer/XcodeScheme.swift
@@ -227,7 +227,7 @@ public func makeXCProjScheme(from scheme: XcodeScheme, project: String) -> XCSch
                 if name == entry.buildableReference.blueprintName {
                     return true
                 }
-                if (name + "-bazel") == entry.buildableReference.blueprintName {
+                if (name + "-Bazel") == entry.buildableReference.blueprintName {
                     return true
                 }
                 return false
@@ -239,7 +239,14 @@ public func makeXCProjScheme(from scheme: XcodeScheme, project: String) -> XCSch
     // There may be several scheme deps - find the first matching one by
     // convention
     let runnableEntry = buildActionEntries.first { runnable in
-        return runnable.buildableReference.blueprintName == scheme.name
+        let name = scheme.name
+        if name == runnable.buildableReference.blueprintName {
+            return true
+        }
+        if (name + "-Bazel") == runnable.buildableReference.blueprintName {
+            return true
+        }
+        return false
     }
     let buildableReference = runnableEntry!.buildableReference
     let productRunable = XCScheme.BuildableProductRunnable(buildableReference: buildableReference)


### PR DESCRIPTION
When Xcode schemes are disabled, this PR drops the suffix. This makes it
easier to migrate over to Bazel.