### PR TITLE
Remove -Bazel suffix when generateXcodeSchemes=false

### DIFF
--- a/IntegrationTests/run_tests.sh
+++ b/IntegrationTests/run_tests.sh
@@ -36,8 +36,12 @@ function test_build() {
 }
 
 function test_bazel_build() {
-    $XCHAMMER_BIN generate $SANDBOX/$SAMPLE/XCHammer.yaml --bazel $BAZEL --force
-    xcodebuild -scheme ios-app-Bazel -project $TEST_PROJ -sdk iphonesimulator
+    # This tests a Bazel project generation and then Bazel builds the targets
+    $BAZEL clean
+    $BAZEL build -s :XcodeBazel --spawn_strategy=standalone
+
+    mkdir -p XcodeBazel.xcodeproj/.tulsi
+    xcodebuild -scheme ios-app -project XcodeBazel.xcodeproj -sdk iphonesimulator
     assertExitCode "Xcode built bazel targets successfully"
 }
 
@@ -83,7 +87,11 @@ function preflightEnv() {
     # program to prevent polluting the sample
     mkdir -p $SANDBOX
     ditto $ROOT_DIR/sample/$SAMPLE $SANDBOX/$SAMPLE
-    rm -rf $SANDBOX/$SAMPLE/$SAMPLE.xcodeproj
+
+    mkdir -p $SANDBOX/$SAMPLE/tools
+    ln -sf $ROOT_DIR/xchammer.app $SANDBOX/$SAMPLE/tools/xchammer.app
+
+    rm -rf $SANDBOX/$SAMPLE/*.xcodeproj
 
     cd $SANDBOX/$SAMPLE;
 
@@ -109,7 +117,6 @@ function runTests() {
 }
 
 ## Execution
-
 echo "Running tests"
 # Do a debug build
 trap testsDidFinish EXIT

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ bazelrc_home:
 	echo "build --disk_cache=$(HOME)/Library/Caches/Bazel \\" > ~/.bazelrc
 	echo "     --spawn_strategy=standalone" >> ~/.bazelrc
 
-ci: bazelrc_home test run_perf_ci run_swift goldmaster
+ci: bazelrc_home test run_perf_ci run_swift run_force_bazel goldmaster
 
 format:
 	$(ROOT_DIR)/tools/bazelwrapper run buildifier

--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -175,6 +175,7 @@ struct XCBuildSettings: Encodable {
     var pythonPath: First<String>?
     var sdkRoot: First<String>?
     var targetedDeviceFamily: OrderedArray<String> = OrderedArray.empty
+    var isBazel: First<String> = First("NO")
     var diagnosticFlags: [String] = []
 
     enum CodingKeys: String, CodingKey {
@@ -221,6 +222,7 @@ struct XCBuildSettings: Encodable {
         case codeSignEntitlementsFile = "HAMMER_ENTITLEMENTS_FILE"
         case mobileProvisionProfileFile = "HAMMER_PROFILE_FILE"
         case diagnosticFlags = "HAMMER_DIAGNOSTIC_FLAGS"
+        case isBazel = "HAMMER_IS_BAZEL"
         case tulsiWR = "TULSI_WR"
         case sdkRoot = "SDKROOT"
         case targetedDeviceFamily = "TARGETED_DEVICE_FAMILY"
@@ -277,6 +279,7 @@ struct XCBuildSettings: Encodable {
         try sdkRoot.map { try container.encode($0.v, forKey: .sdkRoot) }
         try container.encode(targetedDeviceFamily.joined(separator: ","), forKey: .targetedDeviceFamily)
         try swiftVersion.map { try container.encode($0.v, forKey: .swiftVersion) }
+        try container.encode(isBazel.v, forKey: .isBazel)
 
         // XCHammer only supports Xcode projects at the root directory
         try container.encode("$SOURCE_ROOT", forKey: .tulsiWR)
@@ -333,6 +336,7 @@ extension XCBuildSettings: Monoid {
             sdkRoot: lhs.sdkRoot <> rhs.sdkRoot,
             targetedDeviceFamily: lhs.targetedDeviceFamily <>
                 rhs.targetedDeviceFamily,
+            isBazel: lhs.isBazel <> rhs.isBazel,
             diagnosticFlags: lhs.diagnosticFlags <> rhs.diagnosticFlags
         )
     }

--- a/sample/UrlGet/BUILD.bazel
+++ b/sample/UrlGet/BUILD.bazel
@@ -48,6 +48,7 @@ xcode_project(
     name = "XcodeBazel",
     targets = [
 	"//ios-app:ios-app",
+	"//ios-app:UrlGetClasses",
 	"//ios-app:UnitTests",
 	"//ios-app:UnitTestsWithHost",
     ],

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -260,7 +260,7 @@ def xchammer_dependencies():
     namespaced_git_repository(
         name = "Tulsi",
         remote = "https://github.com/pinterest/tulsi.git",
-        commit = "2fd83ec17e0d6e1efbb0ef6d6f73f622212dd38d",
+        commit = "dde8fdd59e7eb2128c91d8f971973d7d28f3aca4",
         patch_cmds = [
             """
          sed -i '' 's/\:__subpackages__/visibility\:public/g' src/TulsiGenerator/BUILD


### PR DESCRIPTION
Adds the ability to generate only Xcode or Bazel targets

- Rename Bazel targets to Xcode targets
- Add only indexer targets to the project