### PR TITLE
Support rules_swift debug info remapping feature

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,9 @@
+# A few settings for XCHammer's .bazelrc
+# Debugging: Use the remapping feature of rules_swift.
 build \
  --spawn_strategy=standalone \
  --strategy=SwiftCompile=worker \
  --incompatible_disallow_load_labels_to_cross_package_boundaries=false \
  --incompatible_new_actions_api=false \
+ --swiftcopt=-Xwrapped-swift=-debug-prefix-pwd-is-dot \
  --experimental_strict_action_env=true

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -164,6 +164,14 @@ xcode_project(
     targets=["//:xchammer",  "//tools/XCConfigExporter:xcconfig-exporter"],
     bazel="tools/bazelwrapper",
     xchammer="xchammer.app",
-    project_config=project_config(["**"])
+    project_config=project_config(
+        paths = ["**"],
+        generate_xcode_schemes=False,
+        xcconfig_overrides = {
+            "Release": "tools/BazelToolchain.xcconfig",
+            "Debug": "tools/BazelToolchain.xcconfig",
+            "Profile": "tools/BazelToolchain.xcconfig",
+        }
+    )
 )
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ To make outputs consistent and debuggable across machines, e.g. with remote
 caching, it's recommended to use debug info remapping. Debug info remapping is a
 technique that simply remaps absolute paths in debug info to a stable location.
 LLDB then is able to map these to the source directory, via a
-`target.source-map`. By default, these bazel flags not configured and requires
-adding additional flags to the build: likely, these flags are set consistelty in
-`.bazelrc` for every build.
+`target.source-map`. By default, these bazel flags are not configured and
+require adding additional flags to the build: likely, these flags are set
+consistelty in `.bazelrc` for every build.
 
 Clang provides debug info remapping via the `-fdebug-prefix-map` flag. For
 Objective-C, C, C++, debug info remapping is implemented at the crosstool level.
@@ -135,9 +135,9 @@ remapping](https://github.com/bazelbuild/rules_swift/commit/43900104d279fcdffbca
 Simply add `--swiftcopt=-Xwrapped-swift=-debug-prefix-pwd-is-dot` to remap debug
 info in Swift.
 
-XCHammer will automatically write this remapping in the `.lldbinit`. Set
-`HAMMER_USE_DEBUG_INFO_REMAPPING=YES` in xcconfig or as an environment
-variable to the `Bazel build` runscript.
+XCHammer will automatically write a compatible remapping in the `.lldbinit`. Set
+`HAMMER_USE_DEBUG_INFO_REMAPPING=YES` in xcconfig or as an environment variable
+to the `Bazel build` runscript.
 
 _Generating a dSYM for development is not recommended due to the performance
 hit, and in practice is only required for Instruments.app._

--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ caching, it's recommended to use debug info remapping. Debug info remapping is a
 technique that simply remaps absolute paths in debug info to a stable location.
 LLDB then is able to map these to the source directory, via a
 `target.source-map`. By default, these bazel flags are not configured and
-require adding additional flags to the build: likely, these flags are set
-consistelty in `.bazelrc` for every build.
+require adding additional flags to the build. Generally, these flags should set
+in _your_ `.bazelrc` for every build.
 
 Clang provides debug info remapping via the `-fdebug-prefix-map` flag. For
 Objective-C, C, C++, debug info remapping is implemented at the crosstool level.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,37 @@ xchammer install_xcode_build_system
 - make sure Xcode's new build system is enabled
 
 
+## LLDB integration
+
+Under Swift and clang compilers, the execution root is written into debug info
+in object files by default. XCHammer writes an lldbinit file to map this
+directory to the source root of source code, so that both breakpoints and
+sources work in Xcode.
+
+It's recommended to use debug info remapping, which often works better, and is
+also required debug outputs created from external machines e.g. from a remote
+cache. XCHammer is often setup to work with the debug remapping features
+provided by Swift and clang compilers:
+
+Starting with Swift 5.0, Swift provides debug info remapping via the
+`-debug-prefix-map` flag.  `rules_swift` supports the ability to [pass the debug
+remapping](https://github.com/bazelbuild/rules_swift/commit/43900104d279fcdffbca2d02dbc550492bf33353).
+Simply add `--swiftcopt=-Xwrapped-swift=-debug-prefix-pwd-is-dot` to remap debug
+info in Swift.
+
+Clang provides debug info remapping via the `-fdebug-prefix-map` flag. For
+Objective-C, C, C++, debug info remapping is implemented at the crosstool level.
+Configure Bazel to pass these arguments by setting setting
+`--copt="DEBUG_PREFIX_MAP_PWD=."` or providing a custom crosstool to do so.
+[crosstool to remap debug info](https://github.com/bazelbuild/bazel/blob/master/tools/osx/crosstool/wrapped_clang.cc#L218).
+
+Finally, to use this remapping, in the `.lldbinit`, set
+`HAMMER_USE_DEBUG_INFO_REMAPPING=YES` either inside of xcconfig for this
+project.
+
+_Generating a dSYM for development builds is not recommended due to the
+performance hit, and in practice is only used for profile builds._
+
 ## Development
 
 Please find more info about developing XCHammer in [The XCHammer FAQ](Docs/XCHammerFAQ.md). Pull requests welcome 💖.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ To make outputs consistent and debuggable across machines, e.g. with remote
 caching, it's recommended to use debug info remapping. Debug info remapping is a
 technique that simply remaps absolute paths in debug info to a stable location.
 LLDB then is able to map these to the source directory, via a
-`target.source-map`. By default, these bazel flags are not configured and
+`target.source-map`. By default, these Bazel flags are not configured and
 require adding additional flags to the build. Generally, these flags should set
 in _your_ `.bazelrc` for every build.
 
@@ -129,15 +129,15 @@ up [crosstool
 logic](https://github.com/bazelbuild/bazel/blob/master/tools/osx/crosstool/wrapped_clang.cc#L218)
 for more info.
 
-Starting with Swift 5.0, Swift provides debug info remapping via the
+Starting with Xcode 10.2, Swift provides debug info remapping via the
 `-debug-prefix-map` flag.  `rules_swift` supports the ability to [pass the debug
 remapping](https://github.com/bazelbuild/rules_swift/commit/43900104d279fcdffbca2d02dbc550492bf33353).
 Simply add `--swiftcopt=-Xwrapped-swift=-debug-prefix-pwd-is-dot` to remap debug
 info in Swift.
 
 XCHammer will automatically write a compatible remapping in the `.lldbinit`. Set
-`HAMMER_USE_DEBUG_INFO_REMAPPING=YES` in xcconfig or as an environment variable
-to the `Bazel build` runscript.
+`HAMMER_USE_DEBUG_INFO_REMAPPING=YES` via an `xcconfig`. See [XCHammer's BUILD
+file](BUILD.bazel), for an example of this.
 
 _Generating a dSYM for development is not recommended due to the performance
 hit, and in practice is only required for Instruments.app._

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -1287,7 +1287,7 @@ public class XcodeTarget: Hashable, Equatable {
                 let template = try? String(contentsOf: (self.genOptions.workspaceRootPath + Path(
                     templatePath)).url) else {
                 return """
-                export TULSI_USE_HAMMER_DEBUG_CONFIG=YES
+                export HAMMER_USE_DEBUG_INFO_REMAPPING=NO
                 \(buildInvocation)
                 """
             }

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -1287,7 +1287,6 @@ public class XcodeTarget: Hashable, Equatable {
                 let template = try? String(contentsOf: (self.genOptions.workspaceRootPath + Path(
                     templatePath)).url) else {
                 return """
-                export HAMMER_USE_DEBUG_INFO_REMAPPING=NO
                 \(buildInvocation)
                 """
             }

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -260,7 +260,7 @@ def xchammer_dependencies():
     namespaced_git_repository(
         name = "Tulsi",
         remote = "https://github.com/pinterest/tulsi.git",
-        commit = "dde8fdd59e7eb2128c91d8f971973d7d28f3aca4",
+        commit = "15fbbf9fca15fad4623e9cae047a88623c75a512",
         patch_cmds = [
             """
          sed -i '' 's/\:__subpackages__/visibility\:public/g' src/TulsiGenerator/BUILD

--- a/tools/BazelToolchain.xcconfig
+++ b/tools/BazelToolchain.xcconfig
@@ -1,0 +1,5 @@
+// The project is setup to use debug info remapping
+HAMMER_USE_DEBUG_INFO_REMAPPING=YES
+// This is the default, which needs to be set. We override this at the target
+// leve.
+SWIFT_VERSION=5.0


### PR DESCRIPTION
This bumps tulsi to use the debug info prefix mapping setup by
`rules_swift` ( previously, we used another path for Pinterest internal
toolchain setup ).

By default, the variable is not set `HAMMER_USE_DEBUG_INFO_REMAPPING`
and is added to the README. In the future, this may be tured on, but is
left off if people want to use older swift releases