### PR TITLE
Automatically add launch automatically substyle

### DIFF
--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -357,7 +357,8 @@ enum Generator {
                     [:],
                     environmentVariables: runConfig?.environmentVariables ?? [],
                     preActions: runConfig?.preActions ?? [],
-                    postActions: runConfig?.postActions ?? [])
+                    postActions: runConfig?.postActions ?? [],
+                    launchAutomaticallySubstyle: xcodeTarget.getLaunchAutomaticallySubstyle())
 
             let testConfig = schemeConfig?[SchemeActionType.test.rawValue]
 

--- a/Sources/XCHammer/XcodeScheme.swift
+++ b/Sources/XCHammer/XcodeScheme.swift
@@ -82,18 +82,21 @@ public struct XcodeScheme: Equatable, Codable {
         public var environmentVariables: [EnvironmentVariable]
         public var preActions: [ExecutionAction]
         public var postActions: [ExecutionAction]
+        public var launchAutomaticallySubstyle: String?
         public init(
             config: String,
             commandLineArguments: [String: Bool] = [:],
             environmentVariables: [EnvironmentVariable] = [],
             preActions: [ExecutionAction] = [],
-            postActions: [ExecutionAction] = []
+            postActions: [ExecutionAction] = [],
+            launchAutomaticallySubstyle: String? = nil
         ) {
             self.config = config
             self.commandLineArguments = commandLineArguments
             self.environmentVariables = environmentVariables
             self.preActions = preActions
             self.postActions = postActions
+            self.launchAutomaticallySubstyle = launchAutomaticallySubstyle
         }
     }
 
@@ -295,7 +298,8 @@ public func makeXCProjScheme(from scheme: XcodeScheme, project: String) -> XCSch
         preActions: scheme.run?.preActions.map(getExecutionAction) ?? [],
         postActions: scheme.run?.postActions.map(getExecutionAction) ?? [],
         commandlineArguments: launchCommandLineArgs,
-        environmentVariables: launchEnvironmentVariables
+        environmentVariables: launchEnvironmentVariables,
+        launchAutomaticallySubstyle: scheme.run?.launchAutomaticallySubstyle
     )
 
     let profileAction = XCScheme.ProfileAction(

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -1473,6 +1473,20 @@ public class XcodeTarget: Hashable, Equatable {
         )
     }
 
+
+    public func getLaunchAutomaticallySubstyle() -> String? {
+        // Support for launch substyle.
+        switch extensionType {
+        // Some extension types require a remote debuggable and different
+        // runtime configuration. Simply put, at launch, this auto selects
+        // the executable. This closely mirrors how Xcode sets up the schemes
+        case "com.apple.intents-service", "com.apple.message-payload-provider":
+            return "2"
+        default:
+            // Use the default value for this, which ends up being "0"
+            return nil
+        }
+    }
 }
 
 // MARK: - Equatable


### PR DESCRIPTION
Some extension types require a remote debuggable and different runtime
configuration. Simply put, at launch, this auto selects the executable.
This closely mirrors how Xcode sets up the schemes