### PR TITLE
Update Pods.WORKSPACE

### DIFF
--- a/sample/UrlGet/Pods.WORKSPACE
+++ b/sample/UrlGet/Pods.WORKSPACE
@@ -21,7 +21,7 @@ new_pod_repository(
 
 new_pod_repository(
   name = "Stripe",
-  url = "https://github.com/stripe/stripe-ios/archive/v12.1.2.zip",
+  url = "https://github.com/stripe/stripe-ios/archive/v14.0.1.zip",
   owner = "@ios-action",
   inhibit_warnings = True,
 


### PR DESCRIPTION
Couldn't build the stripe SDK with XCode 11.4/11.5 due to "Incompatible block pointer types", also see https://github.com/tipsi/tipsi-stripe/issues/632. 

Should upgrade stripe SDK version: https://github.com/tipsi/tipsi-stripe/issues/632#issuecomment-607672078