### PR TITLE
Update XCHammer to Bazel 3.4.1 with Bazelisk

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,7 +3,5 @@
 build \
  --spawn_strategy=standalone \
  --strategy=SwiftCompile=worker \
- --incompatible_disallow_load_labels_to_cross_package_boundaries=false \
- --incompatible_new_actions_api=false \
  --swiftcopt=-Xwrapped-swift=-debug-prefix-pwd-is-dot \
  --experimental_strict_action_env=true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,7 +4,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 git_repository(
     name = "build_bazel_rules_apple",
     remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.18.0",
+    commit = "1cdaf74e44c4c969d7ee739b3a0f11b993c49d2a",
 )
 
 load(
@@ -15,7 +15,7 @@ load(
 git_repository(
     name = "build_bazel_rules_swift",
     remote = "https://github.com/bazelbuild/rules_swift.git",
-    commit = "0192f16b82b2998d846c45187545e38548a6671a",
+    commit = "d07d880dcf939e0ad98df4dd723f8516bf8a2867",
 )
 
 load(
@@ -26,8 +26,6 @@ load(
 swift_rules_dependencies()
 
 apple_rules_dependencies()
-
-
 
 load(
     "@com_google_protobuf//:protobuf_deps.bzl",

--- a/XCHammerAssets/Hammer.bzl
+++ b/XCHammerAssets/Hammer.bzl
@@ -9,7 +9,7 @@ load(
 
 def _entitlements_writer_impl(ctx):
     entitlement_info = ctx.attr.entitlements[AppleEntitlementsInfo]
-    out = ctx.new_file(ctx.attr.name + ".entitlements")
+    out = ctx.actions.declare_file(ctx.attr.name + ".entitlements")
     if not entitlement_info or not entitlement_info.final_entitlements:
         # Create some dummy entitlements
         cmd = " ".join([
@@ -17,7 +17,8 @@ def _entitlements_writer_impl(ctx):
             out.path,
             "\n",
         ])
-        ctx.action(
+
+        ctx.actions.run_shell(
             command = cmd,
             mnemonic = "EntitlementsWriter",
             inputs = [],
@@ -36,7 +37,7 @@ def _entitlements_writer_impl(ctx):
         "\n",
     ])
 
-    ctx.action(
+    ctx.actions.run_shell(
         command = cmd,
         mnemonic = "EntitlementsWriter",
         inputs = [entitlements_file],

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -54,6 +54,7 @@ swift_c_module(
   name = "{name}",
   deps = [":{name}Lib"],
   module_map = "{module_map}",
+  module_name = "{name}",
 )
 """.format(**dict(
         name = name,
@@ -260,7 +261,7 @@ def xchammer_dependencies():
     namespaced_git_repository(
         name = "Tulsi",
         remote = "https://github.com/pinterest/tulsi.git",
-        commit = "15fbbf9fca15fad4623e9cae047a88623c75a512",
+        commit = "e910a978e5381106186653462b9d649a35a997e0",
         patch_cmds = [
             """
          sed -i '' 's/\:__subpackages__/visibility\:public/g' src/TulsiGenerator/BUILD

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -1,134 +1,71 @@
 #!/bin/bash
 
-set -e
-
+set -ex
 # Make sure we're in the project root directory.
-SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
 pushd "$SCRIPTPATH/.." > /dev/null
 
-function exit_trap() {
-  popd 2 &> /dev/null
-  if [[ ! -z $BAZEL_DEBUG_ACTION_CACHE ]]; then
-    echo "INFO: dumping action cache post"
-    mkdir -p bazel-diags
-    $BAZEL dump --action_cache > bazel-diags/bazel-action-cache-post.txt
-  fi
-}
 
-trap exit_trap EXIT
-
-# Go to bazel release page
-# These are typically posted in groups.google
-# https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.28.1"
-BAZEL_VERSION_SHA="5d50ae13ba01a224ddf54cfd818289bee5b38e551cca22bffc79b89f377d2095"
-
-BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
-
-BAZEL_ROOT="$HOME/.bazelenv/versions/$BAZEL_VERSION"
-BAZEL_PATH="$BAZEL_ROOT/bin/bazel"
-
-if [[ "${BUILDKITE}" == "true" ]]; then
-   # The CI uses git clean which blows away the above path
-    if [[ -e "/Volumes/Cache" ]]; then
-        # In some environments, the cache is persistent
-        XCODE_SELECT_ENV_PATH="/Volumes/Cache/.xcode_select_env"
-    else
-        XCODE_SELECT_ENV_PATH="/tmp/.xcode_select_env"
-    fi
-else
-    XCODE_SELECT_ENV_PATH="${SCRIPTPATH}/.xcode_select_env"
-fi
-
-LEGACY_BAZEL_PATH="$SCRIPTPATH/../Scripts/bazel/bin/bazel"
-
-BAZEL=""
-
-function install_bazel() {
-    curl -L "$BAZEL_VERSION_URL" > $PWD/install_bazel.sh
-    SHA=$(shasum -a 256 install_bazel.sh | awk '{ print $1 }')
-    if [[ $SHA == $BAZEL_VERSION_SHA ]]; then
-        chmod +x install_bazel.sh
-        $PWD/install_bazel.sh --prefix="$BAZEL_ROOT" && rm install_bazel.sh
-    else
-        echo "You version of bazel is out of date; ask for help in #cx-ios"
-        exit 1
-    fi
-}
-
-# Check if we have the correct version of bazel installed in the home
-# directory.
-# Fallback to ./Scripts/bazel/bin/bazel for legacy installations
-# Lastly, check if there is one installed on the path
-if [[ -e "$BAZEL_PATH" ]]; then
-  BAZEL="$BAZEL_PATH"
-elif [[ -e "$LEGACY_BAZEL_PATH" ]] && [[ $("$LEGACY_BAZEL_PATH" version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
-  BAZEL="$LEGACY_BAZEL_PATH"
-elif [[ -e $(which bazel) ]] && [[ $($(which bazel) version | head -n1 | awk '{ print $3 }') == "$BAZEL_VERSION" ]]; then
-  BAZEL=$(which bazel)
-fi
-
-# Ensure we can execute the path for bazel and that it's the correct version
-if ! [[ -e "$BAZEL" ]]; then
-  echo "WARNING: Missing installation or incorrect bazel version ($BAZEL_VERSION)" >&2;
-  echo "Installing Bazel $BAZEL_VERSION to $BAZEL_PATH" >&2;
-  install_bazel
-  BAZEL=$BAZEL_PATH
-fi
-
+set -x
+BAZEL="${SCRIPTPATH}/bazel"
 
 function clean() {
-  echo "INFO: Bazel force cleaning"
-  $BAZEL clean --expunge
+    echo "INFO: Bazel force cleaning"
+    $BAZEL clean --expunge
 
-  # The Bazel server can have issues across Bazel versions
-  killall -9 bazel || true
+    # The Bazel server can have issues across Bazel versions
+    killall -9 bazel || true
 }
 
-if [[ -x "${BAZEL}" ]]; then
-  CURRENT_XCODE_PATH="$(/usr/bin/xcode-select -p)"
-  XCODE_VERSION=$(/usr/bin/xcodebuild -version | grep Xcode | cut -d ' ' -f2)
-  CURRENT_XCODE_HASH="${CURRENT_XCODE_PATH}-${XCODE_VERSION}-${BAZEL_VERSION}"
-  if [[ -f "${XCODE_SELECT_ENV_PATH}" ]]; then
+XCODE_SELECT_ENV_PATH="${PWD}/.xcode_select_env"
+CURRENT_XCODE_PATH="$(/usr/bin/xcode-select -p)"
+XCODE_VERSION=$(/usr/bin/xcodebuild -version | grep Xcode | cut -d ' ' -f2)
+CURRENT_XCODE_HASH="${CURRENT_XCODE_PATH}-${XCODE_VERSION}-${BAZEL_VERSION}"
+if [[ -f "${XCODE_SELECT_ENV_PATH}" ]]; then
     EXISTING_XCODE_HASH="$(cat "${XCODE_SELECT_ENV_PATH}")"
-    if [[ $EXISTING_XCODE_HASH != $CURRENT_XCODE_HASH ]]; then
-      echo "Xcode select path or Bazel version has changed, must clear cached data"
-      clean
+    if [[ $EXISTING_XCODE_HASH != "${CURRENT_XCODE_HASH}" ]]; then
+        echo "Xcode select path or Bazel version has changed, must clear cached data"
+        clean
     fi
-  fi
-  echo "${CURRENT_XCODE_HASH}" > $XCODE_SELECT_ENV_PATH
-  if [[ ! -z $BAZEL_FORCE_CLEAN ]]; then
-    clean
-  fi
-
-  if [[ ! -z $BAZEL_DEBUG_ACTION_CACHE ]]; then
-    echo "INFO: dumping action cache pre"
-    mkdir -p bazel-diags
-    $BAZEL dump --action_cache > bazel-diags/bazel-action-cache-pre.txt
-  fi
-
-  # Make variable support
-  # In the context of Xcode builds, variables are defined as "Make variable"
-  # strings.
-  # In practice, the variables are stored as strings, and then later assigned to
-  # the value of the current environment.
-  ARGS=()
-  for ARG in "$@"; do
-      if [[ "$ARG" =~ \$(.*) ]]; then
-        # Get the name of the make variable
-        MAKEVAR=$(echo $ARG | sed 's,.*\$(\(.*\)).*,\1,g')
-        # Next, parameter expansion of the variable by name
-        VALUE="${!MAKEVAR}"
-        REPLACED="$(echo $ARG | sed "s,\$(\(.*\)),$VALUE,g")"
-        ARGS+=(${REPLACED})
-      else
-        ARGS+=("${ARG}")
-      fi
-  done
-
-  # Exec in a subshell in order to trap
-  (exec -a "$0" /usr/bin/env - TERM="${TERM}" SHELL="${SHELL}" PATH="${PATH}" HOME="${HOME}" "${BAZEL}" "${ARGS[@]}")
-else
-  echo "WARNING: Missing installation of bazel" >&2;
-  exit 1
 fi
+
+echo "${CURRENT_XCODE_HASH}" > "${XCODE_SELECT_ENV_PATH}"
+if [[ -n $BAZEL_FORCE_CLEAN ]]; then
+    clean
+fi
+
+
+# Make variable support
+# In the context of Xcode builds, variables are defined as "Make variable"
+# strings.
+# In practice, the variables are stored as strings, and then later assigned to
+# the value of the current environment.
+ARGS=()
+
+HAS_XCODE_VERSION_FLAG=false
+
+for ARG in "$@"; do
+    if [[ "$ARG" =~ \$(.*) ]]; then
+      # Get the name of the make variable
+      MAKEVAR=$(echo $ARG | sed 's,.*\$(\(.*\)).*,\1,g')
+      # Next, parameter expansion of the variable by name
+      VALUE="${!MAKEVAR}"
+      REPLACED="$(echo $ARG | sed "s,\$(\(.*\)),$VALUE,g")"
+      ARGS+=(${REPLACED})
+    else
+      ARGS+=("${ARG}")
+    fi
+    if [[ "$ARG" =~ "--xcode_version" ]]; then
+       HAS_XCODE_VERSION_FLAG=true
+    fi
+done
+
+# If we don't select an Xcode then use the default Xcode
+if [[ "$1" == "build" ]] || [[ "$1" == "test" ]]; then
+    if [[ ! $HAS_XCODE_VERSION_FLAG == true ]]; then
+       ARGS+=("--xcode_version=$(/usr/bin/xcodebuild -version | grep Xcode | cut -d ' ' -f2)")
+    fi
+fi
+
+# Exec in a subshell in order to trap
+(exec -a "$BAZEL" /usr/bin/env - TERM="${TERM}" SHELL="${SHELL}" PATH="${PATH}" HOME="${HOME}" "${BAZEL}" "${ARGS[@]}")


### PR DESCRIPTION
This PR updates XCHammer to build with Bazel 3.4.1 fixing misc updated
APIs.t  `tools/bazelwrapper` is still used to handle subbing of template
vars - it simply invokes `tools/bazelwrapper` It also includes a tulsi
bump to the latest for this support.