### PR TITLE
Improve handling of Swift under Bazel builds

### DIFF
--- a/BazelExtensions/xchammerconfig.bzl
+++ b/BazelExtensions/xchammerconfig.bzl
@@ -2,7 +2,7 @@
 
 
 def _gen_dsl_impl(ctx):
-    ctx.file_action(
+    ctx.actions.write(
         content = ctx.attr.ast,
         output = ctx.outputs.xchammerconfig,
     )

--- a/BazelExtensions/xcode_configuration_provider.bzl
+++ b/BazelExtensions/xcode_configuration_provider.bzl
@@ -84,10 +84,14 @@ def _extract_generated_sources(target, ctx):
     if ctx.rule.kind == "entitlements_writer":
         files.append(target.files)
 
+    include_swift_outputs = ctx.attr.include_swift_outputs == "true" 
+
     if SwiftInfo in target:
         module_info = target[SwiftInfo]
         if hasattr(module_info, "transitive_modulemaps"):
             files.append(module_info.transitive_modulemaps)
+        if include_swift_outputs and hasattr(module_info, "transitive_swiftmodules"):
+            files.append(module_info.transitive_swiftmodules)
 
     if hasattr(target, "objc"):
         objc = target.objc
@@ -101,23 +105,7 @@ def _extract_generated_sources(target, ctx):
 get_srcroot = "\"$(cat ../../DO_NOT_BUILD_HERE)/\""
 non_hermetic_execution_requirements = { "no-cache": "1", "no-remote": "1", "local": "1", "no-sandbox": "1" }
 
-def _xcode_build_sources_aspect_impl(itarget, ctx):
-    """ Install Xcode project dependencies into the source root.
-    This is required as by default, Bazel only installs genfiles for those
-    genfiles which are passed to the Bazel command line.
-    """
-
-    infos = []
-    infos.extend(_extract_generated_sources(itarget, ctx))
-    if hasattr(ctx.rule.attr, "deps"):
-        for target in ctx.rule.attr.deps:
-            if XcodeBuildSourceInfo in target:
-                trans = _extract_generated_sources(target, ctx)
-                infos.extend(trans)
-
-
-    # This uses an external program because bazel action code doesn't like to
-    # be non-hermetic
+def _install_action(ctx, infos, itarget):
     inputs = []
     cmd = []
     cmd.append("SRCROOT=" + get_srcroot)
@@ -137,6 +125,7 @@ def _xcode_build_sources_aspect_impl(itarget, ctx):
             )
             cmd.append("mkdir -p \"$target_dir\"")
             cmd.append("ditto " + info.path + " \"$target_dir\"")
+
     output = ctx.actions.declare_file(itarget.label.name + "_outputs.dummy")
     cmd.append("touch " + output.path)
     ctx.actions.run_shell(
@@ -146,14 +135,39 @@ def _xcode_build_sources_aspect_impl(itarget, ctx):
         outputs=[output],
         execution_requirements = non_hermetic_execution_requirements
     )
+    return output
+
+def _xcode_build_sources_aspect_impl(itarget, ctx):
+    """ Install Xcode project dependencies into the source root.
+    This is required as by default, Bazel only installs genfiles for those
+    genfiles which are passed to the Bazel command line.
+    """
+
+    infos = []
+    infos.extend(_extract_generated_sources(itarget, ctx))
+    if hasattr(ctx.rule.attr, "deps"):
+        for target in ctx.rule.attr.deps:
+            if XcodeBuildSourceInfo in target:
+                trans = _extract_generated_sources(target, ctx)
+                infos.extend(trans)
+
 
     return [
-        OutputGroupInfo(xcode_project_deps=infos + [output]),
+        OutputGroupInfo(
+            xcode_project_deps=[_install_action(ctx, infos, itarget)],
+        ),
         XcodeBuildSourceInfo(values=infos)
     ]
 
+# Note, that for "pure" Xcode builds we build swiftmodules with Xcode, so we
+# don't need to pre-compile them with Bazel
+pure_xcode_build_sources_aspect = aspect(
+    implementation=_xcode_build_sources_aspect_impl, attr_aspects=["*"],
+    attrs = { "include_swift_outputs": attr.string(values=["false","true"], default="false") }
+)
 
 xcode_build_sources_aspect = aspect(
-    implementation=_xcode_build_sources_aspect_impl, attr_aspects=["*"]
+    implementation=_xcode_build_sources_aspect_impl, attr_aspects=["*"],
+    attrs = { "include_swift_outputs": attr.string(values=["false", "true"], default="true") }
 )
 

--- a/BazelExtensions/xcode_configuration_provider.bzl
+++ b/BazelExtensions/xcode_configuration_provider.bzl
@@ -84,9 +84,8 @@ def _extract_generated_sources(target, ctx):
     if ctx.rule.kind == "entitlements_writer":
         files.append(target.files)
 
-    include_swift_outputs = ctx.attr.include_swift_outputs == "true" 
-
     if SwiftInfo in target:
+        include_swift_outputs = ctx.attr.include_swift_outputs == "true"
         module_info = target[SwiftInfo]
         if hasattr(module_info, "transitive_modulemaps"):
             files.append(module_info.transitive_modulemaps)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PREFIX := /usr/local
 workspace: build
 	@tools/bazelwrapper build :xchammer_config
 	$(XCHAMMER_BIN) generate \
-		bazel-genfiles/xchammer_config/XCHammer.json \
+		bazel-bin/xchammer_config/XCHammer.json \
 	    --bazel $(ROOT_DIR)/tools/bazelwrapper \
 	    --force
 
@@ -179,7 +179,7 @@ bazelrc_home:
 	echo "build --disk_cache=$(HOME)/Library/Caches/Bazel \\" > ~/.bazelrc
 	echo "     --spawn_strategy=standalone" >> ~/.bazelrc
 
-ci: bazelrc_home test run_perf_ci run_swift run_force_bazel goldmaster
+ci: bazelrc_home test run_perf_ci run_swift run_force_bazel goldmaster workspace
 
 format:
 	$(ROOT_DIR)/tools/bazelwrapper run buildifier

--- a/Sources/XCHammer/Generator.swift
+++ b/Sources/XCHammer/Generator.swift
@@ -72,7 +72,7 @@ enum Generator {
         // Build xcode_project_deps for the targets in question
         let bazelArgs = [
             "--override_repository=xchammer_resources=" + xchammerResources,
-            "--aspects @xchammer_resources//:xcode_configuration_provider.bzl%xcode_build_sources_aspect",
+            "--aspects @xchammer_resources//:xcode_configuration_provider.bzl%pure_xcode_build_sources_aspect",
             "--output_groups=xcode_project_deps"
         ] + labels.map { $0.value }
 

--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -129,11 +129,9 @@ struct Setting<T: XCSettingStringEncodeable & Semigroup>: Semigroup {
     }
 }
 
-
-
-
 struct XCBuildSettings: Encodable {
     var cc: First<String>?
+    var swiftc: First<String>?
     var ld: First<String>?
     var copts: [String] = []
     var productName: First<String>?
@@ -181,7 +179,9 @@ struct XCBuildSettings: Encodable {
     enum CodingKeys: String, CodingKey {
         // Add to this list the known XCConfig keys
         case cc = "CC"
+        case swiftc = "SWIFT_EXEC"
         case ld = "LD"
+        case libtool = "LIBTOOL"
         case copts = "OTHER_CFLAGS"
         case productName = "PRODUCT_NAME"
         case moduleName = "PRODUCT_MODULE_NAME"
@@ -237,7 +237,9 @@ struct XCBuildSettings: Encodable {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try cc.map { try container.encode($0.v, forKey: .cc) }
+        try swiftc.map { try container.encode($0.v, forKey: .swiftc) }
         try ld.map { try container.encode($0.v, forKey: .ld) }
+        try ld.map { try container.encode($0.v, forKey: .libtool) }
         try container.encode(copts.joined(separator: " "), forKey: .copts)
         try container.encode(swiftCopts.joined(separator: " "), forKey: .swiftCopts)
 
@@ -295,6 +297,7 @@ extension XCBuildSettings: Monoid {
     static func<>(lhs: XCBuildSettings, rhs: XCBuildSettings) -> XCBuildSettings {
         return XCBuildSettings(
             cc: lhs.cc <> rhs.cc,
+            swiftc: lhs.swiftc <> rhs.swiftc,
             ld: lhs.ld <> rhs.ld,
             copts: lhs.copts <> rhs.copts,
             productName: lhs.productName <> rhs.productName,

--- a/XCHammerAssets/swiftc_stub.py
+++ b/XCHammerAssets/swiftc_stub.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+try:
+    from typing import List
+except ImportError:
+    pass
+
+import json
+
+import os
+import sys
+
+
+def _main():
+    # type: () -> None
+    if sys.argv[1:] == ["-v"]:
+        os.system("swiftc -v")
+        return
+    _touch_deps_files(sys.argv)
+    _touch_swiftmodule_files(sys.argv)
+
+
+def _touch_deps_files(args):
+    # type: (List[str]) -> None
+    "Touch the Xcode-required .d files"
+    flag = args.index("-output-file-map")
+    output_file_map_path = args[flag + 1]
+    with open(output_file_map_path) as f:
+        output_file_map = json.load(f)
+    d_files = [
+        entry["dependencies"]
+        for entry in output_file_map.values()
+        if "dependencies" in entry
+    ]
+    for d_file in d_files:
+        _touch(d_file)
+
+
+def _touch_swiftmodule_files(args):
+    # type: (List[str]) -> None
+    "Touch the Xcode-required .swiftmodule and .swiftdoc files"
+    flag = args.index("-emit-module-path")
+    swiftmodule_path = args[flag + 1]
+    swiftdoc_path = _replace_ext(swiftmodule_path, "swiftdoc")
+    swiftsourceinfo_path = _replace_ext(swiftmodule_path, "swiftsourceinfo")
+    _touch(swiftmodule_path)
+    _touch(swiftdoc_path)
+    _touch(swiftsourceinfo_path)
+
+
+def _touch(path):
+    # type: (str) -> None
+    open(path, "a")
+
+
+def _replace_ext(path, extension):
+
+    # type: (str, str) -> str
+    name, _ = os.path.splitext(path)
+    return ".".join((name, extension))
+
+
+if __name__ == "__main__":
+    _main()

--- a/XCHammerAssets/swiftc_stub.py
+++ b/XCHammerAssets/swiftc_stub.py
@@ -45,6 +45,8 @@ def _touch_swiftmodule_files(args):
     _touch(swiftmodule_path)
     _touch(swiftdoc_path)
     _touch(swiftsourceinfo_path)
+    header_path = swiftmodule_path.replace((".swiftmodule"), "-Swift.h")
+    _touch(header_path)
 
 
 def _touch(path):
@@ -53,7 +55,6 @@ def _touch(path):
 
 
 def _replace_ext(path, extension):
-
     # type: (str, str) -> str
     name, _ = os.path.splitext(path)
     return ".".join((name, extension))

--- a/tools/bazelwrapper
+++ b/tools/bazelwrapper
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-set -ex
+set -e
 # Make sure we're in the project root directory.
 SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
 pushd "$SCRIPTPATH/.." > /dev/null
 
 
-set -x
 BAZEL="${SCRIPTPATH}/bazel"
 
 function clean() {


### PR DESCRIPTION
First, it removes transitive module map collection. This is no longer
needed and produces a different result.

Next, It improves the handling of copts in general to adopt the calling
`expand_location` inside of the aspect. In PodToBUILD, we just landed a
series of changes to build the top 50 swift cocoapods. Like other usages
of building mixed module swift libs, it uses `$(execpath` to pass an
internal module map via fmodule-map-file=. The reference Tulsi PR
resides here: https://github.com/bazelbuild/tulsi/pull/157 and I bumped
XCHammer to include this here
https://github.com/pinterest/xchammer/pull/243

Finally, it adds installation of swiftmodules and corresponding include
paths. This makes it easy for sourcekit to pick them up. Additionally, it
creates a swift stub to prevent Xcode from building swift files. This is
conditional for pure Xcode builds, as we build the swift modules with
Xcode in that case.

Additionally, I fixed an issue with `BazelExtensions` caught running
`make workspace` which is now part of the CI