### PR TITLE
Misc fixes for latest Bazel + rules_apple

### DIFF
--- a/BazelExtensions/xcode_configuration_provider.bzl
+++ b/BazelExtensions/xcode_configuration_provider.bzl
@@ -142,21 +142,27 @@ def _xcode_build_sources_aspect_impl(itarget, ctx):
     genfiles which are passed to the Bazel command line.
     """
 
+    # Note: we need to collect the transitive files seperately from our own
     infos = []
+    trans = []
     infos.extend(_extract_generated_sources(itarget, ctx))
     if hasattr(ctx.rule.attr, "deps"):
         for target in ctx.rule.attr.deps:
             if XcodeBuildSourceInfo in target:
-                trans = _extract_generated_sources(target, ctx)
-                infos.extend(trans)
-
+                infos.extend(_extract_generated_sources(target, ctx))
+                trans.extend(target[XcodeBuildSourceInfo].values)
 
     return [
         OutputGroupInfo(
-            xcode_project_deps=[_install_action(ctx, infos, itarget)],
+            xcode_project_deps = _install_action(
+                ctx,
+                depset(infos + trans).to_list(),
+                itarget,
+            ),
         ),
-        XcodeBuildSourceInfo(values=infos)
+        XcodeBuildSourceInfo(values = infos),
     ]
+
 
 # Note, that for "pure" Xcode builds we build swiftmodules with Xcode, so we
 # don't need to pre-compile them with Bazel

--- a/BazelExtensions/xcode_configuration_provider.bzl
+++ b/BazelExtensions/xcode_configuration_provider.bzl
@@ -134,7 +134,7 @@ def _install_action(ctx, infos, itarget):
         outputs=[output],
         execution_requirements = non_hermetic_execution_requirements
     )
-    return output
+    return [output]
 
 def _xcode_build_sources_aspect_impl(itarget, ctx):
     """ Install Xcode project dependencies into the source root.

--- a/BazelExtensions/xcodeproject.bzl
+++ b/BazelExtensions/xcodeproject.bzl
@@ -38,10 +38,14 @@ def _xcode_project_impl(ctx):
     for dep in ctx.attr.targets:
         if XcodeConfigurationAspectInfo in dep:
             for info in dep[XcodeConfigurationAspectInfo].values:
-                # For some targets, this is set on the apple binary target.
-                # Move this to the target level, so that XCHammer can easily
-                # read it
-                key = info.replace(".__internal__.apple_binary", "")
+                # For some targets, this is set on an internal target. We need
+                # to set this on the actual label. The convention is to name the
+                # target as ".__internal__.apple_binary" or
+                # ".__internal__.SOME"
+                if ".__internal__" in info:
+                    key = info.split(".__internal__")[0]
+                else:
+                    key = info
                 aggregate_target_config[key] = dep[XcodeConfigurationAspectInfo].values[info]
 
     xchammerconfig_json = ctx.actions.declare_file(ctx.attr.name + "_xchammer_config.json")


### PR DESCRIPTION
Under the latest Bazel + Rules apple the following changes happened.

1: different naming of test bundles this requires updating of the
`__internal__` binary replacement

2: propgation of transitive headermaps