### PR TITLE
Bump Tulsi to HEAD

### DIFF
--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -261,7 +261,7 @@ def xchammer_dependencies():
     namespaced_git_repository(
         name = "Tulsi",
         remote = "https://github.com/pinterest/tulsi.git",
-        commit = "e910a978e5381106186653462b9d649a35a997e0",
+        commit = "feba74a99096757bd719e9361caaaf3f2bd5387c",
         patch_cmds = [
             """
          sed -i '' 's/\:__subpackages__/visibility\:public/g' src/TulsiGenerator/BUILD


### PR DESCRIPTION
We've hit a few other issues when upgrading to Bazel 3.4.1 that seemed
intermittent before.

Under XCBuild it will conditionally install the XCTest dylibs and
other dylibs only if the bundle has changed. Under XCBuild the
result is that the dylibs are stripped out of the bundle from the
previous build. This change also sync bundles directly to the output
location if they exist.

Please find more info in the linked commit