### PR TITLE
Stop gap for "Could not attach to pid:"

### DIFF
--- a/Sources/XCHammer/Monoids.swift
+++ b/Sources/XCHammer/Monoids.swift
@@ -101,6 +101,16 @@ struct First<T>: Semigroup {
     }
 }
 
+extension String: Monoid {
+    static var empty: String {
+        return ""
+    }
+    
+    static func <>(lhs: String, rhs: String) -> String {
+        return lhs + rhs
+    }
+}
+
 extension Array: Monoid {
     static var empty: Array {
         return []

--- a/Sources/XCHammer/Monoids.swift
+++ b/Sources/XCHammer/Monoids.swift
@@ -101,16 +101,6 @@ struct First<T>: Semigroup {
     }
 }
 
-extension String: Monoid {
-    static var empty: String {
-        return ""
-    }
-    
-    static func <>(lhs: String, rhs: String) -> String {
-        return lhs + rhs
-    }
-}
-
 extension Array: Monoid {
     static var empty: Array {
         return []

--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -43,6 +43,15 @@ protocol XCSettingStringEncodeable {
     func XCSettingString() -> String
 }
 
+extension First: XCSettingStringEncodeable {
+    func XCSettingString() -> String {
+        if let encVal = v as? XCSettingStringEncodeable {
+	    return encVal.XCSettingString()
+	}
+	return ""
+    }
+}
+
 extension XCSettingStringEncodeable {
     func XCSettingString() -> String {
         return ""
@@ -111,12 +120,12 @@ extension KeyedEncodingContainer where K == XCSettingKey {
             try encode(encVal, forKey: baseKey)
         }
 
-        if let encVal = value.SDKiPhoneSimulator?.XCSettingString(), envVal != "" {
+        if let encVal = value.SDKiPhoneSimulator?.XCSettingString(), encVal != "" {
 	    try encode(encVal, forKey: baseKey.vary(on: "sdk=iphonesimulator*"))
         }
 
-        if let envVal = value.SDKiPhone?.XCSettingString(), encVal.isEmpty == false  {
-	    try encode(envVal, forKey: baseKey.vary(on: "sdk=iphoneos*"))
+        if let encVal = value.SDKiPhone?.XCSettingString(), encVal.isEmpty == false  {
+	    try encode(encVal, forKey: baseKey.vary(on: "sdk=iphoneos*"))
         }
     }
 }
@@ -232,10 +241,10 @@ struct XCBuildSettings: Encodable {
 
         // Require this for the simulator platform, which intermittently
         // requires this on Catalina, Xcode 11, and XCBuild
-        if let codeSigningAllowedValue = self.codeSigningAllowed?.v {
-            let setting = Setting(base: codeSigningAllowedValue,
-                SDKiPhoneSimulator: "YES",
-                SDKiPhone: codeSigningAllowedValue)
+        if let codeSigningAllowed = self.codeSigningAllowed {
+            let setting = Setting(base: codeSigningAllowed,
+                SDKiPhoneSimulator: First("YES"),
+                SDKiPhone: codeSigningAllowed)
             try variableContainer.encode(setting, forKey: .codeSigningAllowed)
         }
 

--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -46,9 +46,9 @@ protocol XCSettingStringEncodeable {
 extension First: XCSettingStringEncodeable {
     func XCSettingString() -> String {
         if let encVal = v as? XCSettingStringEncodeable {
-	    return encVal.XCSettingString()
-	}
-	return ""
+            return encVal.XCSettingString()
+        }
+        return ""
     }
 }
 

--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -39,10 +39,6 @@ struct XCSettingKey: CodingKey {
     }
 }
 
-enum XCCodingKey: String {
-    case ldFlags = "OTHER_LDFLAGS"
-}
-
 protocol XCSettingStringEncodeable {
     func XCSettingString() -> String
 }
@@ -102,32 +98,87 @@ struct Setting<T: XCSettingStringEncodeable & Semigroup>: Semigroup {
     }
 
     // Take a data container, and write values to it
-    func encode(to container: inout KeyedEncodingContainer<XCSettingKey>, forKey strKey: XCCodingKey) {
+    func encode(to container: inout KeyedEncodingContainer<XCSettingKey>, forKey strKey: XCSettingCodingKey) throws {
         let baseKey = XCSettingKey(stringValue: strKey.rawValue)!
 
         // Try encoding each setting for a key
         if let base = base {
             let c = base.XCSettingString()
             if c != "" {
-                try? container.encode(base.XCSettingString(), forKey: baseKey)
+                try container.encode(base.XCSettingString(), forKey: baseKey)
             }
         }
 
         if let SDKiPhoneSimulator = SDKiPhoneSimulator {
             let c = SDKiPhoneSimulator.XCSettingString()
             if c != "" {
-                try? container.encode(SDKiPhoneSimulator.XCSettingString(), forKey: baseKey.vary(on: "sdk=iphonesimulator*"))
+                try container.encode(SDKiPhoneSimulator.XCSettingString(), forKey: baseKey.vary(on: "sdk=iphonesimulator*"))
             }
         }
 
         if let SDKiPhone = SDKiPhone {
             let c = SDKiPhone.XCSettingString()
             if c.isEmpty == false {
-                try? container.encode(c, forKey: baseKey.vary(on: "sdk=iphoneos*"))
+                try container.encode(c, forKey: baseKey.vary(on: "sdk=iphoneos*"))
             }
         }
     }
 }
+
+enum XCSettingCodingKey: String, CodingKey {
+    // Add to this list the known XCConfig keys
+    case cc = "CC"
+    case swiftc = "SWIFT_EXEC"
+    case ld = "LD"
+    case libtool = "LIBTOOL"
+    case copts = "OTHER_CFLAGS"
+    case ldFlags = "OTHER_LDFLAGS"
+    case productName = "PRODUCT_NAME"
+    case moduleName = "PRODUCT_MODULE_NAME"
+    case enableModules = "CLANG_ENABLE_MODULES"
+    case headerSearchPaths = "HEADER_SEARCH_PATHS"
+    case frameworkSearchPaths = "FRAMEWORK_SEARCH_PATHS"
+    case librarySearchPaths = "LIBRARY_SEARCH_PATHS"
+    case archs = "ARCHS"
+    case validArchs = "VALID_ARCHS"
+    case pch = "GCC_PREFIX_HEADER"
+    case productBundleId = "PRODUCT_BUNDLE_IDENTIFIER"
+    case codeSigningRequired = "CODE_SIGNING_REQUIRED"
+    case codeSigningAllowed = "CODE_SIGNING_ALLOWED"
+    case debugInformationFormat = "DEBUG_INFORMATION_FORMAT"
+    case onlyActiveArch = "ONLY_ACTIVE_ARCH"
+    case enableTestability = "ENABLE_TESTABILITY"
+    case enableObjcArc = "CLANG_ENABLE_OBJC_ARC"
+    case iOSDeploymentTarget = "IPHONEOS_DEPLOYMENT_TARGET"
+    case macOSDeploymentTarget = "MACOSX_DEPLOYMENT_TARGET"
+    case tvOSDeploymentTarget = "TVOS_DEPLOYMENT_TARGET"
+    case watchOSDeploymentTarget = "WATCHOS_DEPLOYMENT_TARGET"
+    case infoPlistFile = "INFOPLIST_FILE"
+    case testHost = "TEST_HOST"
+    case bundleLoader = "BUNDLE_LOADER"
+    case appIconName = "ASSETCATALOG_COMPILER_APPICON_NAME"
+    case enableBitcode = "ENABLE_BITCODE"
+    case codeSigningIdentity = "CODE_SIGN_IDENTITY[sdk=iphoneos*]"
+    case codeSigningStyle = "CODE_SIGN_STYLE"
+    case moduleMapFile = "MODULEMAP_FILE"
+    case testTargetName = "TEST_TARGET_NAME"
+    case useHeaderMap = "USE_HEADERMAP"
+    case swiftVersion = "SWIFT_VERSION"
+    case swiftCopts = "OTHER_SWIFT_FLAGS"
+
+    case pythonPath = "PYTHONPATH"
+
+    // Hammer Rules
+    case codeSignEntitlementsFile = "HAMMER_ENTITLEMENTS_FILE"
+    case mobileProvisionProfileFile = "HAMMER_PROFILE_FILE"
+    case diagnosticFlags = "HAMMER_DIAGNOSTIC_FLAGS"
+    case isBazel = "HAMMER_IS_BAZEL"
+    case tulsiWR = "TULSI_WR"
+    case sdkRoot = "SDKROOT"
+    case targetedDeviceFamily = "TARGETED_DEVICE_FAMILY"
+    
+}
+
 
 struct XCBuildSettings: Encodable {
     var cc: First<String>?
@@ -176,66 +227,21 @@ struct XCBuildSettings: Encodable {
     var isBazel: First<String> = First("NO")
     var diagnosticFlags: [String] = []
 
-    enum CodingKeys: String, CodingKey {
-        // Add to this list the known XCConfig keys
-        case cc = "CC"
-        case swiftc = "SWIFT_EXEC"
-        case ld = "LD"
-        case libtool = "LIBTOOL"
-        case copts = "OTHER_CFLAGS"
-        case productName = "PRODUCT_NAME"
-        case moduleName = "PRODUCT_MODULE_NAME"
-        case enableModules = "CLANG_ENABLE_MODULES"
-        case headerSearchPaths = "HEADER_SEARCH_PATHS"
-        case frameworkSearchPaths = "FRAMEWORK_SEARCH_PATHS"
-        case librarySearchPaths = "LIBRARY_SEARCH_PATHS"
-        case archs = "ARCHS"
-        case validArchs = "VALID_ARCHS"
-        case pch = "GCC_PREFIX_HEADER"
-        case productBundleId = "PRODUCT_BUNDLE_IDENTIFIER"
-        case codeSigningRequired = "CODE_SIGNING_REQUIRED"
-        case codeSigningAllowed = "CODE_SIGNING_ALLOWED"
-        case debugInformationFormat = "DEBUG_INFORMATION_FORMAT"
-        case onlyActiveArch = "ONLY_ACTIVE_ARCH"
-        case enableTestability = "ENABLE_TESTABILITY"
-        case enableObjcArc = "CLANG_ENABLE_OBJC_ARC"
-        case iOSDeploymentTarget = "IPHONEOS_DEPLOYMENT_TARGET"
-        case macOSDeploymentTarget = "MACOSX_DEPLOYMENT_TARGET"
-        case tvOSDeploymentTarget = "TVOS_DEPLOYMENT_TARGET"
-        case watchOSDeploymentTarget = "WATCHOS_DEPLOYMENT_TARGET"
-        case infoPlistFile = "INFOPLIST_FILE"
-        case testHost = "TEST_HOST"
-        case bundleLoader = "BUNDLE_LOADER"
-        case appIconName = "ASSETCATALOG_COMPILER_APPICON_NAME"
-        case enableBitcode = "ENABLE_BITCODE"
-        case codeSigningIdentity = "CODE_SIGN_IDENTITY[sdk=iphoneos*]"
-        case codeSigningStyle = "CODE_SIGN_STYLE"
-        case moduleMapFile = "MODULEMAP_FILE"
-        case testTargetName = "TEST_TARGET_NAME"
-        case useHeaderMap = "USE_HEADERMAP"
-        case swiftVersion = "SWIFT_VERSION"
-        case swiftCopts = "OTHER_SWIFT_FLAGS"
-
-        case pythonPath = "PYTHONPATH"
-
-        // Hammer Rules
-        case codeSignEntitlementsFile = "HAMMER_ENTITLEMENTS_FILE"
-        case mobileProvisionProfileFile = "HAMMER_PROFILE_FILE"
-        case diagnosticFlags = "HAMMER_DIAGNOSTIC_FLAGS"
-        case isBazel = "HAMMER_IS_BAZEL"
-        case tulsiWR = "TULSI_WR"
-        case sdkRoot = "SDKROOT"
-        case targetedDeviceFamily = "TARGETED_DEVICE_FAMILY"
-        
-    }
 
     func encode(to encoder: Encoder) throws {
         var XCContainer = encoder.container(keyedBy: XCSettingKey.self)
-        ldFlags.encode(to: &XCContainer, forKey: XCCodingKey.ldFlags)
+        try ldFlags.encode(to: &XCContainer, forKey: XCSettingCodingKey.ldFlags)
 
-        // TODO: port all of these to XCCodingKey
-        var container = encoder.container(keyedBy: CodingKeys.self)
+        // Require this for the simulator platform, which intermittently
+        // requires this on Catalina, Xcode 11, and XCBuild
+        if let codeSigningAllowedValue = self.codeSigningAllowed?.v {
+            try Setting(base: codeSigningAllowedValue,
+                SDKiPhoneSimulator: "YES",
+                SDKiPhone: codeSigningAllowedValue)
+                .encode(to: &XCContainer, forKey: XCSettingCodingKey.codeSigningAllowed)
+        }
 
+        var container = encoder.container(keyedBy: XCSettingCodingKey.self)
         try cc.map { try container.encode($0.v, forKey: .cc) }
         try swiftc.map { try container.encode($0.v, forKey: .swiftc) }
         try ld.map { try container.encode($0.v, forKey: .ld) }
@@ -255,7 +261,6 @@ struct XCBuildSettings: Encodable {
         try debugInformationFormat.map { try container.encode($0.v, forKey: .debugInformationFormat) }
         try productBundleId.map { try container.encode($0.v, forKey: .productBundleId) }
         try codeSigningRequired.map { try container.encode($0.v, forKey: .codeSigningRequired) }
-        try codeSigningAllowed.map { try container.encode($0.v, forKey: .codeSigningAllowed) }
         try codeSigningIdentity.map { try container.encode($0.v, forKey: .codeSigningIdentity) }
         try onlyActiveArch.map { try container.encode($0.v, forKey: .onlyActiveArch) }
         try enableTestability.map { try container.encode($0.v, forKey: .enableTestability) }

--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -230,7 +230,7 @@ struct XCBuildSettings: Encodable {
 
     func encode(to encoder: Encoder) throws {
         var XCContainer = encoder.container(keyedBy: XCSettingKey.self)
-        try ldFlags.encode(to: &XCContainer, forKey: XCSettingCodingKey.ldFlags)
+        try ldFlags.encode(to: &XCContainer, forKey: .ldFlags)
 
         // Require this for the simulator platform, which intermittently
         // requires this on Catalina, Xcode 11, and XCBuild
@@ -238,7 +238,7 @@ struct XCBuildSettings: Encodable {
             try Setting(base: codeSigningAllowedValue,
                 SDKiPhoneSimulator: "YES",
                 SDKiPhone: codeSigningAllowedValue)
-                .encode(to: &XCContainer, forKey: XCSettingCodingKey.codeSigningAllowed)
+                .encode(to: &XCContainer, forKey: .codeSigningAllowed)
         }
 
         var container = encoder.container(keyedBy: XCSettingCodingKey.self)

--- a/Sources/XCHammer/XCBuildSettings.swift
+++ b/Sources/XCHammer/XCBuildSettings.swift
@@ -107,25 +107,16 @@ extension KeyedEncodingContainer where K == XCSettingKey {
         }
 
         // Try encoding each setting for a key
-        if let base = value.base {
-            let c = base.XCSettingString()
-            if c != "" {
-                try encode(base.XCSettingString(), forKey: baseKey)
-            }
+        if let encVal = value.base?.XCSettingString(), encVal != ""  {
+            try encode(encVal, forKey: baseKey)
         }
 
-        if let SDKiPhoneSimulator = value.SDKiPhoneSimulator {
-            let c = SDKiPhoneSimulator.XCSettingString()
-            if c != "" {
-                try encode(SDKiPhoneSimulator.XCSettingString(), forKey: baseKey.vary(on: "sdk=iphonesimulator*"))
-            }
+        if let encVal = value.SDKiPhoneSimulator?.XCSettingString(), envVal != "" {
+	    try encode(encVal, forKey: baseKey.vary(on: "sdk=iphonesimulator*"))
         }
 
-        if let SDKiPhone = value.SDKiPhone {
-            let c = SDKiPhone.XCSettingString()
-            if c.isEmpty == false {
-                try encode(c, forKey: baseKey.vary(on: "sdk=iphoneos*"))
-            }
+        if let envVal = value.SDKiPhone?.XCSettingString(), encVal.isEmpty == false  {
+	    try encode(envVal, forKey: baseKey.vary(on: "sdk=iphoneos*"))
         }
     }
 }

--- a/Sources/XCHammer/XcodeTarget.swift
+++ b/Sources/XCHammer/XcodeTarget.swift
@@ -1346,7 +1346,8 @@ public class XcodeTarget: Hashable, Equatable {
 
         settings.isBazel = First("YES")
         settings.onlyActiveArch = First("YES")
-        settings.codeSigningRequired <>= First("NO")
+        settings.codeSigningRequired = First("NO")
+        settings.codeSigningAllowed = First("NO")
         settings.productName <>= First("$(TARGET_NAME)")
         // A custom XCHammerAsset bazel_build_settings.py is loaded by bazel_build.py
         settings.pythonPath =


### PR DESCRIPTION
On my encatation of macOS Catalina, XCBuild, and Xcode 11, the simulator
intermittently fails with the error "Could not attach to pid:"

It turns out that there's 2 symptoms

1: the binary doesn't launch
2: lldb fails to attach w/o get-task-allow

For now, the workaround allows XCBuild to code sign if needed. Longer
term, we shouldn't really need this but folks often have to add the
setting manually.

Additionally, streamlines some of the keys.