### PR TITLE
Fix documentation links and add a CI step to make sure they are valid

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ jobs:
     steps:
     - name: Checkout the Git repository
       uses: actions/checkout@v1
+    - name: Initial setup
+      run: ./taskfile setup
+    - name: Check documentation links
+      run: ./taskfile checkDocumentationLinks ${{ github.sha }}
     - name: Setup dependencies 
       run: sudo gem install cocoapods 
     - name: Run Tests

--- a/.github/workflows/ci_push.yml
+++ b/.github/workflows/ci_push.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
     - name: Checkout the Git repository
       uses: actions/checkout@v1
+    - name: Initial setup
+      run: ./taskfile setup
+    - name: Check documentation links
+      run: ./taskfile checkDocumentationLinks ${{ github.sha }}
     - name: Setup dependencies 
       run: sudo gem install cocoapods 
     - name: Run Tests

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ external
 *.swp
 
 xchammer-includes
+vendor/bundle

--- a/Docs/XCHammerFAQ.md
+++ b/Docs/XCHammerFAQ.md
@@ -17,7 +17,7 @@ identical.
 
 ## What is XCHammer?
 
-Please see the document, [XCHammer Overview](Docs/XCHammerOverview.md)
+Please see the document, [XCHammer Overview](XCHammerOverview.md)
 
 ## How is XCHammer different than Tulsi?
 

--- a/Docs/XCHammerOverview.md
+++ b/Docs/XCHammerOverview.md
@@ -55,9 +55,9 @@ XcodeGen, XCHammer is overall easier to maintain and update across Bazel and
 Xcode updates.
 
 Please see the document [Bazel for iOS
-developers](Docs/BazelForiOSDevelopers.md) to learn more about the common
+developers](BazelForiOSDevelopers.md) to learn more about the common
 interfaces that XCHammer uses. The segment [Xcode Project
-generators](Docs/BazelForiOSDevelopers.md#generated-xcode-projects) provides an
+generators](BazelForiOSDevelopers.md#generated-xcode-projects) provides an
 high level overview of such an architecture and how an aspects and rule fit
 together with Bazel and how Xcode is integrated with Bazel.
 
@@ -77,10 +77,10 @@ xcode_project(
 ```
 
 The rule `xcode_project` invokes the [XCHammer
-binary](Sources/XCHammer/main.swift) with arguments including a json
-representation of [XCHammerConfig](Sources/XCHammer/XCHammerConfig.swift) and a
+binary](../Sources/XCHammer/main.swift) with arguments including a json
+representation of [XCHammerConfig](../Sources/XCHammer/XCHammerConfig.swift) and a
 json represention of
-[XcodeProjectRuleInfo](Sources/XCHammer/XCHammerGenerateOptions.swift). Inside
+[XcodeProjectRuleInfo](../Sources/XCHammer/XCHammerGenerateOptions.swift). Inside
 of the main function is where the main logic of generating an Xcode project
 exists. 
 
@@ -95,7 +95,7 @@ of the rule only_
 
 ## Sources Aspect
 
-The rule, [`xcode_project`](BazelExtensions/xcodeproject.bzl) accepts 2
+The rule, [`xcode_project`](../BazelExtensions/xcodeproject.bzl) accepts 2
 different aspects for the users specified target. 
 
 First, and most involved, is the `tulsi_sources_aspect`. This aspect is used to
@@ -123,7 +123,7 @@ grew in complexity and features. The main issue was having to set many kinds of
 options in Xcode for each target. For example, a project may have different
 environment variables in the scheme and vary on each target. Another example,
 is [bolting on xcode project
-instrumentation](Docs/PinterestFocusedXcodeProjects.md) in order to track local
+instrumentation](PinterestFocusedXcodeProjects.md) in order to track local
 build times in Xcode with statsd. At one point, the `XCHammerConfig` was too
 complex and unmaintainable. This aspect was created to setup Xcode target
 metadata adjacent to the rules.
@@ -203,7 +203,7 @@ focus on the problem at hand. By using XcodeGen, it's straight forward to
 generate an Xcode project that _just works_ with or without Bazel.
 
 For information about how Xcode runs Bazel builds, see [Xcode Project
-generators](Docs/BazelForiOSDevelopers.md#generated-xcode-projects)
+generators](BazelForiOSDevelopers.md#generated-xcode-projects)
 
 ## Examples of common problems and how they were fixed
 
@@ -219,7 +219,7 @@ Xcode configuration files and there is no defaults enforced.
 In vanilla Bazel usage, a similar problem exists  when the user is allowed to
 specificy `copts`. Therefore, a simple system of macros is implemented in order
 to prevent users from configuring `copts` in an unexpected way. See the segment
-[marcos](Docs/BazelForiOSDevelopers.md#macros) for a complete listing.
+[marcos](BazelForiOSDevelopers.md#macros) for a complete listing.
 Recently, there has been work on Bazel to extract the native rules. Note, that
 the Bazel toolchain is orthogonal to using macros to wrap rules
 [rules_cc](https://github.com/bazelbuild/rules_cc).
@@ -243,6 +243,6 @@ solves the problem of being able to build the app with Xcode.
 When Xcode projects grown in size and scope, the IDE experience starts to
 degrade. By default Xcode ends up indexing the entire source tree which hogs CPU
 resources and slows down autocomplete. The document, [Pinterest Focused Xcode
-Projects](Docs/PinterestFocusedXcodeProjects.md) explains how Bazel and XCHammer
+Projects](PinterestFocusedXcodeProjects.md) explains how Bazel and XCHammer
 are used to solve this problem and reduce the load by orders of magnitude.
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org' do
+  gem 'awesome_bot', '1.19.1'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    awesome_bot (1.19.1)
+      parallel (= 1.17.0)
+    parallel (1.17.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  awesome_bot (= 1.19.1)!
+
+BUNDLED WITH
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ FAQ](Docs/XCHammerFAQ.md). To learn more about Bazel, see [Bazel for iOS
 developers](Docs/BazelForiOSDevelopers.md). To learn about how Pinterest uses
 XCHammer see [Introducing
 XCHammer](Docs/FastAndReproducibleBuildsWithXCHammer.md) and [Pinterest Focused
-Xcode Projects](PinterestFocusedXcodeProjects.md)_
+Xcode Projects](Docs/PinterestFocusedXcodeProjects.md)_
 
 ### Installation
 

--- a/taskfile
+++ b/taskfile
@@ -1,0 +1,38 @@
+#!/bin/zsh
+
+#####################################################################
+# This file contains several functions that can be run as tasks
+#
+# In order to run them easily, add the following alias to your shell:
+# > echo "alias task='./taskfile'" >> ~/.zshrc
+#
+# After that, you can run the functions as follows:
+# > task <function_name>
+#####################################################################
+
+# Fail if exit code is not zero, in pipes, and also if variable is not set
+# See: https://vaneyckt.io/posts/safer_bash_scripts_with_set_euxo_pipefail/
+set -euo pipefail
+
+setup() {
+  echo "✨ Install gem dependencies"
+  bundle config set path 'vendor/bundle'
+  bundle install
+}
+
+checkDocumentationLinks() {
+  echo "✨ Check that the links contained in *.md files are valid"
+
+  revision=$1
+  cmd="bundle exec awesome_bot \
+    --allow-redirect \
+    --allow-dupe \
+    --skip-save-results \
+    --set-timeout 5 \
+    --base-url https://github.com/pinterest/xchammer/tree/$revision/"
+  
+  eval "${cmd} README.md"
+  eval "${cmd}Docs/ Docs/*.md"
+}
+
+"$@" # Source: https://stackoverflow.com/a/16159057/3203441


### PR DESCRIPTION
Hey :)

There were several broken links in the documentation. This PR:
* Fixes them
* Adds a CI step to validate them, so they are never broken again