### PR TITLE
Correct output path for the ditto command

### DIFF
--- a/BazelExtensions/xcodeproject.bzl
+++ b/BazelExtensions/xcodeproject.bzl
@@ -127,7 +127,7 @@ def _xcode_project_impl(ctx):
             else "\$SRCROOT/" + ctx.attr.bazel,
             "--xcode_project_rule_info",
             xchammer_info_json.path,
-            "; ditto " + project_name + " " + ctx.bin_dir.path + "/" + project_name,
+            "; ditto " + project_name + " " + ctx.outputs.out.path,
         ]
     )
 


### PR DESCRIPTION
Fixes https://github.com/pinterest/xchammer/issues/241

I think the issue could be reproduced if the `xcode_project` rule is placed somewhere NOT in the top level of the bazel workspace.

All samples in this repo have the `BUILD.bazel` files next to the `WORKSPACE`, and I think that may be why the issue does not arise on CI.

