### PR TITLE
symlink `external` to installroot external dir

### DIFF
--- a/BazelExtensions/xcodeproject.bzl
+++ b/BazelExtensions/xcodeproject.bzl
@@ -180,11 +180,9 @@ def _install_xcode_project_impl(ctx):
         "sed -i '' \"s,\$SRCROOT,$SRCROOT,g\" "
         + output_proj
         + "/XCHammerAssets/bazel_build_settings.py",
-        # If the external symlink exists already remove it and symlink to the
-        # bazel install root symlink. The execroot external directory might not
-        # have all material at one point
-        "test -h $SRCROOT/external && rm -rf $SRCROOT/external",
-        "ln -sf $PWD/../../external $SRCROOT/external",
+        # Ensure the `external` symlink points to output_base/external
+        "test $SRCROOT/external -ef $PWD/../../external || " +
+        "(rm -f $SRCROOT/external && ln -sf $PWD/../../external $SRCROOT/external)",
         'echo "' + output_proj + '" > ' + ctx.outputs.out.path,
     ]
     ctx.actions.run_shell(

--- a/BazelExtensions/xcodeproject.bzl
+++ b/BazelExtensions/xcodeproject.bzl
@@ -180,7 +180,11 @@ def _install_xcode_project_impl(ctx):
         "sed -i '' \"s,\$SRCROOT,$SRCROOT,g\" "
         + output_proj
         + "/XCHammerAssets/bazel_build_settings.py",
-        "ln -sf $PWD/external $SRCROOT/external",
+        # If the external symlink exists already remove it and symlink to the
+        # bazel install root symlink. The execroot external directory might not
+        # have all material at one point
+        "test -h $SRCROOT/external && rm -rf $SRCROOT/external",
+        "ln -sf $PWD/../../external $SRCROOT/external",
         'echo "' + output_proj + '" > ' + ctx.outputs.out.path,
     ]
     ctx.actions.run_shell(


### PR DESCRIPTION
The directory inside of `execroot` is subject to change. It's possible
that running bazel after generating the Xcode project puts the wrong
material there.