### PR TITLE
Add `compilation_mode` into XCHammer's own xcodeproj

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -68,8 +68,17 @@ load(
     "apple_resource_group",
 )
 
+# Note:
+# - $(SPAWN_OPTS) is determined at build time by tools/XCHammerXcodeRunscript.sh
+# XCHammer's `bazel`, tools/bazelwrapper subs out make variable
+xchammer_xcode_target_config = target_config(
+    build_bazel_template="tools/XCHammerXcodeRunscript.sh",
+    build_bazel_options="$(SPAWN_OPTS)"
+)
+
 # This is an example of declaring a target config.
-declare_target_config(name="XCHammerSourcesXcodeConfig", config=target_config())
+declare_target_config(name="XCHammerSourcesXcodeConfig",
+     config=xchammer_xcode_target_config)
 
 # This BUILD file is not actually imported into XCHammer
 # There is already a BUILD file placed in there by another dep.
@@ -123,7 +132,7 @@ macos_application(
     infoplists = ["Info.plist"],
     minimum_os_version = "10.14",
     version = ":XCHammerVersion",
-    deps = [":XCHammerSources"],
+    deps = [":XCHammerSources", ":XCHammerSourcesXcodeConfig"],
 )
 
 buildifier(
@@ -149,35 +158,35 @@ scheme_config = {
     ),
 }
 
-xchammer_config = xchammer_config(
-    projects = {
-        "xchammer": project_config(paths = ["**"]),
-    },
-    target_config = {
-        "//:xchammer": target_config(
-            # Metrics are disabled by default
-            # scheme_config=scheme_config
-        ),
-        "//tools/XCConfigExporter:xcconfig-exporter": target_config(),
-    },
-    targets = ["//:xchammer", "//tools/XCConfigExporter:xcconfig-exporter"],
-)
-
+# XCHammer config for the CLI build project
+# For large projects, we'd want to use the xcode_project rule
+# and let the `xcode_project` rule aggregate the config options.
 gen_xchammer_config(
     name = "xchammer_config",
-    config = xchammer_config,
+    config = xchammer_config(
+        projects = {
+            "xchammer": project_config(paths = ["**"]),
+        },
+        target_config = {
+            "//:xchammer": xchammer_xcode_target_config,
+            "//tools/XCConfigExporter:xcconfig-exporter": xchammer_xcode_target_config
+        },
+        targets = ["//:xchammer", "//tools/XCConfigExporter:xcconfig-exporter"],
+    ),
 )
 
-# Experimental xcode_project rule
+# Xcode project for Bazel built project
 load(
     "//:BazelExtensions/xcodeproject.bzl",
     "xcode_project"
 )
 
+# The xcode_project for Bazel built Xcode project
+# Note: the target_config is declared in :XCHammerSourcesXcodeConfig
 xcode_project(
     name="workspace_v2",
     bazel="tools/bazelwrapper",
-    targets=["//:xchammer",  "//tools/XCConfigExporter:xcconfig-exporter"],
+    targets=["//:xchammer", "//tools/XCConfigExporter:xcconfig-exporter"],
     project_config=project_config(
         paths = ["**"],
         generate_xcode_schemes=False,

--- a/README.md
+++ b/README.md
@@ -102,9 +102,13 @@ projects:
             - "**"
 ```
 
-_See [XCHammerConfig.swift](https://github.com/pinterest/xchammer/blob/master/Sources/XCHammer/XCHammerConfig.swift) for detailed documentation of the format._
+_See
+[XCHammerConfig.swift](https://github.com/pinterest/xchammer/blob/master/Sources/XCHammer/XCHammerConfig.swift)
+for detailed documentation of the format._
 
-_To learn about how Pinterest uses XCHammer with Bazel locally check out [Pinterest Xcode Focused Projects](https://github.com/pinterest/xchammer/blob/master/Docs/PinterestFocusedXcodeProjects.md)._
+_To learn about how Pinterest uses XCHammer with Bazel locally check out
+[Pinterest Xcode Focused
+Projects](https://github.com/pinterest/xchammer/blob/master/Docs/PinterestFocusedXcodeProjects.md)._
 
 ### Practical configuration examples
 
@@ -114,7 +118,7 @@ Xcode dynamically, on a target level, on a project level, and on an
 architecture level.
 
 _When using the CLI the
-XCHammerConfig.swift](https://github.com/pinterest/xchammer/blob/master/Sources/XCHammer/XCHammerConfig.swift)
+[XCHammerConfig.swift](https://github.com/pinterest/xchammer/blob/master/Sources/XCHammer/XCHammerConfig.swift)
 is passed via an `.yml` file, and when using the `xcode_project` rule, the
 `XCHammerConfig` is passed into the rule._
 
@@ -133,8 +137,8 @@ architecture in an iOS app.
 
 #### Target Level
 
-The [configuration](BazelExtensions/BazelExtensions/xchammerconfig.bzl) option, `build_bazel_options` makes it possible, to
-set extra options on bazel target.
+The [configuration](BazelExtensions/BazelExtensions/xchammerconfig.bzl) option,
+`build_bazel_options` makes it possible, to set extra options on bazel target.
 
 Finally, the `build_bazel_template` makes it possible to run a script _inside_
 of Xcode before and after building. This also allows the user to pass in Bazel
@@ -145,7 +149,7 @@ Checkout the [BUILD](BUILD.bazel) file and samples for examples.
 #### Build Time - debugging and static analysis
 
 At the time of writing, there should be a way to build in "debug mode" in order
-for LLDB to work. One possibility is to set this a default and override when
+for LLDB to work. One possibility is to set this as a default and override when
 releasing. By default, it's possible to pass variables to Bazel. For example,
 in XCHammer's own Xcode project,
 [tools/XCHammerXcodeRunscript.sh](tools/XCHammerXcodeRunscript.sh) it set's the

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ Projects](https://github.com/pinterest/xchammer/blob/master/Docs/PinterestFocuse
 ### Practical configuration examples
 
 By default, XCHammer doesn't provide or enforce any build configuration
-defaults.  It does exposes APIs to make it possible to configure Bazel options
-Xcode dynamically, on a target level, on a project level, and on an
-architecture level.
+defaults in Bazel or Xcode. It exposes APIs to make it possible to configure
+Bazel options Xcode dynamically, on a target level, on a project level, and per
+architecture.
 
 _When using the CLI the
 [XCHammerConfig.swift](https://github.com/pinterest/xchammer/blob/master/Sources/XCHammer/XCHammerConfig.swift)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,57 @@ _See [XCHammerConfig.swift](https://github.com/pinterest/xchammer/blob/master/So
 
 _To learn about how Pinterest uses XCHammer with Bazel locally check out [Pinterest Xcode Focused Projects](https://github.com/pinterest/xchammer/blob/master/Docs/PinterestFocusedXcodeProjects.md)._
 
+### Practical configuration examples
+
+By default, XCHammer doesn't provide or enforce any build configuration
+defaults.  It does exposes APIs to make it possible to configure Bazel options
+Xcode dynamically, on a target level, on a project level, and on an
+architecture level.
+
+_When using the CLI the
+XCHammerConfig.swift](https://github.com/pinterest/xchammer/blob/master/Sources/XCHammer/XCHammerConfig.swift)
+is passed via an `.yml` file, and when using the `xcode_project` rule, the
+`XCHammerConfig` is passed into the rule._
+
+#### Project level
+
+The parameter `bazel` makes it possible to select a wrapper command for Bazel.
+In practice, this might be `bazelisk` or a wrapper script. In the case of
+XCHammer's own Xcode project, it's [tools/bazelwrapper](tools/bazelwrapper) to
+handle make variable substitution at build time.
+
+The [configuration](BazelExtensions/BazelExtensions/xchammerconfig.bzl) option,
+`build_bazel_platform_options` make it possible to configure architecture
+specific settings for each target. Checkout
+[sample/UrlGet/BUILD.bazel](sample/UrlGet/BUILD.bazel) passes a `config` per
+architecture in an iOS app.
+
+#### Target Level
+
+The [configuration](BazelExtensions/BazelExtensions/xchammerconfig.bzl) option, `build_bazel_options` makes it possible, to
+set extra options on bazel target.
+
+Finally, the `build_bazel_template` makes it possible to run a script _inside_
+of Xcode before and after building. This also allows the user to pass in Bazel
+arguments at build time.
+
+Checkout the [BUILD](BUILD.bazel) file and samples for examples.
+
+#### Build Time - debugging and static analysis
+
+At the time of writing, there should be a way to build in "debug mode" in order
+for LLDB to work. One possibility is to set this a default and override when
+releasing. By default, it's possible to pass variables to Bazel. For example,
+in XCHammer's own Xcode project,
+[tools/XCHammerXcodeRunscript.sh](tools/XCHammerXcodeRunscript.sh) it set's the
+`compilation_mode` based on Xcode's `CONFIGURATION` variable.
+
+For the purpose of running static analysis, linters, and enabling other
+options, it's possible to pass in extra bazel arguments at build time. For
+example you might hinge running static analyzer on the analysis action in Xcode
+which sets `RUN_CLANG_STATIC_ANALYZER`. Bazel doesn't have a way to run linters
+or static analysis so it's totally up to the user how to run this.
+
 ## Samples
 
 - [a Objective-C iOS app](sample/UrlGet)

--- a/tools/XCHammerXcodeRunscript.sh
+++ b/tools/XCHammerXcodeRunscript.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ "$CONFIGURATION" == "Release" ]]; then
+    COMPILATION_MODE="opt"
+elif [[ "$CONFIGURATION" == "Profile" ]]; then
+    COMPILATION_MODE="opt"
+else
+    COMPILATION_MODE="dbg"
+fi
+
+export SPAWN_OPTS="--compilation_mode=$COMPILATION_MODE"
+exec __BAZEL_COMMAND__


### PR DESCRIPTION
By default this is set to `fastbuild` and debug info isn't set or
working. This PR uses existing config systems to set the
`compilation_mode`

Additionally document current config possibilities which don't really
handle this by default.

After running into this in XCHammer it's pretty clear to me that we
should have a sensible default to set the `compilation_mode` by default.
Perhaps a followup could consider adding defaults. I realized we don't
have this issue in the test sample because it sets the default
`compilation_mode` to `dbg` in the `.bazelrc`