### PR TITLE
Safer SCRIPTPATH formation

### DIFF
--- a/sample/Frankenstein/tools/bazelwrapper
+++ b/sample/Frankenstein/tools/bazelwrapper
@@ -3,7 +3,7 @@
 set -e
 
 # Make sure we're in the project root directory.
-SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
 pushd "$SCRIPTPATH/.." > /dev/null
 
 function exit_trap() {

--- a/sample/SnapshotMe/tools/bazelwrapper
+++ b/sample/SnapshotMe/tools/bazelwrapper
@@ -3,7 +3,7 @@
 set -e
 
 # Make sure we're in the project root directory.
-SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
 pushd "$SCRIPTPATH/.." > /dev/null
 
 function exit_trap() {

--- a/sample/Tailor/tools/bazelwrapper
+++ b/sample/Tailor/tools/bazelwrapper
@@ -3,7 +3,7 @@
 set -e
 
 # Make sure we're in the project root directory.
-SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
 pushd "$SCRIPTPATH/.." > /dev/null
 
 function exit_trap() {

--- a/sample/UrlGet/tools/bazelwrapper
+++ b/sample/UrlGet/tools/bazelwrapper
@@ -3,7 +3,7 @@
 set -e
 
 # Make sure we're in the project root directory.
-SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
 pushd "$SCRIPTPATH/.." > /dev/null
 
 function exit_trap() {

--- a/sample/WorkspaceSource/tools/bazelwrapper
+++ b/sample/WorkspaceSource/tools/bazelwrapper
@@ -3,7 +3,7 @@
 set -e
 
 # Make sure we're in the project root directory.
-SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}"  )" && pwd  )"
+SCRIPTPATH="$( cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
 pushd "$SCRIPTPATH/.." > /dev/null
 
 function exit_trap() {


### PR DESCRIPTION
Under some newer versions of bash (perhaps macOS-specific?), we should
account for errors returned by dirname(1). Also pass `-P` to pwd(1).