### PR TITLE
Remove the Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # XCHammer
 > If all you've got is Xcode, your only tool is a 🔨
 
-[![Build Status](https://travis-ci.org/pinterest/xchammer.svg?branch=master)](https://travis-ci.org/pinterest/xchammer)
-
 XCHammer generates Xcode projects from a [Bazel](https://bazel.build/) Workspace.
 
 - [x] Complete Bazel Xcode IDE integration


### PR DESCRIPTION
This is no longer relevant now that we use GitHub Actions for CI.