### PR TITLE
Support Bazel ObjcProvider compile_info migration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,4 +11,6 @@ build \
  --swiftcopt=-Xwrapped-swift=-debug-prefix-pwd-is-dot \
  --experimental_strict_action_env=true \
  --cpu darwin_x86_64 \
- --experimental_show_artifacts
+ --experimental_show_artifacts \
+ --incompatible_objc_compile_info_migration=true \
+ --incompatible_objc_provider_remove_compile_info=true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,11 +2,12 @@ workspace(name = "xchammer")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
-git_repository(
+http_archive(
     name = "build_bazel_rules_apple",
-    remote = "https://github.com/bazelbuild/rules_apple.git",
-    commit = "1cdaf74e44c4c969d7ee739b3a0f11b993c49d2a",
+    sha256 = "55f4dc1c9bf21bb87442665f4618cff1f1343537a2bd89252078b987dcd9c382",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.20.0/rules_apple.0.20.0.tar.gz",
 )
 
 load(
@@ -14,10 +15,12 @@ load(
     "apple_rules_dependencies",
 )
 
-git_repository(
+apple_rules_dependencies()
+
+http_archive(
     name = "build_bazel_rules_swift",
-    remote = "https://github.com/bazelbuild/rules_swift.git",
-    commit = "d07d880dcf939e0ad98df4dd723f8516bf8a2867",
+    sha256 = "cea22c0616d797e494d7844a9b604520c87f53c81de49613a7e679ec5b821620",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.14.0/rules_swift.0.14.0.tar.gz",
 )
 
 load(
@@ -27,7 +30,12 @@ load(
 
 swift_rules_dependencies()
 
-apple_rules_dependencies()
+load(
+    "@build_bazel_apple_support//lib:repositories.bzl",
+    "apple_support_dependencies",
+)
+
+apple_support_dependencies()
 
 load(
     "@com_google_protobuf//:protobuf_deps.bzl",
@@ -35,14 +43,6 @@ load(
 )
 
 protobuf_deps()
-
-load(
-    "@build_bazel_apple_support//lib:repositories.bzl",
-    "apple_support_dependencies",
-)
-
-apple_support_dependencies()
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 http_file(
     name = "xctestrunner",

--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -259,7 +259,7 @@ def xchammer_dependencies():
     namespaced_git_repository(
         name = "Tulsi",
         remote = "https://github.com/pinterest/tulsi.git",
-        commit = "feba74a99096757bd719e9361caaaf3f2bd5387c",
+        commit = "0c7ae95691a617d5bb99b83afdc81207b4026fd9",
         patch_cmds = [
             """
          sed -i '' 's/\:__subpackages__/visibility\:public/g' src/TulsiGenerator/BUILD
@@ -275,7 +275,7 @@ def xchammer_dependencies():
     new_git_repository(
         name = "xchammer_tulsi_aspects",
         remote = "https://github.com/pinterest/tulsi.git",
-        commit = "6302ee15a49a93fcaaff75e1fcd235fc87ac2ec8",
+        commit = "131e87bbd5d5aab43a3c98d95d92749c68f35f73",
         strip_prefix="src/TulsiGenerator/Bazel",
         build_file_content="exports_files(['tulsi'])"
     )


### PR DESCRIPTION
This represents the minimal set of changes to get this project through
the upstream Bazel project's ObjcProvider migration:

https://github.com/bazelbuild/bazel/issues/10674

In addition to updating our direct WORKSPACE dependencies, it also bumps
the commit reference to our (quite stale) Tulsi fork that now contains
these cherry-picked upstream commits:

Branch: xchammer-0.28.1
- https://github.com/pinterest/tulsi/commit/432cdb64c0ebf3bae73dda598147ac3dc4224b54
- https://github.com/pinterest/tulsi/commit/62cfb95c68a2842a99c395d1f12715928eccfc3e
- https://github.com/pinterest/tulsi/commit/131e87bbd5d5aab43a3c98d95d92749c68f35f73

Branch: xchammer-3.4.1
- https://github.com/pinterest/tulsi/commit/3d4f37a67e22dcaa5a9daf212ee11a874676ad7f
- https://github.com/pinterest/tulsi/commit/a44bc1c3c4f7beb4151a8978034e101fa2d23855
- https://github.com/pinterest/tulsi/commit/0c7ae95691a617d5bb99b83afdc81207b4026fd9