### PR TITLE
Address "'depset' is not iterable" in Tulsi

### DIFF
--- a/third_party/repositories.bzl
+++ b/third_party/repositories.bzl
@@ -275,7 +275,7 @@ def xchammer_dependencies():
     new_git_repository(
         name = "xchammer_tulsi_aspects",
         remote = "https://github.com/pinterest/tulsi.git",
-        commit = "131e87bbd5d5aab43a3c98d95d92749c68f35f73",
+        commit = "d9f7da58ff7a620e64d695baa2179c3598333bf7",
         strip_prefix="src/TulsiGenerator/Bazel",
         build_file_content="exports_files(['tulsi'])"
     )


### PR DESCRIPTION
This was caused by a local patch we have in our Tulsi fork, so I've
patch it there:

https://github.com/pinterest/tulsi/commit/d9f7da58ff7a620e64d695baa2179c3598333bf7