### PR TITLE
Update dependencies of sample tests so most of them are able to run 

### DIFF
--- a/sample/Frankenstein/WORKSPACE
+++ b/sample/Frankenstein/WORKSPACE
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
 http_archive(
     name = "build_bazel_rules_apple",

--- a/sample/Frankenstein/WORKSPACE
+++ b/sample/Frankenstein/WORKSPACE
@@ -1,19 +1,9 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
-# Build with changes to add --standalone to test invocation. Additionally, fix
-# several python build issues
-http_file(
-    name = "xctestrunner",
-    executable = 1,
-    urls = ["https://github.com/jerrymarino/xctestrunner/files/3453677/ios_test_runner.par.zip"],
-)
-
-git_repository(
+http_archive(
     name = "build_bazel_rules_apple",
-    remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.18.0",
+    sha256 = "55f4dc1c9bf21bb87442665f4618cff1f1343537a2bd89252078b987dcd9c382",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.20.0/rules_apple.0.20.0.tar.gz",
 )
 
 load(
@@ -21,10 +11,12 @@ load(
     "apple_rules_dependencies",
 )
 
-git_repository(
+apple_rules_dependencies()
+
+http_archive(
     name = "build_bazel_rules_swift",
-    commit = "0192f16b82b2998d846c45187545e38548a6671a",
-    remote = "https://github.com/bazelbuild/rules_swift.git",
+    sha256 = "cea22c0616d797e494d7844a9b604520c87f53c81de49613a7e679ec5b821620",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.14.0/rules_swift.0.14.0.tar.gz",
 )
 
 load(
@@ -33,8 +25,6 @@ load(
 )
 
 swift_rules_dependencies()
-
-apple_rules_dependencies(ignore_version_differences = True)
 
 load(
     "@com_google_protobuf//:protobuf_deps.bzl",

--- a/sample/Frankenstein/tools/bazelwrapper
+++ b/sample/Frankenstein/tools/bazelwrapper
@@ -20,8 +20,8 @@ trap exit_trap EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.28.1"
-BAZEL_VERSION_SHA="5d50ae13ba01a224ddf54cfd818289bee5b38e551cca22bffc79b89f377d2095"
+BAZEL_VERSION="3.4.1"
+BAZEL_VERSION_SHA="b168b9c4186916cd07922b1155bca14eecc812729669f1fdbab141f3f4eee2a0"
 
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 

--- a/sample/SnapshotMe/WORKSPACE
+++ b/sample/SnapshotMe/WORKSPACE
@@ -1,10 +1,9 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-git_repository(
+http_archive(
     name = "build_bazel_rules_apple",
-    remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.18.0",
+    sha256 = "55f4dc1c9bf21bb87442665f4618cff1f1343537a2bd89252078b987dcd9c382",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.20.0/rules_apple.0.20.0.tar.gz",
 )
 
 load(
@@ -12,11 +11,12 @@ load(
     "apple_rules_dependencies",
 )
 
+apple_rules_dependencies()
+
 http_archive(
     name = "build_bazel_rules_swift",
-    urls = [
-        "https://github.com/bazelbuild/rules_swift/releases/download/0.12.1/rules_swift.0.12.1.tar.gz",
-    ],
+    sha256 = "cea22c0616d797e494d7844a9b604520c87f53c81de49613a7e679ec5b821620",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.14.0/rules_swift.0.14.0.tar.gz",
 )
 
 load(
@@ -25,8 +25,6 @@ load(
 )
 
 swift_rules_dependencies()
-
-apple_rules_dependencies()
 
 load(
     "@com_google_protobuf//:protobuf_deps.bzl",

--- a/sample/SnapshotMe/tools/bazelwrapper
+++ b/sample/SnapshotMe/tools/bazelwrapper
@@ -20,8 +20,8 @@ trap exit_trap EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.28.1"
-BAZEL_VERSION_SHA="5d50ae13ba01a224ddf54cfd818289bee5b38e551cca22bffc79b89f377d2095"
+BAZEL_VERSION="3.4.1"
+BAZEL_VERSION_SHA="b168b9c4186916cd07922b1155bca14eecc812729669f1fdbab141f3f4eee2a0"
 
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 

--- a/sample/Tailor/WORKSPACE
+++ b/sample/Tailor/WORKSPACE
@@ -1,9 +1,9 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-git_repository(
+http_archive(
     name = "build_bazel_rules_apple",
-    remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.18.0",
+    sha256 = "55f4dc1c9bf21bb87442665f4618cff1f1343537a2bd89252078b987dcd9c382",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.20.0/rules_apple.0.20.0.tar.gz",
 )
 
 load(
@@ -11,10 +11,12 @@ load(
     "apple_rules_dependencies",
 )
 
-git_repository(
+apple_rules_dependencies()
+
+http_archive(
     name = "build_bazel_rules_swift",
-    commit = "0192f16b82b2998d846c45187545e38548a6671a",
-    remote = "https://github.com/bazelbuild/rules_swift.git",
+    sha256 = "cea22c0616d797e494d7844a9b604520c87f53c81de49613a7e679ec5b821620",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.14.0/rules_swift.0.14.0.tar.gz",
 )
 
 load(
@@ -23,8 +25,6 @@ load(
 )
 
 swift_rules_dependencies()
-
-apple_rules_dependencies()
 
 load(
     "@com_google_protobuf//:protobuf_deps.bzl",

--- a/sample/Tailor/tools/bazelwrapper
+++ b/sample/Tailor/tools/bazelwrapper
@@ -20,8 +20,8 @@ trap exit_trap EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.28.1"
-BAZEL_VERSION_SHA="5d50ae13ba01a224ddf54cfd818289bee5b38e551cca22bffc79b89f377d2095"
+BAZEL_VERSION="3.4.1"
+BAZEL_VERSION_SHA="b168b9c4186916cd07922b1155bca14eecc812729669f1fdbab141f3f4eee2a0"
 
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 

--- a/sample/UrlGet/.bazelrc
+++ b/sample/UrlGet/.bazelrc
@@ -12,8 +12,6 @@ build \
     --apple_generate_dsym=false \
     --spawn_strategy=standalone \
     --apple_platform_type=ios \
-    --noincompatible_disallow_load_labels_to_cross_package_boundaries  \
-    --incompatible_new_actions_api=false
 
 build:ios_x86_64 \
     --ios_multi_cpus=x86_64

--- a/sample/UrlGet/Vendor/GoogleAppIndexing/BUILD
+++ b/sample/UrlGet/Vendor/GoogleAppIndexing/BUILD
@@ -109,7 +109,6 @@ objc_library(
         "//visibility:public",
     ],
     deps = [
-        ":GoogleAppIndexing_Bundle_GoogleAppIndexingResources",
         ":GoogleAppIndexing_VendoredFrameworks",
         ":GoogleAppIndexing_includes",
     ],

--- a/sample/UrlGet/WORKSPACE
+++ b/sample/UrlGet/WORKSPACE
@@ -1,10 +1,9 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-git_repository(
+http_archive(
     name = "build_bazel_rules_apple",
-    remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.18.0",
+    sha256 = "55f4dc1c9bf21bb87442665f4618cff1f1343537a2bd89252078b987dcd9c382",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.20.0/rules_apple.0.20.0.tar.gz",
 )
 
 load(
@@ -12,11 +11,12 @@ load(
     "apple_rules_dependencies",
 )
 
+apple_rules_dependencies()
+
 http_archive(
     name = "build_bazel_rules_swift",
-    urls = [
-        "https://github.com/bazelbuild/rules_swift/releases/download/0.12.1/rules_swift.0.12.1.tar.gz",
-    ],
+    sha256 = "cea22c0616d797e494d7844a9b604520c87f53c81de49613a7e679ec5b821620",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.14.0/rules_swift.0.14.0.tar.gz",
 )
 
 load(
@@ -25,8 +25,6 @@ load(
 )
 
 swift_rules_dependencies()
-
-apple_rules_dependencies()
 
 load(
     "@com_google_protobuf//:protobuf_deps.bzl",

--- a/sample/UrlGet/ios-app/BUILD
+++ b/sample/UrlGet/ios-app/BUILD
@@ -91,8 +91,8 @@ ios_application(
     bundle_id = "Google.UrlGet",
     entitlements = "Example.entitlements",
     extensions = [
-        ":share-extension",
-        ":siri-extension",
+        #":share-extension",
+        #":siri-extension",
     ],
     families = ["iphone"],
     infoplists = ["UrlGet/UrlGet-Info.plist"],
@@ -215,7 +215,7 @@ objc_library(
     deps = [
         "//Vendor/GoogleAppIndexing",
         "//Vendor/GoogleAuthUtilities",
-        "//Vendor/PINCache",
+        #"//Vendor/PINCache",
         "//Vendor/PINOperation",
         "//ios-app/HeaderLib",
     ],

--- a/sample/UrlGet/tools/bazelwrapper
+++ b/sample/UrlGet/tools/bazelwrapper
@@ -20,8 +20,8 @@ trap exit_trap EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.28.1"
-BAZEL_VERSION_SHA="5d50ae13ba01a224ddf54cfd818289bee5b38e551cca22bffc79b89f377d2095"
+BAZEL_VERSION="3.4.1"
+BAZEL_VERSION_SHA="b168b9c4186916cd07922b1155bca14eecc812729669f1fdbab141f3f4eee2a0"
 
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 

--- a/sample/WorkspaceSource/WORKSPACE
+++ b/sample/WorkspaceSource/WORKSPACE
@@ -1,11 +1,9 @@
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load(":workspace.bzl", "gen_repo")
 
-git_repository(
+http_archive(
     name = "build_bazel_rules_apple",
-    remote = "https://github.com/bazelbuild/rules_apple.git",
-    tag = "0.18.0",
+    sha256 = "55f4dc1c9bf21bb87442665f4618cff1f1343537a2bd89252078b987dcd9c382",
+    url = "https://github.com/bazelbuild/rules_apple/releases/download/0.20.0/rules_apple.0.20.0.tar.gz",
 )
 
 load(
@@ -13,11 +11,12 @@ load(
     "apple_rules_dependencies",
 )
 
+apple_rules_dependencies()
+
 http_archive(
     name = "build_bazel_rules_swift",
-    urls = [
-        "https://github.com/bazelbuild/rules_swift/releases/download/0.12.1/rules_swift.0.12.1.tar.gz",
-    ],
+    sha256 = "cea22c0616d797e494d7844a9b604520c87f53c81de49613a7e679ec5b821620",
+    url = "https://github.com/bazelbuild/rules_swift/releases/download/0.14.0/rules_swift.0.14.0.tar.gz",
 )
 
 load(
@@ -26,8 +25,6 @@ load(
 )
 
 swift_rules_dependencies()
-
-apple_rules_dependencies()
 
 load(
     "@com_google_protobuf//:protobuf_deps.bzl",

--- a/sample/WorkspaceSource/tools/bazelwrapper
+++ b/sample/WorkspaceSource/tools/bazelwrapper
@@ -20,8 +20,8 @@ trap exit_trap EXIT
 # Go to bazel release page
 # These are typically posted in groups.google
 # https://groups.google.com/forum/#!forum/bazel-discuss
-BAZEL_VERSION="0.28.1"
-BAZEL_VERSION_SHA="5d50ae13ba01a224ddf54cfd818289bee5b38e551cca22bffc79b89f377d2095"
+BAZEL_VERSION="3.4.1"
+BAZEL_VERSION_SHA="b168b9c4186916cd07922b1155bca14eecc812729669f1fdbab141f3f4eee2a0"
 
 BAZEL_VERSION_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-darwin-x86_64.sh"
 


### PR DESCRIPTION
i.e., **make run_swift** should work now, which previously would fail.

The integration test(make test) requires more changes, but only a few errors now :)

```
The following build commands failed:
	Ld /Users/lma/Library/Developer/Xcode/DerivedData/UrlGet-hgpbgbnmkatzrbcfjhuuwfdjsmxh/Build/Intermediates.noindex/UrlGet.build/Debug-iphonesimulator/ios-app.build/Objects-normal/x86_64/Binary/ios-app normal x86_64 (in target 'ios-app' from project 'UrlGet')
	Ld /Users/lma/Library/Developer/Xcode/DerivedData/UrlGet-hgpbgbnmkatzrbcfjhuuwfdjsmxh/Build/Intermediates.noindex/UrlGet.build/Debug-iphonesimulator/ios-app.build/Objects-normal/i386/Binary/ios-app normal i386 (in target 'ios-app' from project 'UrlGet')
	Ld /Users/lma/Library/Developer/Xcode/DerivedData/UrlGet-hgpbgbnmkatzrbcfjhuuwfdjsmxh/Build/Intermediates.noindex/UrlGet.build/Debug-iphonesimulator/ios-app.build/Objects-normal/arm64/Binary/ios-app normal arm64 (in target 'ios-app' from project 'UrlGet')
```