### PR TITLE
Add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# Code of Conduct
+
+At Pinterest, we work hard to ensure that our work environment is welcoming
+and inclusive to as many people as possible. We are committed to creating this
+environment for everyone involved in our open source projects as well. We
+welcome all participants regardless of ability, age, ethnicity, identified
+gender, religion (or lack there of), sexual orientation and socioeconomic
+status.
+
+This code of conduct details our expectations for upholding these values.
+
+## Good behavior
+
+We expect members of our community to exhibit good behavior including (but of
+course not limited to):
+
+- Using intentional and empathetic language.
+- Focusing on resolving instead of escalating conflict.
+- Providing constructive feedback.
+
+## Unacceptable behavior
+
+Some examples of unacceptable behavior (again, this is not an exhaustive
+list):
+
+- Harassment, publicly or in private.
+- Trolling.
+- Sexual advances (this isn’t the place for it).
+- Publishing other’s personal information.
+- Any behavior which would be deemed unacceptable in a professional environment.
+
+## Recourse
+
+If you are witness to or the target of unacceptable behavior, it should be
+reported to Pinterest at opensource-policy@pinterest.com. All reporters will
+be kept confidential and an appropriate response for each incident will be
+evaluated.
+
+If the maintainers do not uphold and enforce this code of conduct in
+good faith, community leadership will hold them accountable.


### PR DESCRIPTION
Imports the code of conduct to uphold for XCHammer imported from https://github.com/pinterest/.github/blob/main/CODE_OF_CONDUCT.md